### PR TITLE
fix: remove hard-coded paths and patch overrides

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,0 @@
-# Temporary coverage config - DO NOT COMMIT
-# Replaces project config during coverage runs
-[build]
-target-dir = "/mnt/nvme-raid0/coverage/forjar"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2211,6 +2211,8 @@ dependencies = [
 [[package]]
 name = "provable-contracts"
 version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25d845cee13c0160ff2d644c8bd4b65a8487f894a827d9d0fe23d47980a9fa5"
 dependencies = [
  "serde",
  "serde_json",
@@ -2221,6 +2223,8 @@ dependencies = [
 [[package]]
 name = "provable-contracts-macros"
 version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c383d865124fe9fda96af4a04d0c2641bcb93e16eb5e13f7c665f98c15333447"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ serde_yaml_ng = "0.10"
 serde_json = "1.0"
 clap = { version = "4", features = ["derive"] }
 indexmap = { version = "2.7", features = ["serde"] }
-provable-contracts-macros = { version = "0.1", path = "../provable-contracts/crates/provable-contracts-macros" }
+provable-contracts-macros = { version = "0.1" }
 base64 = "0.22.1"
 bashrs = "6.64.0"
 pforge-runtime = "0.1.4"
@@ -43,7 +43,7 @@ zstd = "0.13"
 tar = "0.4"
 
 [build-dependencies]
-provable-contracts = { version = "0.1", path = "../provable-contracts/crates/provable-contracts" }
+provable-contracts = { version = "0.1" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/resources/tests_mount.rs
+++ b/src/resources/tests_mount.rs
@@ -12,7 +12,7 @@ pub(super) fn make_mount_resource() -> Resource {
         version: None,
         path: Some("/mnt/lambda-raid".to_string()),
         content: None,
-        source: Some("192.168.50.50:/mnt/nvme-raid0".to_string()),
+        source: Some("192.168.1.1:/srv/nfs/export".to_string()),
         target: None,
         owner: None,
         group: None,
@@ -96,7 +96,7 @@ fn test_fj009_apply_mount() {
     let script = apply_script(&r);
     assert!(script.contains("mkdir -p '/mnt/lambda-raid'"));
     assert!(script.contains("mount -t 'nfs' -o 'ro,hard,intr'"));
-    assert!(script.contains("192.168.50.50:/mnt/nvme-raid0"));
+    assert!(script.contains("192.168.1.1:/srv/nfs/export"));
     assert!(script.contains("/etc/fstab"));
 }
 
@@ -171,7 +171,7 @@ fn test_fj009_fstab_entry_format() {
     let r = make_mount_resource();
     let script = apply_script(&r);
     // Verify fstab entry has correct fields: source target fstype options dump pass
-    assert!(script.contains("192.168.50.50:/mnt/nvme-raid0 /mnt/lambda-raid nfs ro,hard,intr 0 0"));
+    assert!(script.contains("192.168.1.1:/srv/nfs/export /mnt/lambda-raid nfs ro,hard,intr 0 0"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Remove `[patch.crates-io]` path overrides for `provable-contracts` and `provable-contracts-macros` in `Cargo.toml` — both crates are published on crates.io at v0.1.1, so path overrides are unnecessary and break clean-room CI builds
- Delete `.cargo/config.toml` which contained a hard-coded `/mnt/nvme-raid0/coverage/forjar` build target-dir (was already deleted locally, now committed)
- Replace `/mnt/nvme-raid0` NFS source fixture in `src/resources/tests_mount.rs` with a generic test value (`192.168.1.1:/srv/nfs/export`) — all 18 mount tests still pass

Spec: sovereign-stack-protected-branch-strategy.md (Section 5)

## Test plan

- [x] `cargo check` passes cleanly (resolves `provable-contracts` v0.1.1 from crates.io)
- [x] `cargo test test_fj009` — all 18 mount tests pass with updated NFS fixture
- [ ] Clean-room CI gate passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)