### PR TITLE
fix(release): use musl-strip for aarch64-musl target

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -143,18 +143,20 @@ jobs:
         run: |
           TARGET="${{ matrix.target }}"
           BIN_PATH="target/${TARGET}/release/forjar"
+          # Each cross image ships only the matching ${triple}-strip;
+          # the gnu image lacks musl-strip and vice-versa.
           case "$TARGET" in
-            aarch64-*)
-              # Strip via the cross Docker image's GNU strip — handles
-              # both musl and gnu ELF binaries.
-              docker run --rm -v "$PWD/target:/target:Z" \
-                "ghcr.io/cross-rs/${TARGET}:main" \
-                aarch64-linux-gnu-strip "/$BIN_PATH" || true
-              ;;
-            *)
-              strip "$BIN_PATH" || true
-              ;;
+            aarch64-unknown-linux-musl) STRIP=aarch64-linux-musl-strip ;;
+            aarch64-unknown-linux-gnu)  STRIP=aarch64-linux-gnu-strip ;;
+            *)                          STRIP="" ;;
           esac
+          if [ -n "$STRIP" ]; then
+            docker run --rm -v "$PWD/target:/target:Z" \
+              "ghcr.io/cross-rs/${TARGET}:main" \
+              "$STRIP" "/$BIN_PATH" || true
+          else
+            strip "$BIN_PATH" || true
+          fi
           ls -la "$BIN_PATH"
 
       - name: Package archive


### PR DESCRIPTION
## Summary
- Mirrors pmat #555 — per-triple strip binary
- Avoids invoking `aarch64-linux-gnu-strip` inside the musl cross image (which only ships `aarch64-linux-musl-strip`)
- `|| true` was previously masking the failure; now it succeeds outright

## Test plan
- [ ] Merge → cut a new tag (or backfill via `gh workflow run "Binary Release" -f tag=v1.3.0`)
- [ ] Verify all 4 archives are properly stripped (size <= unstripped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)