### PR TITLE
fix(release): rustup target add to defeat workspace toolchain pin

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -90,6 +90,15 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      # The workspace pins a specific channel in `rust-toolchain.toml`
+      # which overrides the dtolnay action for any cargo invocation in
+      # the tree. Add the target explicitly to that pinned toolchain so
+      # native cross-compiles (x86_64-musl) don't fail with `can't find
+      # crate for core` mid-build.
+      - name: Install target on workspace-pinned toolchain
+        if: ${{ !matrix.cross }}
+        run: rustup target add ${{ matrix.target }}
+
       - name: Generate contract assertions — pv codegen
         run: |
           if ! command -v pv >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

forjar v1.3.0 backfill ran 4 jobs; 3 succeeded but x86_64-unknown-linux-musl failed mid-build with:

> error[E0463]: can't find crate for \`core\`

Root cause (Five Whys):

1. cargo build with --target x86_64-unknown-linux-musl couldn't find core
2. because the target wasn't installed in the active toolchain
3. because rust-toolchain.toml pins channel = "1.93.0" with no targets list
4. and that toolchain is the active one whenever cargo runs in the workspace tree
5. and dtolnay/rust-toolchain@stable's \`targets:\` parameter installs the target into the action's toolchain (stable), not the workspace-pinned one

Fix: add an explicit \`rustup target add \${{ matrix.target }}\` step after the dtolnay step. Skip when matrix.cross=true (cross uses its own Docker image).

## Test plan

- [x] forjar v1.3.0 backfill x86_64-musl was failing at "Build forjar" step — diagnosed via run 25003882860 logs
- [ ] Backfill v1.3.0 again after merge to confirm 4/4 succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)