### PR TITLE
chore(release): forjar 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2026-05-02
+
+### Added
+- `state: latest` for the apt package provider (#125, Refs PMAT-161). Validation already accepted `latest` for Package types but `apply_script()` fell through to the unsupported arm, making it a no-op. The new `apply_apt_latest()` runs `apt-get update -qq` then `apt-get install -y -qq <pkgs>`, which installs missing packages or upgrades to the newest available version (no-op if already current). Closes the gap that made `apply_apt_present` (presence-only `dpkg -l` guard) unable to express "always latest" — adding `version:` to YAML was a no-op once a package was already installed at any older version. Postcondition verified via `dpkg -l "$pkg" | grep -q '^ii '` for each requested package.
+
 ## [1.3.0] - 2026-04-25
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forjar"
-version = "1.3.0"
+version = "1.4.0"
 edition.workspace = true
 rust-version = "1.89.0"
 authors = ["Pragmatic AI Labs"]


### PR DESCRIPTION
## Summary

- Bumps version 1.3.0 → 1.4.0 (minor; additive feature, backward-compatible)
- CHANGELOG entry for the new apt `state: latest` arm merged in #125 (Refs PMAT-161)

## Why

Need a release so the new apt `state: latest` provider arm becomes consumable from infra (lambda-labs Docker upgrade 29.1.4 → 29.4.1).

## Test plan

- [x] `cargo check --workspace` clean against bumped version
- [x] PR #125 already merged on main; full lib suite (12,069 tests) green there
- [ ] CI (this PR) green
- [ ] Local clean-room (`make -C ~/src/infra/machines/clean-room clean-room-forjar`) passes — running in parallel
- [ ] After merge: tag v1.4.0, release.yml workflow runs verify on `[self-hosted, clean-room]`
- [ ] `cargo publish` from lambda-labs (has crates.io creds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)