### PR TITLE
fix(package): tolerate apt-get update partial failures in state: latest (1.4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.1] - 2026-05-02
+
+### Fixed
+- `apply_apt_latest` (`state: latest`) now tolerates `apt-get update` partial failures via `|| true` (Refs PMAT-161). Real hosts routinely have one or two unreachable third-party PPAs, masked PackageKit units, or stale arm64 entries on x86_64 boxes that make `apt-get update` exit non-zero even when the repos we actually care about refreshed cleanly. The subsequent `apt-get install` still fails loud if the requested package can't be resolved, so the `dpkg -l '^ii '` postcondition is preserved. Matches canonical Dockerfile / Ansible practice. Discovered when applying `state: latest` for `docker-ce` on lambda-labs (broken `mozillateam`, `obsproject`, etc. PPAs).
+
 ## [1.4.0] - 2026-05-02
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forjar"
-version = "1.4.0"
+version = "1.4.1"
 edition.workspace = true
 rust-version = "1.89.0"
 authors = ["Pragmatic AI Labs"]

--- a/src/resources/package.rs
+++ b/src/resources/package.rs
@@ -109,6 +109,16 @@ fn apply_apt_present(resource: &Resource) -> String {
 // this is not guarded by a `dpkg -l` presence check, since the goal is
 // to converge on the latest available version regardless of what is
 // currently installed.
+//
+// FJ-PMAT-161-1: `apt-get update` is tolerated as best-effort (`|| true`).
+// In production, hosts routinely have one or two unreachable third-party
+// PPAs, masked PackageKit units, or stale arm64 entries on x86_64 boxes
+// that make `apt-get update` exit non-zero even when the repos we
+// actually care about refreshed cleanly. Failing hard there blocks
+// upgrades that should succeed. The subsequent `apt-get install` fails
+// loud and clear if the requested package can't be resolved against the
+// (possibly partially-stale) cache, so correctness of the postcondition
+// is preserved. This matches canonical Dockerfile / Ansible practice.
 fn apply_apt_latest(resource: &Resource) -> String {
     let packages = &resource.packages;
     let pkg_list: Vec<String> = packages.iter().map(|p| format!("'{p}'")).collect();
@@ -117,10 +127,10 @@ fn apply_apt_latest(resource: &Resource) -> String {
     format!(
         "set -euo pipefail\n\
          if [ \"$(id -u)\" -ne 0 ]; then\n\
-           sudo apt-get update -qq\n\
+           sudo apt-get update -qq || true\n\
            DEBIAN_FRONTEND=noninteractive sudo apt-get install -y -qq {joined}\n\
          else\n\
-           apt-get update -qq\n\
+           apt-get update -qq || true\n\
            DEBIAN_FRONTEND=noninteractive apt-get install -y -qq {joined}\n\
          fi\n\
          # Postcondition: all packages installed (at latest available)\n\

--- a/src/resources/tests_package_b.rs
+++ b/src/resources/tests_package_b.rs
@@ -365,6 +365,11 @@ fn test_apply_script_arm_apt_latest() {
         script.contains("dpkg -l"),
         "apt latest must verify postcondition via dpkg: {script}"
     );
+    // FJ-PMAT-161-1: tolerate apt-get update partial failures
+    assert!(
+        script.contains("apt-get update -qq || true"),
+        "apt latest must tolerate apt-get update failures: {script}"
+    );
 }
 
 /// Match arm: ("cargo", "present")


### PR DESCRIPTION
## Summary

Patches `apply_apt_latest` to tolerate `apt-get update` partial failures via `|| true`. Bumps to **1.4.1**.

## Why

The 1.4.0 implementation (#125) failed hard when `apt-get update -qq` exited non-zero. Real hosts routinely have:

- unreachable third-party PPAs (mozillateam, obsproject, etc.)
- masked PackageKit units (`org.freedesktop.systemd1.UnitMasked`)
- stale `arm64` entries on `x86_64` boxes (404s)

…which make `apt-get update` non-zero even when the docker-ce / nvidia / etc. repos we actually care about refreshed cleanly. Failing hard at update time blocks upgrades that should succeed.

The subsequent `apt-get install -y -qq` still fails loud if the requested package can't be resolved against the (possibly partially-stale) cache, so the `dpkg -l '^ii '` postcondition is preserved. This matches canonical Dockerfile / Ansible practice.

Discovered when applying `state: latest` for `docker-ce` on lambda-labs.

Tracks **PMAT-161**.

## Test plan

- [x] `test_apply_script_arm_apt_latest` extended to assert `apt-get update -qq || true`
- [x] All 12,069 lib tests pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [ ] CI green
- [ ] Local clean-room (`make -C ~/src/infra/machines/clean-room clean-room-forjar`) re-run
- [ ] Tag v1.4.1 + cargo publish
- [ ] `forjar apply -f machines/lambda-labs/forjar.yaml` succeeds and lands docker-ce 29.4.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)