### PR TITLE
docs(book): build mdBook in CI + CLI reference parity for 154 subcommands (Refs PMAT-086)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,59 @@
+# DOCS-1 (PMAT-086): Build "The Forjar Book" (docs/book) in CI.
+#
+# The book was previously never built in CI, so broken SUMMARY.md entries and
+# stale chapters went undetected. This workflow keeps the job light (~1 min)
+# by installing a pinned prebuilt mdbook binary instead of compiling it.
+#
+# Follow-up (not in this PR): deploy the built book to GitHub Pages.
+name: docs
+
+on:
+  pull_request:
+    paths:
+      - "docs/book/**"
+      - "src/cli/commands/**"
+      - ".github/workflows/docs.yml"
+  push:
+    branches: [main]
+    paths:
+      - "docs/book/**"
+      - "src/cli/commands/**"
+      - ".github/workflows/docs.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  build-book:
+    name: mdbook build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      MDBOOK_VERSION: v0.4.40
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install mdbook (pinned prebuilt binary)
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          curl --proto '=https' --tlsv1.2 -fsSL \
+            "https://github.com/rust-lang/mdBook/releases/download/${MDBOOK_VERSION}/mdbook-${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
+            | tar -xz -C "$HOME/.local/bin"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      # mdbook silently *creates* chapters listed in SUMMARY.md that do not
+      # exist on disk, so a plain `mdbook build` cannot catch broken entries.
+      # Verify every linked chapter resolves before building.
+      - name: Check SUMMARY.md entries resolve
+        run: |
+          missing=0
+          while IFS= read -r chapter; do
+            if [ ! -f "docs/book/src/${chapter}" ]; then
+              echo "::error::SUMMARY.md links missing chapter: src/${chapter}"
+              missing=1
+            fi
+          done < <(grep -o '(\./[^)]*\.md)' docs/book/src/SUMMARY.md | sed 's/^(\.\///; s/)$//')
+          exit "${missing}"
+
+      - name: Build book
+        run: mdbook build docs/book

--- a/docs/book/src/01-getting-started.md
+++ b/docs/book/src/01-getting-started.md
@@ -2,7 +2,7 @@
 
 ## Installation
 
-Build from source (requires Rust 1.85+):
+Build from source (requires Rust 1.89.0+):
 
 ```bash
 git clone https://github.com/paiml/forjar.git
@@ -16,7 +16,7 @@ Verify:
 forjar --help
 ```
 
-You should see forjar's 79 subcommands: `init`, `validate`, `plan`, `apply`, `drift`, `status`, `history`, `destroy`, `import`, `show`, `graph`, `check`, `diff`, `fmt`, `lint`, `rollback`, `anomaly`, `trace`, `migrate`, `mcp`, `bench`, `state-list`, `state-mv`, `state-rm`, `output`, `policy`, `workspace`, `secrets`, `doctor`, `completion`, `lock`, `snapshot`, `schema`, `watch`, `explain`, `env`, `test`, `inventory`, `retry-failed`, `rolling`, `canary`, `audit`, `plan-compact`, `compliance`, `export`, `suggest`, `compare`, `lock-prune`, `env-diff`, `template`, `lock-info`, `lock-compact`, `lock-verify`, `lock-export`, `lock-gc`, `lock-diff`, `lock-merge`, `lock-rebase`, `lock-sign`, `lock-verify-sig`, `lock-compact-all`, `lock-audit-trail`, `lock-rotate-keys`, `lock-backup`, `lock-verify-chain`, `lock-stats`, `lock-audit`, `lock-compress`, `lock-defrag`, `lock-normalize`, `lock-validate`, `lock-verify-hmac`, `lock-archive`, `lock-snapshot`, `lock-repair`.
+You should see forjar's full set of subcommands, from the core workflow (`init`, `validate`, `plan`, `apply`, `drift`, `status`) through state, lock, security, and platform operations. See the [CLI Reference](06-cli.md) and the [CLI Reference Appendix](06b-cli-reference-appendix.md) for the complete list.
 
 ## Your First Project
 

--- a/docs/book/src/06-cli.md
+++ b/docs/book/src/06-cli.md
@@ -1316,17 +1316,17 @@ forjar fmt -f forjar.yaml --check
 
 ```bash
 # Generate completion script
-forjar completions bash > /etc/bash_completion.d/forjar
+forjar completion bash > /etc/bash_completion.d/forjar
 
 # Or in user directory
-forjar completions bash > ~/.local/share/bash-completion/completions/forjar
+forjar completion bash > ~/.local/share/bash-completion/completions/forjar
 ```
 
 ### Zsh
 
 ```zsh
 # Generate completion script
-forjar completions zsh > ~/.zfunc/_forjar
+forjar completion zsh > ~/.zfunc/_forjar
 
 # Add to .zshrc
 fpath=(~/.zfunc $fpath)
@@ -1336,7 +1336,7 @@ autoload -Uz compinit && compinit
 ### Fish
 
 ```fish
-forjar completions fish > ~/.config/fish/completions/forjar.fish
+forjar completion fish > ~/.config/fish/completions/forjar.fish
 ```
 
 ## Environment Variables

--- a/docs/book/src/06b-cli-reference-appendix.md
+++ b/docs/book/src/06b-cli-reference-appendix.md
@@ -1,0 +1,207 @@
+# CLI Reference Appendix
+
+This appendix documents subcommands not yet covered in the main
+[CLI Reference](06-cli.md). Each entry is a minimal stub: purpose and usage.
+A CI parity test (`tests/doc_cli_parity.rs`) ensures every subcommand in the
+`Commands` enum appears somewhere in this book, so new commands must be added
+here (or in a full chapter) before they can merge.
+
+## Config Analysis & Composition
+
+### forjar stack-diff
+
+Unified stack diff — compare two configs (resources, machines, params).
+
+```bash
+forjar stack-diff <FILE1> <FILE2> [--json]
+```
+
+### forjar config-merge
+
+Merge two forjar config files into one.
+
+```bash
+forjar config-merge <FILE_A> <FILE_B> [-o <OUTPUT>] [--allow-collisions]
+```
+
+### forjar extract
+
+Extract resources matching tag, group, or glob into a sub-config.
+
+```bash
+forjar extract -f forjar.yaml [--tags <TAG>] [--group <GROUP>] [--glob "web-*"] [-o <OUTPUT>]
+```
+
+### forjar query
+
+Infrastructure query — search resources across config and state.
+
+```bash
+forjar query -f forjar.yaml [--pattern <P>] [--type <T>] [--machine <M>] [--tag <T>] [--live] [--json]
+```
+
+### forjar preservation
+
+Preservation checking — verify resources that must never be destroyed.
+
+```bash
+forjar preservation -f forjar.yaml [--json]
+```
+
+## State & Lock Integrity
+
+### forjar reseal
+
+Regenerate BLAKE3 integrity sidecars from current lock contents (use when a
+lock file and its `.b3` sidecar diverge).
+
+```bash
+forjar reseal [--file <LOCK> | --all | --machine <NAME>] [--dry-run]
+```
+
+### forjar generation
+
+Manage state generations (Nix-style numbered snapshots): list, garbage-collect,
+and diff.
+
+```bash
+forjar generation <list|gc|diff> [OPTIONS]
+```
+
+### forjar state-backend
+
+Remote state backend operations — inspect backend keys.
+
+```bash
+forjar state-backend [--state-dir state] [--prefix <PREFIX>] [--json]
+```
+
+## Policy & Supply Chain
+
+### forjar policy-coverage
+
+Policy rule coverage analysis — which rules fire against the current config.
+
+```bash
+forjar policy-coverage -f forjar.yaml [--json]
+```
+
+### forjar policy-install
+
+Install a compliance pack (e.g., `cis-ubuntu-22`, `nist-800-53`, `soc2`, `hipaa`).
+
+```bash
+forjar policy-install <PACK> [--output-dir policies] [--json]
+```
+
+### forjar sign
+
+Recipe signing — sign or verify a recipe file (optionally post-quantum dual
+signing).
+
+```bash
+forjar sign <RECIPE> [--verify] [--signer <ID>] [--pq] [--json]
+```
+
+## Multi-Stack Orchestration
+
+### forjar multi-apply
+
+Multi-config apply ordering — analyze cross-stack dependencies and report the
+correct apply order.
+
+```bash
+forjar multi-apply -f <CONFIG> -f <CONFIG2> [--json]
+```
+
+### forjar stack-graph
+
+Stack dependency graph across multiple config files.
+
+```bash
+forjar stack-graph -f <CONFIG> -f <CONFIG2> [--json]
+```
+
+### forjar parallel-apply
+
+Parallel multi-stack apply with a bounded worker pool.
+
+```bash
+forjar parallel-apply -f <CONFIG> -f <CONFIG2> [--max-parallel 4] [--json]
+```
+
+## Agents & Registries
+
+### forjar agent
+
+Pull agent / hybrid push-pull enforcement — one-shot push by default, daemon
+loop with `--pull`.
+
+```bash
+forjar agent -f forjar.yaml [--pull] [--interval 60] [--auto-apply] [--json]
+```
+
+### forjar agent-registry
+
+Agent recipe registry — list agent recipes by category.
+
+```bash
+forjar agent-registry [--registry-dir <DIR>] [--category <CAT>] [--json]
+```
+
+### forjar catalog-list
+
+Service catalog listing — browse the service catalog by category.
+
+```bash
+forjar catalog-list [--catalog-dir <DIR>] [--category <CAT>] [--json]
+```
+
+## Environments
+
+### forjar environments
+
+Manage named environments (dev, staging, prod): list, diff, rollback, and
+history.
+
+```bash
+forjar environments <list|diff|rollback|history> [OPTIONS]
+```
+
+## Plugins
+
+### forjar plugin
+
+Manage WASM resource plugins: list, verify, init, install, build, run, remove.
+
+```bash
+forjar plugin <list|verify|init|install|build|run|remove> [OPTIONS]
+```
+
+## Provisioning & Distribution
+
+### forjar iso-export
+
+ISO distribution export — export config and state for offline installation.
+
+```bash
+forjar iso-export -o <OUTPUT_DIR> -f forjar.yaml [--include-binary] [--json]
+```
+
+### forjar import-brownfield
+
+Brownfield state import — scan an existing machine and import discovered
+resources into state.
+
+```bash
+forjar import-brownfield [-m localhost] [-s package -s file -s service] [-o <OUTPUT>] [--json]
+```
+
+### forjar dist
+
+Generate distribution artifacts (installer script, Homebrew formula,
+cargo-binstall metadata, Nix flake, GitHub Action, deb/rpm specs).
+
+```bash
+forjar dist [--installer|--homebrew|--binstall|--nix|--github-action|--deb|--rpm|--all] [-o <OUT>]
+```

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -7,6 +7,7 @@
 - [Recipes](./04-recipes.md)
 - [Architecture](./05-architecture.md)
 - [CLI Reference](./06-cli.md)
+- [CLI Reference Appendix](./06b-cli-reference-appendix.md)
 - [Cookbook](./07-cookbook.md)
 - [State Management](./08-state-management.md)
 - [Drift Detection & Tripwire](./09-drift-and-tripwire.md)

--- a/tests/doc_cli_parity.rs
+++ b/tests/doc_cli_parity.rs
@@ -1,0 +1,205 @@
+//! DOCS-1 (PMAT-086): CLI <-> book parity test.
+//!
+//! Parses the `Commands` enum in `src/cli/commands/mod.rs` at test time and
+//! asserts that every subcommand appears at least once across
+//! `docs/book/src/*.md` as `forjar <name>`.
+//!
+//! Deterministic and offline: reads only files in this repository.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Convert a PascalCase enum variant name to clap's default kebab-case
+/// command name (e.g. `UndoDestroy` -> `undo-destroy`).
+fn kebab_case(variant: &str) -> String {
+    let mut out = String::with_capacity(variant.len() + 4);
+    for (i, ch) in variant.chars().enumerate() {
+        if ch.is_ascii_uppercase() {
+            if i > 0 {
+                out.push('-');
+            }
+            out.push(ch.to_ascii_lowercase());
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+/// Extract the body of `pub enum Commands { ... }` from the module source.
+fn commands_enum_body(src: &str) -> &str {
+    let start = src
+        .find("pub enum Commands {")
+        .expect("Commands enum not found in src/cli/commands/mod.rs");
+    let body_start = start + "pub enum Commands {".len();
+    // Variants are unit or tuple style, so the first line starting with `}`
+    // terminates the enum body.
+    let body_end = src[body_start..]
+        .find("\n}")
+        .map(|i| body_start + i)
+        .expect("Commands enum closing brace not found");
+    &src[body_start..body_end]
+}
+
+/// Parse a `#[command(name = "...")]` attribute line, returning the override.
+fn parse_name_override(line: &str) -> Option<String> {
+    let line = line.trim();
+    if !line.starts_with("#[command(") || !line.contains("name") {
+        return None;
+    }
+    let after = line.split("name").nth(1)?;
+    let first_quote = after.find('"')?;
+    let rest = &after[first_quote + 1..];
+    let second_quote = rest.find('"')?;
+    Some(rest[..second_quote].to_string())
+}
+
+/// Parse an enum variant line, returning the variant identifier.
+/// Matches `Init(InitArgs),` and unit variants like `Schema,`.
+fn parse_variant(line: &str) -> Option<String> {
+    let line = line.trim();
+    let first = line.chars().next()?;
+    if !first.is_ascii_uppercase() {
+        return None;
+    }
+    let ident: String = line
+        .chars()
+        .take_while(|c| c.is_ascii_alphanumeric())
+        .collect();
+    let next = line[ident.len()..].chars().next();
+    match next {
+        Some('(') | Some(',') => Some(ident),
+        _ => None,
+    }
+}
+
+/// Extract all CLI subcommand names from the Commands enum source,
+/// honoring `#[command(name = "...")]` overrides.
+fn extract_command_names(src: &str) -> Vec<String> {
+    let body = commands_enum_body(src);
+    let mut names = Vec::new();
+    let mut pending_override: Option<String> = None;
+    for line in body.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("///") || trimmed.is_empty() {
+            continue;
+        }
+        if let Some(name) = parse_name_override(trimmed) {
+            pending_override = Some(name);
+            continue;
+        }
+        if trimmed.starts_with("#[") {
+            continue;
+        }
+        if let Some(variant) = parse_variant(trimmed) {
+            let name = pending_override
+                .take()
+                .unwrap_or_else(|| kebab_case(&variant));
+            names.push(name);
+        }
+    }
+    names
+}
+
+/// Concatenate the contents of every `.md` file in `docs/book/src/`.
+fn load_book_text(dir: &Path) -> String {
+    let mut text = String::new();
+    let mut entries: Vec<PathBuf> = fs::read_dir(dir)
+        .expect("docs/book/src not readable")
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.extension().is_some_and(|x| x == "md"))
+        .collect();
+    entries.sort();
+    for path in entries {
+        text.push_str(&fs::read_to_string(&path).expect("doc file not readable"));
+        text.push('\n');
+    }
+    text
+}
+
+/// True if `forjar <cmd>` appears in the book with a word boundary after it
+/// (so `forjar state` is not satisfied by `forjar state-list`).
+fn is_documented(book: &str, cmd: &str) -> bool {
+    let needle = format!("forjar {cmd}");
+    let mut from = 0;
+    while let Some(pos) = book[from..].find(&needle) {
+        let end = from + pos + needle.len();
+        let boundary = match book[end..].chars().next() {
+            Some(c) => !c.is_ascii_alphanumeric() && c != '-' && c != '_',
+            None => true,
+        };
+        if boundary {
+            return true;
+        }
+        from = end;
+    }
+    false
+}
+
+fn repo_path(rel: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(rel)
+}
+
+#[test]
+fn kebab_case_handles_multi_word_variants() {
+    assert_eq!(kebab_case("Init"), "init");
+    assert_eq!(kebab_case("UndoDestroy"), "undo-destroy");
+    assert_eq!(kebab_case("RetryFailed"), "retry-failed");
+}
+
+#[test]
+fn name_override_is_parsed() {
+    assert_eq!(
+        parse_name_override(r##"#[command(name = "state-list")]"##),
+        Some("state-list".to_string())
+    );
+    assert_eq!(parse_name_override("#[command(subcommand)]"), None);
+    assert_eq!(parse_name_override("Init(InitArgs),"), None);
+}
+
+#[test]
+fn commands_enum_parses_known_names() {
+    let src = fs::read_to_string(repo_path("src/cli/commands/mod.rs"))
+        .expect("src/cli/commands/mod.rs not readable");
+    let names = extract_command_names(&src);
+    assert!(
+        names.len() >= 100,
+        "parser found only {} commands — parsing logic likely broken",
+        names.len()
+    );
+    for expected in [
+        "apply",
+        "state-list",
+        "query",
+        "agent",
+        "schema",
+        "undo-destroy",
+    ] {
+        assert!(
+            names.iter().any(|n| n == expected),
+            "expected command `{expected}` not extracted from Commands enum"
+        );
+    }
+    // Overrides must replace, not duplicate, the kebab-cased variant name.
+    assert!(
+        !names.iter().any(|n| n == "infra-query"),
+        "name override for InfraQuery (`query`) was not honored"
+    );
+}
+
+#[test]
+fn every_cli_subcommand_is_documented_in_the_book() {
+    let src = fs::read_to_string(repo_path("src/cli/commands/mod.rs"))
+        .expect("src/cli/commands/mod.rs not readable");
+    let names = extract_command_names(&src);
+    let book = load_book_text(&repo_path("docs/book/src"));
+
+    let missing: Vec<&String> = names.iter().filter(|n| !is_documented(&book, n)).collect();
+    assert!(
+        missing.is_empty(),
+        "{} subcommand(s) missing from docs/book/src/*.md (add a section with \
+         `forjar <name>` to docs/book/src/06b-cli-reference-appendix.md): {:?}",
+        missing.len(),
+        missing
+    );
+}


### PR DESCRIPTION
## What

Sprint item **PMAT-086 (DOCS-1)**: the 102-file mdBook ("The Forjar Book") was never built in CI, the CLI reference covered only ~53 of the 154 subcommands (23 appeared in no doc at all), and the book contained known errors.

1. **New `.github/workflows/docs.yml`** — builds `docs/book` on PRs/pushes touching `docs/book/**`, `src/cli/commands/**`, or the workflow itself. Installs a **pinned prebuilt mdbook v0.4.40 binary** (no compile, job runs in ~1 min). Includes an explicit SUMMARY.md resolution check, because `mdbook build` silently *creates* missing chapters instead of failing. GitHub Pages deploy is intentionally **not** included — noted as follow-up.
2. **Doc bug fixes**
   - `06-cli.md`: 4x `forjar completions <shell>` → `forjar completion <shell>` (the clap variant is `Completion`, singular).
   - `01-getting-started.md`: dropped the stale hardcoded "79 subcommands" claim (now count-free) and fixed "Rust 1.85+" → "Rust 1.89.0+" (matches `Cargo.toml` `rust-version`).
3. **Doc-parity test `tests/doc_cli_parity.rs`** — parses the `Commands` enum source at test time (kebab-cases variant names, honors `#[command(name = "...")]` overrides) and asserts each of the 154 subcommands appears as `forjar <name>` (with word-boundary check) somewhere in `docs/book/src/*.md`. Deterministic, offline, std-only (no new dependencies), 4 tests, ~205 lines.
4. **New `06b-cli-reference-appendix.md`** (wired into SUMMARY.md) — stub sections (purpose + usage, sourced from the clap doc comments and arg structs) for the 22 previously-undocumented commands; the 23rd (`completion`) is now covered by the typo fix.

## Previously-undocumented commands (23)

`stack-diff`, `reseal`, `policy-coverage`, `policy-install`, `completion` (typo fix), `generation`, `config-merge`, `extract`, `iso-export`, `import-brownfield`, `state-backend`, `catalog-list`, `multi-apply`, `stack-graph`, `query`, `sign`, `preservation`, `parallel-apply`, `agent-registry`, `agent`, `environments`, `plugin`, `dist`

## Why

New subcommands kept landing without docs because nothing enforced parity, and the book could silently rot because it was never built. The parity test makes undocumented commands a CI failure with an actionable message pointing at the appendix.

## Test plan

- [x] `cargo test --test doc_cli_parity` — 4/4 pass (parity over all 154 commands)
- [x] `mdbook build docs/book` — passes with local mdbook v0.5.2 **and** the CI-pinned v0.4.40 prebuilt binary
- [x] SUMMARY.md resolution check — all 102 linked chapters resolve
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --test doc_cli_parity -- -D warnings` — clean
- [x] No `src/`, `Cargo.toml`/`Cargo.lock`, or existing-workflow changes

## Follow-up (not in this PR)

- Deploy the built book to GitHub Pages from the `docs` workflow on `main` pushes.
- Flesh out the appendix stubs into full chapters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)