### PR TITLE
feat(contracts): formalize idempotent-apply, plan-apply-equivalence, destroy-undo-roundtrip (Refs #97)

### DIFF
--- a/contracts/binding.yaml
+++ b/contracts/binding.yaml
@@ -87,6 +87,81 @@ bindings:
     status: implemented
     notes: "Private helper; dispatches to type-specific validation"
 
+  # ── Idempotent Apply (#97 KZ-11) ───────────────────────
+  - contract: idempotent-apply-v1.yaml
+    equation: plan_fixed_point
+    module_path: "forjar::core::planner::plan"
+    function: plan
+    signature: "fn plan(config: &ForjarConfig, execution_order: &[String], locks: &HashMap<String, StateLock>, tag_filter: Option<&str>) -> ExecutionPlan"
+    status: implemented
+    notes: "Counter-conservation debug_assert; second plan over converged locks yields zero changes"
+
+  - contract: idempotent-apply-v1.yaml
+    equation: hash_determinism
+    module_path: "forjar::core::planner::hash_desired_state"
+    function: hash_desired_state
+    signature: "fn hash_desired_state(resource: &Resource) -> String"
+    status: implemented
+    notes: "FJ-2200 determinism debug_assert_eq; stable field order, BLAKE3 over NUL-joined components"
+
+  - contract: idempotent-apply-v1.yaml
+    equation: noop_fixed_point
+    module_path: "forjar::core::planner::determine_present_action"
+    function: determine_present_action
+    signature: "fn determine_present_action(resource_id: &str, resource: &Resource, machine_name: &str, locks: &HashMap<String, StateLock>) -> PlanAction"
+    status: implemented
+    notes: "Private helper; FJ-2200 debug_assert enforces converged + matching hash → NoOp"
+
+  # ── Plan/Apply Equivalence (#97 KZ-11) ─────────────────
+  - contract: plan-apply-equivalence-v1.yaml
+    equation: plan_determinism
+    module_path: "forjar::core::planner::plan"
+    function: plan
+    signature: "fn plan(config: &ForjarConfig, execution_order: &[String], locks: &HashMap<String, StateLock>, tag_filter: Option<&str>) -> ExecutionPlan"
+    status: implemented
+    notes: "Pure function; forjar plan (src/cli/plan.rs) and forjar apply (executor::apply) share it"
+
+  - contract: plan-apply-equivalence-v1.yaml
+    equation: apply_executes_plan
+    module_path: "forjar::core::executor::apply"
+    function: apply
+    signature: "fn apply(cfg: &ApplyConfig) -> Result<Vec<ApplyResult>, String>"
+    status: implemented
+    notes: "Executor iterates plan.changes only; outcome-conservation debug_assert in apply_machine"
+
+  - contract: plan-apply-equivalence-v1.yaml
+    equation: noop_no_execution
+    module_path: "forjar::core::executor::apply_single_resource"
+    function: apply_single_resource
+    signature: "fn apply_single_resource(cfg: &ApplyConfig, change: &PlannedChange, machine: &Machine, ctx: &mut RecordCtx, converged_resources: &HashSet<String>) -> Result<ResourceOutcome, String>"
+    status: implemented
+    notes: "Private helper; planned NoOp without force/trigger short-circuits to Unchanged"
+
+  # ── Destroy/Undo Roundtrip (#97 KZ-11) ─────────────────
+  - contract: destroy-undo-roundtrip-v1.yaml
+    equation: snapshot_generation
+    module_path: "forjar::cli::generation::create_generation"
+    function: create_generation
+    signature: "fn create_generation(state_dir: &Path, config_path: Option<&Path>) -> Result<u32, String>"
+    status: implemented
+    notes: "FJ-1386; monotonic numbering, atomic current-symlink switch, debug_assert on current"
+
+  - contract: destroy-undo-roundtrip-v1.yaml
+    equation: restore_generation
+    module_path: "forjar::cli::generation::rollback_to_generation"
+    function: rollback_to_generation
+    signature: "fn rollback_to_generation(state_dir: &Path, generation: u32, yes: bool) -> Result<(), String>"
+    status: implemented
+    notes: "Restores snapshot then atomically re-points current; debug_assert on current"
+
+  - contract: destroy-undo-roundtrip-v1.yaml
+    equation: undo_roundtrip
+    module_path: "forjar::cli::undo::cmd_undo"
+    function: cmd_undo
+    signature: "fn cmd_undo(file: &Path, state_dir: &Path, generations: u32, machine_filter: Option<&str>, dry_run: bool, yes: bool) -> Result<(), String>"
+    status: implemented
+    notes: "FJ-2003; targets current − n, rejects impossible targets, re-applies to converge"
+
   # ── Codegen Dispatch (I2) ──────────────────────────────
   - contract: codegen-dispatch-v1.yaml
     equation: check_script

--- a/contracts/destroy-undo-roundtrip-v1.yaml
+++ b/contracts/destroy-undo-roundtrip-v1.yaml
@@ -1,0 +1,121 @@
+---
+metadata:
+  version: "1.0.0"
+  created: "2026-06-12"
+  author: "PAIML Engineering"
+  description: |
+    Destroy/undo roundtrip — a destroy (or any state mutation) followed by
+    `forjar undo` restores the prior generation's state snapshot. Each apply
+    snapshots the state directory as a numbered generation (Nix-style);
+    rollback restores the snapshot and atomically re-points the `current`
+    symlink. Resolves the destroy/undo-roundtrip leg of paiml/forjar#97
+    (KZ-11).
+  references:
+    - "issue: https://github.com/paiml/forjar/issues/97"
+    - "FJ-1386: generational state snapshots — src/cli/generation.rs"
+    - "FJ-2003: active undo — src/cli/undo.rs"
+    - "FJ-2005: undo-destroy replay — src/cli/undo_helpers.rs"
+    - "Dolstra (2006) The Purely Functional Software Deployment Model (Nix generations)"
+
+equations:
+  snapshot_generation:
+    formula: |
+      create_generation(S) = g
+        where generations/g = copy(S) ∧ current → g ∧ g = max(existing) + 1
+    domain: "S = state_dir contents (lock files per machine)"
+    codomain: "Result<u32, String> (new generation number)"
+    invariants:
+      - "Generation numbers are strictly increasing and never reused"
+      - "current symlink points at the new generation after create"
+      - "Snapshot excludes generations/ and snapshots/ (no recursion)"
+
+  restore_generation:
+    formula: "rollback_to_generation(g) ⟹ state_dir = generations/g ∧ current → g"
+    domain: "g ∈ u32, existing generation"
+    codomain: "Result<(), String>"
+    invariants:
+      - "current symlink points at the restored generation after rollback"
+      - "Restored lock files match the snapshot content byte-for-byte"
+      - "Rollback to a nonexistent generation is an error"
+      - "Symlink switch is atomic (temp symlink + rename)"
+
+  undo_roundtrip:
+    formula: |
+      undo(n) targets g = current − n;
+      rollback(g) ∘ mutate ∘ snapshot(S → g) = S at the lock level
+    domain: "n ∈ u32, n ≤ current generation"
+    codomain: "Result<(), String>"
+    invariants:
+      - "Destroy followed by undo restores the prior generation's lock state"
+      - "undo(n) with fewer than n generations is an error"
+      - "After undo, current_generation = generation_from − n"
+
+proof_obligations:
+  - type: invariant
+    property: "Create points current at the new generation"
+    formal: "∀ S: create_generation(S) = Ok(g) ⟹ current_generation(gen_dir) = Some(g)"
+    applies_to: all
+    enforced_by: "src/cli/generation.rs::create_generation debug_assert_eq!"
+
+  - type: invariant
+    property: "Rollback points current at the restored generation"
+    formal: "∀ g: rollback_to_generation(g) = Ok(()) ⟹ current_generation(gen_dir) = Some(g)"
+    applies_to: all
+    enforced_by: "src/cli/generation.rs::rollback_to_generation debug_assert_eq!"
+
+  - type: test
+    property: "Roundtrip restores the snapshot byte-for-byte"
+    formal: "snapshot(S → g); mutate(S); rollback(g) ⟹ locks(state_dir) = locks(S)"
+    applies_to: all
+    enforced_by: "src/cli/tests_generation.rs::test_gh97_destroy_undo_roundtrip_restores_snapshot"
+
+  - type: soundness
+    property: "Undo refuses impossible targets"
+    formal: "current < n ⟹ cmd_undo(n) = Err"
+    applies_to: all
+    enforced_by: "src/cli/undo.rs::cmd_undo guard (current < generations)"
+
+enforcement:
+  layer: runtime
+  failure_mode: debug_assert
+  ci_gate: required
+  notes: |
+    The debug_assert! call-sites abort a debug build if the `current`
+    symlink does not resolve to the generation just created/restored
+    (a torn symlink switch). Release builds skip the asserts; the
+    roundtrip unit test catches the same shape on CI. The replay path
+    (cmd_undo_destroy) is best-effort by design — entries flagged
+    reliable_recreate=false require --force and are excluded from the
+    byte-for-byte guarantee.
+
+falsification_tests:
+  - id: FALSIFY-UNDO-001
+    rule: "Snapshot monotonicity"
+    prediction: "Consecutive create_generation calls return strictly increasing numbers"
+    test: "src/cli/tests_generation.rs::test_create_multiple_generations"
+    if_fails: "Generation numbers reused — rollback target ambiguous"
+
+  - id: FALSIFY-UNDO-002
+    rule: "Roundtrip restoration"
+    prediction: "snapshot, mutate, rollback restores original lock content and current symlink"
+    test: "src/cli/tests_generation.rs::test_gh97_destroy_undo_roundtrip_restores_snapshot"
+    if_fails: "Rollback loses or corrupts state — undo is not a true inverse"
+
+  - id: FALSIFY-UNDO-003
+    rule: "Nonexistent target rejected"
+    prediction: "rollback_to_generation to a missing generation returns Err"
+    test: "src/cli/tests_generation.rs::test_rollback_nonexistent_generation"
+    if_fails: "Rollback silently no-ops or destroys state on bad target"
+
+qa_gate:
+  id: F-UNDO-001
+  name: "Destroy/Undo Roundtrip Contract"
+  description: "Undo restores the prior generation's state snapshot"
+  checks:
+    - "snapshot_generation"
+    - "restore_generation"
+    - "undo_roundtrip"
+  pass_criteria: "All 3 falsification tests pass"
+  falsification: "Skip restore_generation_to_state in rollback, switching only the symlink"
+
+verification_level: L3

--- a/contracts/idempotent-apply-v1.yaml
+++ b/contracts/idempotent-apply-v1.yaml
@@ -1,0 +1,121 @@
+---
+metadata:
+  version: "1.0.0"
+  created: "2026-06-12"
+  author: "PAIML Engineering"
+  description: |
+    Idempotent apply — f(f(x)) = f(x) at the plan level. A resource whose
+    lock entry is Converged with a hash equal to hash_desired_state(resource)
+    plans NoOp, and a second plan over converged locks yields zero pending
+    changes. Resolves the idempotency leg of paiml/forjar#97 (KZ-11).
+  references:
+    - "issue: https://github.com/paiml/forjar/issues/97"
+    - "C3: forjar's idempotency falsifiable claim — README.md § Falsifiable Claims"
+    - "FJ-2200: runtime idempotency contracts — src/core/planner/mod.rs"
+    - "apply-summary-distinguishability-v1.yaml — C3 observability through --force"
+
+equations:
+  noop_fixed_point:
+    formula: |
+      determine_present_action(id, r, m, locks) = NoOp
+        ⟺ locks[m].resources[id].status = Converged
+          ∧ locks[m].resources[id].hash = hash_desired_state(r)
+    domain: "r ∈ Resource, locks ∈ HashMap<String, StateLock>"
+    codomain: "PlanAction"
+    invariants:
+      - "Converged lock entry with matching hash always plans NoOp"
+      - "Converged lock entry with differing hash always plans Update"
+      - "Missing lock entry always plans Create"
+
+  hash_determinism:
+    formula: "hash_desired_state(r) = hash_desired_state(r)"
+    domain: "r ∈ Resource"
+    codomain: "String ('blake3:' || hex digest)"
+    invariants:
+      - "Same resource always produces the same hash"
+      - "Hash component field order is stable across calls"
+
+  plan_fixed_point:
+    formula: |
+      plan(c, order, locks_after_apply(c), tag) = P
+        where P.to_create = P.to_update = P.to_destroy = 0
+    domain: "c ∈ ForjarConfig, order ∈ [String], locks ∈ HashMap<String, StateLock>"
+    codomain: "ExecutionPlan"
+    invariants:
+      - "to_create + to_update + to_destroy + unchanged = |changes|"
+      - "Second plan over converged locks yields zero pending changes"
+
+proof_obligations:
+  - type: invariant
+    property: "Converged + matching hash is a NoOp fixed point"
+    formal: "∀ r, locks: status = Converged ∧ hash = hash_desired_state(r) ⟹ action = NoOp"
+    applies_to: all
+    enforced_by: "src/core/planner/mod.rs::determine_present_action debug_assert! (FJ-2200)"
+
+  - type: invariant
+    property: "Desired-state hash is deterministic"
+    formal: "∀ r: hash_desired_state(r) = hash_desired_state(r)"
+    applies_to: all
+    enforced_by: "src/core/planner/mod.rs::hash_desired_state debug_assert_eq! (FJ-2200)"
+
+  - type: invariant
+    property: "Plan counters partition the change set"
+    formal: "∀ P = plan(...): P.to_create + P.to_update + P.to_destroy + P.unchanged = |P.changes|"
+    applies_to: all
+    enforced_by: "src/core/planner/mod.rs::plan debug_assert_eq!"
+
+  - type: test
+    property: "Second plan over converged locks is all-NoOp (f(f(x)) = f(x))"
+    formal: "locks = converged(c) ⟹ plan(c, locks).{to_create, to_update, to_destroy} = 0"
+    applies_to: all
+    enforced_by: "src/core/planner/tests_plan.rs::test_gh97_second_plan_over_converged_locks_is_noop"
+
+enforcement:
+  layer: runtime
+  failure_mode: debug_assert
+  ci_gate: required
+  notes: |
+    The debug_assert! call-sites abort a debug build when the fixed point
+    is violated; release builds skip the asserts, but unit tests and the
+    bounded Kani harness (src/core/kani_proofs.rs::
+    proof_planner_idempotency_bounded) cover the same shapes on CI.
+
+falsification_tests:
+  - id: FALSIFY-IDEM-001
+    rule: "NoOp fixed point"
+    prediction: "Converged lock with hash = hash_desired_state(r) plans NoOp"
+    test: "src/core/planner/tests_plan.rs::test_fj004_plan_all_unchanged"
+    if_fails: "Planner re-applies converged resources — idempotency broken"
+
+  - id: FALSIFY-IDEM-002
+    rule: "Hash determinism"
+    prediction: "hash_desired_state(r) called twice yields identical strings"
+    test: "src/core/planner/tests_hash.rs determinism tests"
+    if_fails: "Unstable field ordering or non-deterministic hashing"
+
+  - id: FALSIFY-IDEM-003
+    rule: "Plan fixed point"
+    prediction: "plan over post-apply locks yields zero create/update/destroy"
+    test: "src/core/planner/tests_plan.rs::test_gh97_second_plan_over_converged_locks_is_noop"
+    if_fails: "f(f(x)) ≠ f(x): apply is not idempotent at the plan level"
+
+kani_harnesses:
+  - id: KANI-IDEM-001
+    obligation: "NoOp fixed point"
+    property: "converged + matching hash → NoOp"
+    bound: 4
+    strategy: bounded
+    harness: proof_planner_idempotency_bounded
+
+qa_gate:
+  id: F-IDEM-001
+  name: "Idempotent Apply Contract"
+  description: "f(f(x)) = f(x) quality gate for plan-level idempotency"
+  checks:
+    - "noop_fixed_point"
+    - "hash_determinism"
+    - "plan_fixed_point"
+  pass_criteria: "All 3 falsification tests pass"
+  falsification: "Make determine_present_action return Update on matching hashes"
+
+verification_level: L3

--- a/contracts/plan-apply-equivalence-v1.yaml
+++ b/contracts/plan-apply-equivalence-v1.yaml
@@ -1,0 +1,112 @@
+---
+metadata:
+  version: "1.0.0"
+  created: "2026-06-12"
+  author: "PAIML Engineering"
+  description: |
+    Plan/apply equivalence — the set of actions `forjar plan` predicts
+    equals the set of actions `forjar apply` executes for the same
+    config + state. Both commands derive their action set from the same
+    pure function (planner::plan), and the executor consumes exactly the
+    planned change set. Resolves the plan/apply-equivalence leg of
+    paiml/forjar#97 (KZ-11).
+  references:
+    - "issue: https://github.com/paiml/forjar/issues/97"
+    - "C2: forjar's plan-fidelity falsifiable claim — README.md § Falsifiable Claims"
+    - "dag-ordering-v1.yaml — shared execution order for plan and apply"
+
+equations:
+  plan_determinism:
+    formula: "plan(c, order, locks, tag) = plan(c, order, locks, tag)"
+    domain: "c ∈ ForjarConfig, order ∈ [String], locks ∈ HashMap<String, StateLock>"
+    codomain: "ExecutionPlan"
+    invariants:
+      - "plan is a pure function of (config, execution_order, locks, tag_filter)"
+      - "forjar plan and forjar apply call the same planner::plan function"
+
+  apply_executes_plan:
+    formula: |
+      executed(apply(cfg)) = changes(plan(cfg.config, order, plan_locks, cfg.tag_filter))
+        partitioned per machine
+    domain: "cfg ∈ ApplyConfig"
+    codomain: "Vec<ApplyResult>"
+    invariants:
+      - "The executor iterates exactly the planned change set per machine"
+      - "converged + unchanged + failed never exceeds the planned change count per machine"
+      - "No resource outside plan.changes is ever executed"
+
+  noop_no_execution:
+    formula: "change.action = NoOp ∧ ¬cfg.force ∧ ¬triggered ⟹ outcome = Unchanged"
+    domain: "change ∈ PlannedChange, cfg ∈ ApplyConfig"
+    codomain: "ResourceOutcome"
+    invariants:
+      - "A planned NoOp without force or trigger runs no apply script"
+      - "A planned Create or Update always reaches execute_resource"
+
+proof_obligations:
+  - type: equivalence
+    property: "Plan and apply derive from the same function"
+    formal: "cmd_plan and executor::apply both call planner::plan with the same (config, order, locks, tag)"
+    applies_to: all
+    enforced_by: "src/core/executor/mod.rs::apply, src/cli/plan.rs::cmd_plan — single planner::plan call site each"
+
+  - type: invariant
+    property: "Executor outcome conservation"
+    formal: "∀ machine m: converged(m) + unchanged(m) + failed(m) ≤ |plan.changes(m)|"
+    applies_to: all
+    enforced_by: "src/core/executor/machine.rs::apply_machine debug_assert!"
+
+  - type: test
+    property: "Apply outcome counts match the plan's prediction"
+    formal: |
+      apply(fresh)     → converged = to_create + to_update ∧ unchanged = plan.unchanged
+      apply(converged) → converged = 0 ∧ unchanged = plan.unchanged
+    applies_to: all
+    enforced_by: "src/core/executor/tests_converge.rs::test_gh97_plan_apply_equivalence"
+    notes: |
+      Deviation is only legal in the executor's *narrowing* direction
+      (resource_filter, when:/arch: re-evaluation, jidoka early stop,
+      --force/--refresh widening is explicit operator intent). Without
+      those flags the executed set equals the planned set.
+
+enforcement:
+  layer: runtime
+  failure_mode: debug_assert
+  ci_gate: required
+  notes: |
+    The runtime debug_assert! aborts a debug build if the executor records
+    more outcomes than the plan predicted changes (planner/executor
+    disagreement). Release builds skip the assert; the integration test
+    catches the same shape on CI.
+
+falsification_tests:
+  - id: FALSIFY-PAE-001
+    rule: "Plan determinism"
+    prediction: "plan(c, order, locks, tag) called twice yields identical plans"
+    test: "call planner::plan twice with the same inputs, compare summaries"
+    if_fails: "Non-deterministic iteration or hashing in the planner"
+
+  - id: FALSIFY-PAE-002
+    rule: "Apply executes plan"
+    prediction: "Fresh apply converges exactly to_create + to_update resources"
+    test: "src/core/executor/tests_converge.rs::test_gh97_plan_apply_equivalence"
+    if_fails: "Executor executes actions the plan did not predict"
+
+  - id: FALSIFY-PAE-003
+    rule: "NoOp no execution"
+    prediction: "Second apply over converged state reports unchanged = plan.unchanged and converged = 0"
+    test: "src/core/executor/tests_converge.rs::test_gh97_plan_apply_equivalence"
+    if_fails: "Executor re-runs scripts for planned NoOps without --force"
+
+qa_gate:
+  id: F-PAE-001
+  name: "Plan/Apply Equivalence Contract"
+  description: "Plan-predicted action set equals apply-executed action set"
+  checks:
+    - "plan_determinism"
+    - "apply_executes_plan"
+    - "noop_no_execution"
+  pass_criteria: "All 3 falsification tests pass"
+  falsification: "Make apply() re-plan with empty locks while plan uses real locks"
+
+verification_level: L3

--- a/src/cli/generation.rs
+++ b/src/cli/generation.rs
@@ -52,6 +52,14 @@ pub(crate) fn create_generation(
     // Atomically switch current symlink
     atomic_symlink_switch(&gen_dir, &target)?;
 
+    // destroy-undo-roundtrip-v1 contract: after the atomic switch, `current`
+    // must resolve to the generation just created.
+    debug_assert_eq!(
+        current_generation(&gen_dir),
+        Some(next),
+        "DESTROY-UNDO-ROUNDTRIP violated: current symlink not at new generation"
+    );
+
     Ok(next)
 }
 
@@ -75,6 +83,14 @@ pub(crate) fn rollback_to_generation(
 
     // Switch current symlink
     atomic_symlink_switch(&gen_dir, &target)?;
+
+    // destroy-undo-roundtrip-v1 contract: after rollback, `current` must
+    // resolve to the restored generation.
+    debug_assert_eq!(
+        current_generation(&gen_dir),
+        Some(generation),
+        "DESTROY-UNDO-ROUNDTRIP violated: current symlink not at restored generation"
+    );
 
     println!("Rolled back to generation {generation}");
     Ok(())

--- a/src/cli/tests_generation.rs
+++ b/src/cli/tests_generation.rs
@@ -220,6 +220,46 @@ mod tests {
     }
 
     #[test]
+    fn test_gh97_destroy_undo_roundtrip_restores_snapshot() {
+        // destroy-undo-roundtrip-v1 contract: rollback(snapshot(S)) = S at
+        // the lock level, and `current` points at the restored generation.
+        let dir = tempfile::tempdir().unwrap();
+        let state_dir = setup_state(dir.path());
+        let lock_path = state_dir.join("m1").join("state.lock.yaml");
+
+        // Pre-destroy state: one converged resource
+        std::fs::write(
+            &lock_path,
+            "schema: '1.0'\nresources: {pkg-a: {status: converged}}",
+        )
+        .unwrap();
+        let original = std::fs::read_to_string(&lock_path).unwrap();
+        let g0 = create_generation(&state_dir, None).unwrap();
+
+        // Simulate a destroy: resource removed, new generation snapshotted
+        std::fs::write(&lock_path, "schema: '1.0'\nresources: {}").unwrap();
+        let g1 = create_generation(&state_dir, None).unwrap();
+        assert_eq!(g1, g0 + 1, "generation numbers must be monotonic");
+
+        let gen_dir = state_dir.join("generations");
+        assert_eq!(current_generation(&gen_dir), Some(g1));
+
+        // Undo: roll back to the pre-destroy generation
+        rollback_to_generation(&state_dir, g0, true).unwrap();
+
+        let restored = std::fs::read_to_string(&lock_path).unwrap();
+        assert_eq!(
+            restored, original,
+            "undo must restore the prior generation's lock byte-for-byte"
+        );
+        assert_eq!(
+            current_generation(&gen_dir),
+            Some(g0),
+            "current must point at the restored generation"
+        );
+    }
+
+    #[test]
     fn test_generation_without_config_hash() {
         let dir = tempfile::tempdir().unwrap();
         let state_dir = setup_state(dir.path());

--- a/src/core/executor/machine.rs
+++ b/src/core/executor/machine.rs
@@ -140,6 +140,17 @@ pub(crate) fn apply_machine(
 
     result?;
 
+    // plan-apply-equivalence-v1 contract: the executor records at most one
+    // outcome per planned change — it never executes an action the plan did
+    // not predict (filters, cascades, and jidoka stops may record fewer).
+    debug_assert!(
+        (counters.converged + counters.unchanged + counters.failed) as usize
+            <= machine_changes.len(),
+        "PLAN-APPLY-EQUIVALENCE violated: outcomes ({}) exceed planned changes ({})",
+        counters.converged + counters.unchanged + counters.failed,
+        machine_changes.len()
+    );
+
     finalize_machine(
         cfg,
         ctx.lock,

--- a/src/core/executor/tests_converge.rs
+++ b/src/core/executor/tests_converge.rs
@@ -365,3 +365,64 @@ resources:
 
     assert!(!path.exists(), "dry-run should not create files");
 }
+
+#[test]
+fn test_gh97_plan_apply_equivalence() {
+    // plan-apply-equivalence-v1 contract: the action set `forjar plan`
+    // predicts equals the action set `forjar apply` executes for the same
+    // config + state.
+    let output_dir = tempfile::tempdir().unwrap();
+    let file_path = output_dir.path().join("equiv.txt");
+    let config = drift_config(file_path.to_str().unwrap());
+    let dir = tempfile::tempdir().unwrap();
+
+    let order = resolver::build_execution_order(&config).unwrap();
+
+    // Fresh state: plan predicts exactly one create
+    let plan1 = planner::plan(&config, &order, &HashMap::new(), None);
+    assert_eq!(plan1.to_create, 1);
+    assert_eq!(plan1.unchanged, 0);
+
+    let cfg = ApplyConfig {
+        config: &config,
+        state_dir: dir.path(),
+        force: false,
+        dry_run: false,
+        machine_filter: None,
+        resource_filter: None,
+        tag_filter: None,
+        group_filter: None,
+        timeout_secs: None,
+        force_unlock: false,
+        progress: false,
+        retry: 0,
+        parallel: None,
+        resource_timeout: None,
+        rollback_on_failure: false,
+        max_parallel: None,
+        trace: false,
+        run_id: None,
+        refresh: false,
+        force_tag: None,
+    };
+    let r1 = apply(&cfg).unwrap();
+
+    // Executor performed exactly what the plan predicted
+    assert_eq!(r1[0].resources_converged, plan1.to_create + plan1.to_update);
+    assert_eq!(r1[0].resources_unchanged, plan1.unchanged);
+    assert_eq!(r1[0].resources_failed, 0);
+
+    // Converged state: plan over the saved locks predicts zero work
+    let lock = state::load_lock(dir.path(), "local").unwrap().unwrap();
+    let mut locks = HashMap::new();
+    locks.insert("local".to_string(), lock);
+    let plan2 = planner::plan(&config, &order, &locks, None);
+    assert_eq!(plan2.to_create + plan2.to_update + plan2.to_destroy, 0);
+    assert_eq!(plan2.unchanged, 1);
+
+    // Second apply executes exactly the predicted (empty) action set
+    let r2 = apply(&cfg).unwrap();
+    assert_eq!(r2[0].resources_converged, plan2.to_create + plan2.to_update);
+    assert_eq!(r2[0].resources_unchanged, plan2.unchanged);
+    assert_eq!(r2[0].resources_failed, 0);
+}

--- a/src/core/planner/mod.rs
+++ b/src/core/planner/mod.rs
@@ -59,6 +59,16 @@ pub fn plan(
         }
     }
 
+    // idempotent-apply-v1 contract: action counters partition the change
+    // set — every planned change is counted exactly once, so a fully
+    // converged stack shows to_create = to_update = to_destroy = 0
+    // (f(f(x)) = f(x) at the plan level).
+    debug_assert_eq!(
+        (to_create + to_update + to_destroy + unchanged) as usize,
+        changes.len(),
+        "IDEMPOTENT-APPLY violated: action counters do not partition the change set"
+    );
+
     ExecutionPlan {
         name: config.name.clone(),
         changes,
@@ -223,7 +233,8 @@ fn determine_present_action(
         PlanAction::Update
     };
 
-    // FJ-2200: Idempotency postcondition — converged + matching hash → NoOp
+    // FJ-2200 / idempotent-apply-v1 contract: idempotency postcondition —
+    // converged + matching hash → NoOp
     debug_assert!(
         rl.status != ResourceStatus::Converged
             || rl.hash != desired_hash
@@ -304,7 +315,8 @@ pub fn hash_desired_state(resource: &Resource) -> String {
     let joined = components.join("\0");
     let result = hasher::hash_string(&joined);
 
-    // FJ-2200: Determinism postcondition — calling again must produce same hash
+    // FJ-2200 / idempotent-apply-v1 contract: determinism postcondition —
+    // calling again must produce the same hash
     debug_assert_eq!(
         result,
         hasher::hash_string(&joined),

--- a/src/core/planner/tests_plan.rs
+++ b/src/core/planner/tests_plan.rs
@@ -355,3 +355,61 @@ fn test_fj132_plan_mixed_actions() {
     assert_eq!(p.unchanged, 1, "pkg should be unchanged");
     assert_eq!(p.to_create, 1, "conf should be created");
 }
+
+#[test]
+fn test_gh97_plan_counter_conservation() {
+    // idempotent-apply-v1 contract: action counters partition the change set.
+    let config = make_config();
+    let order = vec!["pkg".to_string(), "conf".to_string(), "svc".to_string()];
+    let locks = HashMap::new();
+
+    let p = plan(&config, &order, &locks, None);
+    assert_eq!(
+        (p.to_create + p.to_update + p.to_destroy + p.unchanged) as usize,
+        p.changes.len(),
+        "counters must partition the change set"
+    );
+}
+
+#[test]
+fn test_gh97_second_plan_over_converged_locks_is_noop() {
+    // idempotent-apply-v1 contract: f(f(x)) = f(x) — a second plan over
+    // locks that record every resource as Converged with the desired-state
+    // hash yields zero pending changes.
+    let config = make_config();
+    let order = vec!["pkg".to_string(), "conf".to_string(), "svc".to_string()];
+
+    let mut resources = indexmap::IndexMap::new();
+    for id in &order {
+        let resource = &config.resources[id];
+        resources.insert(
+            id.clone(),
+            ResourceLock {
+                resource_type: resource.resource_type.clone(),
+                status: ResourceStatus::Converged,
+                applied_at: None,
+                duration_seconds: None,
+                hash: hash_desired_state(resource),
+                details: HashMap::new(),
+            },
+        );
+    }
+    let lock = StateLock {
+        schema: "1.0".to_string(),
+        machine: "m1".to_string(),
+        hostname: "m1".to_string(),
+        generated_at: "2026-01-01T00:00:00Z".to_string(),
+        generator: "forjar".to_string(),
+        blake3_version: "1.8".to_string(),
+        resources,
+    };
+    let mut locks = HashMap::new();
+    locks.insert("m1".to_string(), lock);
+
+    let p = plan(&config, &order, &locks, None);
+    assert_eq!(p.to_create, 0, "converged stack must plan no creates");
+    assert_eq!(p.to_update, 0, "converged stack must plan no updates");
+    assert_eq!(p.to_destroy, 0, "converged stack must plan no destroys");
+    assert_eq!(p.unchanged, 3, "all resources must be NoOp");
+    assert!(p.changes.iter().all(|c| c.action == PlanAction::NoOp));
+}


### PR DESCRIPTION
## Summary

Resolves the three missing provable contracts from #97 (KZ-11) — roadmap item **PMAT-083 (CONTRACT-1)**. The fourth contract requested by the issue (dependency ordering / DAG topological sort) already shipped as `contracts/dag-ordering-v1.yaml`.

### 1. `contracts/idempotent-apply-v1.yaml` — f(f(x)) = f(x) at the plan level

A resource whose lock entry is `Converged` with `hash == hash_desired_state(resource)` plans `NoOp`, and a second plan over converged locks yields zero pending changes.

Bound functions (status: implemented):
- `forjar::core::planner::plan` (equation `plan_fixed_point`) — new counter-conservation `debug_assert_eq!`
- `forjar::core::planner::hash_desired_state` (equation `hash_determinism`) — existing FJ-2200 determinism assert, now contract-tagged
- `forjar::core::planner::determine_present_action` (equation `noop_fixed_point`) — existing FJ-2200 idempotency assert, now contract-tagged

### 2. `contracts/plan-apply-equivalence-v1.yaml` — plan/apply action-set equality

The set of actions `forjar plan` predicts equals the set `forjar apply` executes for the same config + state: both derive from the same pure `planner::plan`, and the executor iterates exactly `plan.changes` (planned `NoOp` without `--force`/trigger runs no script).

Bound functions (status: implemented):
- `forjar::core::planner::plan` (equation `plan_determinism`)
- `forjar::core::executor::apply` (equation `apply_executes_plan`) — new outcome-conservation `debug_assert!` in `apply_machine`
- `forjar::core::executor::apply_single_resource` (equation `noop_no_execution`)

### 3. `contracts/destroy-undo-roundtrip-v1.yaml` — undo restores the prior generation

Destroy (or any mutation) followed by `forjar undo` restores the prior generation's state snapshot byte-for-byte, with the `current` symlink atomically re-pointed; generation numbers are strictly monotonic.

Bound functions (status: implemented):
- `forjar::cli::generation::create_generation` (equation `snapshot_generation`) — new `debug_assert_eq!` on `current` symlink
- `forjar::cli::generation::rollback_to_generation` (equation `restore_generation`) — new `debug_assert_eq!` on `current` symlink
- `forjar::cli::undo::cmd_undo` (equation `undo_roundtrip`)

## Runtime enforcement

Follows the `apply-summary-distinguishability-v1` pattern (PR #130): `debug_assert!` call-sites with contract comments in the bound functions, zero cost in release builds. No new runtime logic — all bindings point at existing functions. `src/generated_contracts.rs` is unchanged by design: it is generated by `pv codegen` from the external provable-contracts repo, while forjar-local contracts are enforced via plain `debug_assert!` call-sites + `build.rs` env-var emission.

## New tests (one per assert site)

- `core::planner::tests_plan::test_gh97_plan_counter_conservation`
- `core::planner::tests_plan::test_gh97_second_plan_over_converged_locks_is_noop`
- `core::executor::tests_converge::test_gh97_plan_apply_equivalence`
- `cli::tests_generation::tests::test_gh97_destroy_undo_roundtrip_restores_snapshot`

## Verification

- `cargo build` — **22/22 bindings bound** (0 partial, 0 not_implemented) under `BindingPolicy::AllImplemented`
- `cargo test --lib` — 12,075 passed, 0 failed (4 new `gh97` tests green)
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- YAML validated (3 new contracts + binding.yaml); every binding equation resolves to a contract equation; all precondition/postcondition/invariant strings are single-line (safe for build.rs `cargo::rustc-env` emission)

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)