### PR TITLE
fix(core): scrub GIT_DIR env so forjar git calls can't escape their repo

### DIFF
--- a/src/cli/apply_helpers.rs
+++ b/src/cli/apply_helpers.rs
@@ -107,16 +107,14 @@ pub(crate) fn git_commit_state(
     let msg = format!("forjar: {config_name} — {converged} resource(s) converged");
     // Find the git repo root from state_dir's parent
     let repo_root = state_dir.parent().unwrap_or(Path::new("."));
-    let status = std::process::Command::new("git")
-        .current_dir(repo_root)
+    let status = crate::core::gitenv::git_in(repo_root)
         .args(["add", "state"])
         .status()
         .map_err(|e| format!("git add failed: {e}"))?;
     if !status.success() {
         return Err("git add state/ failed".to_string());
     }
-    let status = std::process::Command::new("git")
-        .current_dir(repo_root)
+    let status = crate::core::gitenv::git_in(repo_root)
         .args(["commit", "--no-verify", "-m", &msg])
         .status()
         .map_err(|e| format!("git commit failed: {e}"))?;

--- a/src/cli/destroy.rs
+++ b/src/cli/destroy.rs
@@ -237,7 +237,7 @@ pub(crate) fn cmd_rollback(
 ) -> Result<(), String> {
     let file_str = file.to_string_lossy();
     let git_ref = format!("HEAD~{revision}:{file_str}");
-    let output = std::process::Command::new("git")
+    let output = crate::core::gitenv::git()
         .args(["show", &git_ref])
         .output()
         .map_err(|e| format!("git show failed: {e}"))?;

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -1,7 +1,7 @@
 //! Doctor diagnostics.
 
 use super::helpers::*;
-use crate::core::{parser, secrets, types};
+use crate::core::{gitenv, parser, secrets, types};
 use std::path::Path;
 
 #[derive(Debug)]
@@ -238,8 +238,8 @@ fn check_state_dir(fix: bool) -> Vec<DoctorCheck> {
 }
 
 fn check_git() -> DoctorCheck {
-    use std::process::Command;
-    match Command::new("git").args(["status", "--porcelain"]).output() {
+    let out = gitenv::git().args(["status", "--porcelain"]).output();
+    match out {
         Ok(out) if out.status.success() => {
             let output = String::from_utf8_lossy(&out.stdout);
             if output.trim().is_empty() {

--- a/src/cli/query_format.rs
+++ b/src/cli/query_format.rs
@@ -160,7 +160,7 @@ pub(crate) struct GitLogEntry {
 
 /// Search git log for query terms, fuse with FTS results via RRF.
 pub(crate) fn print_git_history(query: &str, results: &[FtsResult]) -> Result<(), String> {
-    let output = std::process::Command::new("git")
+    let output = crate::core::gitenv::git()
         .args([
             "log",
             "--oneline",

--- a/src/cli/repro_proof.rs
+++ b/src/cli/repro_proof.rs
@@ -50,9 +50,8 @@ pub(crate) fn cmd_repro_proof(file: &Path, state_dir: &Path, json: bool) -> Resu
 
 fn get_git_sha(file: &Path) -> Option<String> {
     let dir = file.parent()?;
-    let output = std::process::Command::new("git")
+    let output = crate::core::gitenv::git_in(dir)
         .args(["rev-parse", "HEAD"])
-        .current_dir(dir)
         .output()
         .ok()?;
     if output.status.success() {

--- a/src/cli/status_convergence.rs
+++ b/src/cli/status_convergence.rs
@@ -90,7 +90,7 @@ pub(crate) fn cmd_status_changes_since(
     commit: &str,
     json: bool,
 ) -> Result<(), String> {
-    let output = std::process::Command::new("git")
+    let output = crate::core::gitenv::git()
         .args([
             "diff",
             "--name-only",

--- a/src/cli/tests_check.rs
+++ b/src/cli/tests_check.rs
@@ -28,32 +28,30 @@ mod tests {
         let state = dir.path().join("state");
         std::fs::create_dir_all(&state).unwrap();
 
-        // Init git repo in temp dir
-        std::process::Command::new("git")
+        // Init git repo in temp dir. Must go through gitenv: when this
+        // suite runs inside a git hook (pre-push), inherited GIT_DIR would
+        // otherwise re-target every one of these commands — and the
+        // auto-commit under test — at the host repository (GH-134).
+        crate::core::gitenv::git_in(dir.path())
             .args(["init"])
-            .current_dir(dir.path())
             .output()
             .unwrap();
-        std::process::Command::new("git")
+        crate::core::gitenv::git_in(dir.path())
             .args(["config", "user.email", "test@test.com"])
-            .current_dir(dir.path())
             .output()
             .unwrap();
-        std::process::Command::new("git")
+        crate::core::gitenv::git_in(dir.path())
             .args(["config", "user.name", "Test"])
-            .current_dir(dir.path())
             .output()
             .unwrap();
         // Initial commit so the repo is in a valid state
         std::fs::write(dir.path().join(".gitkeep"), "").unwrap();
-        std::process::Command::new("git")
+        crate::core::gitenv::git_in(dir.path())
             .args(["add", ".gitkeep"])
-            .current_dir(dir.path())
             .output()
             .unwrap();
-        std::process::Command::new("git")
+        crate::core::gitenv::git_in(dir.path())
             .args(["commit", "-m", "init"])
-            .current_dir(dir.path())
             .output()
             .unwrap();
 
@@ -122,9 +120,8 @@ resources:
         assert!(target.exists());
 
         // Verify git committed the state
-        let output = std::process::Command::new("git")
+        let output = crate::core::gitenv::git_in(dir.path())
             .args(["log", "--oneline", "-1"])
-            .current_dir(dir.path())
             .output()
             .unwrap();
         let log = String::from_utf8_lossy(&output.stdout);

--- a/src/core/gitenv.rs
+++ b/src/core/gitenv.rs
@@ -1,0 +1,114 @@
+//! Git subprocess construction immune to hook-injected repository targeting.
+//!
+//! Git exports `GIT_DIR` (and related variables) to processes it spawns from
+//! hooks. A forjar invocation inside a pre-push/post-commit hook would
+//! therefore run its own `git` subprocesses against the *hook's* repository
+//! instead of the stack's — `current_dir()` is ignored once `GIT_DIR` is set
+//! (GH-134). Every production `git` invocation must go through these
+//! constructors.
+
+use std::path::Path;
+use std::process::Command;
+
+/// Environment variables through which git redirects repository discovery.
+const GIT_REPO_ENV: [&str; 9] = [
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_COMMON_DIR",
+    "GIT_NAMESPACE",
+    "GIT_PREFIX",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_CEILING_DIRECTORIES",
+];
+
+/// A `git` command whose repository is resolved solely from the process cwd.
+pub fn git() -> Command {
+    let mut cmd = Command::new("git");
+    for var in GIT_REPO_ENV {
+        cmd.env_remove(var);
+    }
+    cmd
+}
+
+/// A `git` command whose repository is resolved solely from `dir`.
+pub fn git_in(dir: &Path) -> Command {
+    let mut cmd = git();
+    cmd.current_dir(dir);
+    cmd
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn git_scrubs_all_repo_env_vars() {
+        let cmd = git();
+        let removed: Vec<_> = cmd
+            .get_envs()
+            .filter(|(_, v)| v.is_none())
+            .map(|(k, _)| k.to_os_string())
+            .collect();
+        for var in GIT_REPO_ENV {
+            assert!(
+                removed.iter().any(|k| k == var),
+                "expected {var} to be scrubbed"
+            );
+        }
+    }
+
+    #[test]
+    fn git_in_sets_cwd_and_scrubs() {
+        let dir = tempfile::tempdir().unwrap();
+        let cmd = git_in(dir.path());
+        assert_eq!(cmd.get_current_dir(), Some(dir.path()));
+        assert!(cmd.get_envs().any(|(k, v)| k == "GIT_DIR" && v.is_none()));
+    }
+
+    /// Demonstrates the GH-134 failure mode at the Command level: an
+    /// explicit GIT_DIR overrides current_dir for repository targeting,
+    /// while the scrubbed constructor resolves the cwd repository.
+    #[test]
+    fn git_dir_env_overrides_cwd_but_scrubbed_command_is_immune() {
+        let repo = tempfile::tempdir().unwrap();
+        let decoy = tempfile::tempdir().unwrap();
+        for dir in [repo.path(), decoy.path()] {
+            let ok = git_in(dir).args(["init", "-q"]).status().unwrap();
+            assert!(ok.success());
+        }
+
+        // Unscrubbed + GIT_DIR (as inside a git hook): the decoy wins.
+        let out = Command::new("git")
+            .current_dir(repo.path())
+            .env("GIT_DIR", decoy.path().join(".git"))
+            .args(["rev-parse", "--absolute-git-dir"])
+            .output()
+            .unwrap();
+        let hijacked = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            hijacked
+                .trim()
+                .starts_with(&*decoy.path().to_string_lossy()),
+            "expected GIT_DIR to hijack discovery, got: {hijacked}"
+        );
+
+        // Scrubbed constructor: cwd repository wins. (The scrub list is
+        // applied by git_in; the decoy var cannot be re-injected here
+        // without defeating the test, so this asserts the cwd resolution.)
+        let out = git_in(repo.path())
+            .args(["rev-parse", "--absolute-git-dir"])
+            .output()
+            .unwrap();
+        let resolved = String::from_utf8_lossy(&out.stdout);
+        let canon = repo.path().canonicalize().unwrap();
+        let canon_resolved = Path::new(resolved.trim())
+            .canonicalize()
+            .unwrap_or_default();
+        assert!(
+            canon_resolved.starts_with(&canon),
+            "expected {canon:?} prefix, got {canon_resolved:?}"
+        );
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -10,6 +10,7 @@ pub mod conditions;
 pub mod cron_source;
 pub mod ephemeral;
 pub mod executor;
+pub mod gitenv;
 pub mod metric_collector;
 pub mod metric_source;
 pub mod migrate;

--- a/src/core/types/generation_types.rs
+++ b/src/core/types/generation_types.rs
@@ -157,7 +157,7 @@ impl MachineDelta {
 
 /// FJ-2002: Get the current git HEAD ref, if in a git repository.
 pub fn get_git_ref() -> Option<String> {
-    std::process::Command::new("git")
+    crate::core::gitenv::git()
         .args(["rev-parse", "--short", "HEAD"])
         .output()
         .ok()
@@ -168,7 +168,7 @@ pub fn get_git_ref() -> Option<String> {
 
 /// FJ-2002: Check if the git working tree is dirty (uncommitted changes).
 pub fn git_is_dirty() -> bool {
-    std::process::Command::new("git")
+    crate::core::gitenv::git()
         .args(["status", "--porcelain"])
         .output()
         .ok()


### PR DESCRIPTION
## Summary

Closes #134. Git exports `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE` (and six more repo-discovery variables) to hook subprocesses. forjar's git invocations passed `current_dir()` but inherited those vars — so `forjar apply` with `auto_commit` running inside **any git hook** operated on the hook's repository instead of the stack's (`current_dir` is ignored once `GIT_DIR` is set).

Observed today, three times, while this repo's own pre-push gate ran the test suite:
- staged deletions of tracked `state/backup-*/` files in the host repo
- a stray `forjar: autocommit-test` commit (author `Test <test@test.com>`) on a feature branch
- **`core.bare = true` flipped on the host `.git/config`** via a leaked `git init`, breaking every worktree

## Change

New `core::gitenv` module: `git()` / `git_in(dir)` constructors that `env_remove` all nine repo-discovery vars. Every production git call site now goes through them:
- `apply_helpers::git_commit_state` (the auto-commit — the critical one)
- `generation_types::{get_git_ref, git_is_dirty}`
- `repro_proof::get_git_sha`, `status_convergence::cmd_status_changes_since`
- `doctor::check_git`, `destroy::cmd_rollback`, `query_format::print_git_history`
- plus the `test_auto_commit_in_git_repo` setup helpers

## Tests
- Scrub-list assertion via `Command::get_envs()`
- Behavioral demo: `GIT_DIR` hijacks discovery for an unscrubbed command targeting a decoy repo; `git_in()` resolves the cwd repository
- Real-world validation: the pre-push gate (which reproduces the hook env) passed the full 12k suite twice with this fix — it was failing intermittently before

Roadmap: filed as #134 during the sprint (fault discovered by PMAT-073/074 execution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)