### PR TITLE
chore(release): prep v1.4.4 — working install path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.4] - 2026-06-12
+
+### Fixed
+
+- **`install.sh` works end-to-end** (#143) — verified live against the
+  v1.4.3 release. The curl installer previously failed on every
+  platform: wrong extraction path (archives contain a directory),
+  unexpanded `~` fallback dir, hard dependency on a SHA256SUMS asset no
+  release carried, `example.com` placeholder URLs, and a post-install
+  version check that reported any pre-existing PATH binary. Generator
+  now emits `$HOME`, directory-aware extraction, per-asset `.sha256`
+  fallback, `"$DEST/$BINARY"`-anchored verification, `--prefix`
+  traversal rejection, and lints clean (bashrs 16 errors → 0).
+- **gnu binaries run on older distros again**: release builds moved to
+  ubuntu-22.04 (glibc 2.35 baseline) — 24.04-built binaries demanded
+  glibc ≥ 2.38.
+- Regression tests pin the fixes for #85, #86, #88, #90 (#140); 15
+  stale issues closed with evidence — open issues went from 18 to 1.
+- Six F-grade files refactored to A-/B+ (#142, closes #116): zero
+  F-grade files repo-wide; strict TDG pre-commit enforcement can be
+  re-enabled via `pmat hooks refresh`.
+
+### Added
+
+- `binary-release.yml` uploads a combined **SHA256SUMS** asset per
+  release (backfilled to v1.4.0/1/3); nightly **tag/release parity
+  check**; all 8 historical tags now have GitHub releases with
+  CHANGELOG-sourced notes, and v1.4.0/v1.4.1 received backfilled
+  binaries.
+- `tests/install_sh_parity.rs`: committed installer is byte-equal to
+  generator output; workflow asset naming matches installer
+  expectations.
+- README documents the binary install path (installer one-liner,
+  manual verify, cargo-binstall).
+- `forjar dist` resolves **real checksums/versions** for Homebrew/Nix
+  artifacts (#139, PMAT-080/F-3608/F-3610): `--version` + offline
+  `--checksums-file`, hard errors instead of `PLACEHOLDER_CHECKSUM`.
+
 ## [1.4.3] - 2026-06-12
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1092,7 +1092,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "forjar"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "age",
  "aprender-contracts",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forjar"
-version = "1.4.3"
+version = "1.4.4"
 edition.workspace = true
 rust-version = "1.89.0"
 authors = ["Pragmatic AI Labs"]

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -1271,11 +1271,11 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'REL-4: Tag v1.4.3 and verify end-to-end hosted-runner release'
-  status: inprogress
+  status: completed
   priority: high
   assigned_to: null
   created: 2026-06-12T12:00:00Z
-  updated: 2026-06-12T20:30:00Z
+  updated: 2026-06-12T22:30:00Z
   spec: null
   acceptance_criteria:
   - Cargo.toml + Cargo.lock bumped to 1.4.3 together, CHANGELOG entry written
@@ -1290,11 +1290,11 @@ roadmap:
   github_issue: 96
   item_type: task
   title: 'HYG-1: Regression tests for already-fixed issues, then close ~12 stale issues with evidence'
-  status: pending
+  status: completed
   priority: medium
   assigned_to: null
   created: 2026-06-12T12:00:00Z
-  updated: 2026-06-12T12:00:00Z
+  updated: 2026-06-12T22:30:00Z
   spec: null
   acceptance_criteria:
   - Regression tests pin fixes for #85 (secret_provider traversal/injection), #86 (p95 clamp), #87 (UTF-8 truncate), #88 (recipe depends_on)
@@ -1310,11 +1310,11 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'INST-1: install.sh works end-to-end — SHA256SUMS asset, naming parity test, README/book install rewrite'
-  status: pending
+  status: completed
   priority: high
   assigned_to: null
   created: 2026-06-12T12:00:00Z
-  updated: 2026-06-12T12:00:00Z
+  updated: 2026-06-12T22:30:00Z
   spec: null
   acceptance_criteria:
   - binary-release.yml uploads a combined SHA256SUMS asset (or install.sh falls back to per-asset .sha256)
@@ -1331,11 +1331,11 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'INST-2: Backfill 5 tag-only GitHub releases + nightly tag/release parity check'
-  status: pending
+  status: completed
   priority: medium
   assigned_to: null
   created: 2026-06-12T12:00:00Z
-  updated: 2026-06-12T12:00:00Z
+  updated: 2026-06-12T22:30:00Z
   spec: null
   acceptance_criteria:
   - v1.0.0, v1.1.0, v1.1.1, v1.4.0, v1.4.1 have GitHub releases with notes from matching CHANGELOG sections
@@ -1350,11 +1350,11 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'REL-5: Tag v1.4.4 — working install path release'
-  status: pending
+  status: inprogress
   priority: high
   assigned_to: null
   created: 2026-06-12T12:00:00Z
-  updated: 2026-06-12T12:00:00Z
+  updated: 2026-06-12T22:30:00Z
   spec: null
   acceptance_criteria:
   - v1.4.4 tagged after INST-1/INST-2 merge; release auto-created with binaries + SHA256SUMS + install.sh verified
@@ -1368,11 +1368,11 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'DIST-1: forjar dist --version + real checksum resolution for Homebrew/Nix (F-3608, F-3610)'
-  status: pending
+  status: completed
   priority: high
   assigned_to: null
   created: 2026-06-12T12:00:00Z
-  updated: 2026-06-12T12:00:00Z
+  updated: 2026-06-12T22:30:00Z
   spec: docs/specifications/platform/25-distribution-artifact-generation.md
   acceptance_criteria:
   - DistArgs gains --version <TAG>; generators resolve real per-target sha256 from the release SHA256SUMS (network) or --checksums-file (offline)


### PR DESCRIPTION
Release prep for **v1.4.4** (PMAT-079): version bump (toml+lock together), CHANGELOG covering #139 #140 #142 #143, roadmap sprint statuses.

After merge: tag v1.4.4 → hosted-runner release with 4 Linux binaries on the **ubuntu-22.04 glibc baseline** + the first auto-generated **SHA256SUMS** asset; install.sh one-liner then works against `releases/latest` out of the box. No crates.io publish (Friday-only rule; 2026-06-19 ships v1.5.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)