### PR TITLE
fix(release): include runner image in cargo cache key

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -164,7 +164,10 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: binary-${{ matrix.target }}
+          # The runner image MUST be part of the key: objects cached on
+          # 24.04 (glibc 2.38, __isoc23_* symbols) fail to link on 22.04
+          # (v1.4.4 x86_64-gnu leg failed exactly this way).
+          shared-key: binary-${{ matrix.target }}-u2204
 
       - name: Build forjar
         run: |


### PR DESCRIPTION
v1.4.4's x86_64-gnu build leg failed: Swatinem/rust-cache restored objects built on ubuntu-24.04 (glibc 2.38, `__isoc23_*` symbols) onto the new ubuntu-22.04 runner (#143's glibc-baseline change), and linking died with `undefined symbol: __isoc23_strtol`. The other 3 legs succeeded (musl static, aarch64 in cross containers).

One-line fix: the runner image is now part of the `shared-key`. After merge, `gh workflow run binary-release.yml -f tag=v1.4.4` backfills the missing x86_64-gnu asset + SHA256SUMS (the aggregate job was skipped on the failed matrix).

Workflow-only change; YAML validated. Refs PMAT-079.

🤖 Generated with [Claude Code](https://claude.com/claude-code)