### PR TITLE
fix(test): de-flake convergence_parallel_multiple_targets (Refs #141)

### DIFF
--- a/src/core/store/convergence_runner.rs
+++ b/src/core/store/convergence_runner.rs
@@ -172,9 +172,20 @@ pub fn run_convergence_test_dispatch(
 pub fn run_convergence_test(target: &ConvergenceTarget) -> ConvergenceResult {
     let start = std::time::Instant::now();
 
-    // Create isolated sandbox directory
+    // Create isolated sandbox directory.
+    //
+    // Uniqueness MUST NOT depend on wall-clock time alone (issue #141):
+    // concurrent callers share the PID, and two threads can read identical
+    // `SystemTime` values on coarse-granularity clocks (e.g. 100ns Hyper-V
+    // ticks on virtualized CI runners). Colliding runs then share a sandbox
+    // and race each other's cleanup — `remove_dir_all` yanks the directory
+    // out from under the sibling's bash subprocess (spawn fails with ENOENT).
+    // A process-wide atomic counter guarantees in-process uniqueness; the
+    // PID separates processes; the timestamp avoids stale-dir reuse.
+    static SANDBOX_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = SANDBOX_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let sandbox_dir = std::env::temp_dir().join(format!(
-        "forjar-conv-{}-{:x}",
+        "forjar-conv-{}-{seq}-{:x}",
         std::process::id(),
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)


### PR DESCRIPTION
Closes #141

## Root cause

`run_convergence_test` named its per-run sandbox directory `forjar-conv-{pid}-{nanos}` using `SystemTime::now()`. Every concurrent caller in the test process shares the PID, so directory uniqueness rested **solely on a wall-clock nanosecond read**:

- `run_convergence_parallel(targets, 2)` spawns 2 scoped worker threads that read the clock almost simultaneously, and sibling `#[test]`s on other harness threads call `run_convergence_test` at the same instant.
- On coarse-granularity clocks (GitHub Actions runners are Azure/Hyper-V VMs with 100 ns clock ticks) two threads can read **identical** timestamps; llvm-cov instrumentation overhead shifts thread startup timing into closer alignment, which is why only the Coverage workflow flaked.
- Colliding runs then share one sandbox directory. The first thread to finish calls `remove_dir_all` on it while the sibling is mid-cycle: the sibling's next `bash` spawn with `current_dir` pointing at the removed directory fails with ENOENT, producing `error: Some("local exec: No such file or directory")` / `converged=false` / `idempotent=false` — so `passed()` is false and the line-118 assertion fails.

**Mechanism proven** with a standalone repro: two threads sharing one sandbox dir running the exact apply/query/apply/query + cleanup cycle fail **32/240 trials** with `local exec: No such file or directory (os error 2)` — the exact failure signature.

## Fix

Make sandbox-dir uniqueness clock-independent: a process-wide `AtomicU64` sequence number is added to the directory name (`forjar-conv-{pid}-{seq}-{nanos}`). The PID still separates processes, the timestamp still avoids stale-dir reuse. This is a root-cause fix in production code (the same collision could hit `forjar check`'s parallel convergence runs), not an assertion loosening — the test is unchanged and remains a regression guard.

## Evidence

- 50x plain loop: `cargo test --lib convergence_parallel -- --test-threads=4` → **0 failures in 50 runs**
- 50x under coverage instrumentation, widened to the whole collision domain: `cargo llvm-cov --no-report -p forjar --lib -- convergence --test-threads=8` (all 239 convergence tests) → **0 failures in 50 runs**
- Full suite: `cargo test --lib` → 12136 passed, 0 failed
- `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --all -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)