### PR TITLE
test(cov): close CLI coverage gaps in apply/fleet/dispatch paths (Refs PMAT-088)

### DIFF
--- a/src/cli/apply_output.rs
+++ b/src/cli/apply_output.rs
@@ -334,7 +334,7 @@ pub(super) fn apply_post_actions(
 /// Check blocks execute AFTER all resources converge. Each check runs a command
 /// on the specified machine and verifies the exit code matches expect_exit (default 0).
 /// Failures are warnings — they don't roll back the apply (like OpenTofu).
-fn run_check_blocks(config: &types::ForjarConfig, verbose: bool) {
+pub(super) fn run_check_blocks(config: &types::ForjarConfig, verbose: bool) {
     let total = config.checks.len();
     let mut passed = 0usize;
     let mut failed = 0usize;

--- a/src/cli/mod_test_decl_c.rs
+++ b/src/cli/mod_test_decl_c.rs
@@ -120,3 +120,13 @@ mod tests_lsp_ext_cov;
 mod tests_parallel_multi_stack_cov;
 #[cfg(test)]
 mod tests_iso_export_ext2_cov;
+#[cfg(test)]
+mod tests_cov_apply_modes;
+#[cfg(test)]
+mod tests_cov_apply_variants2;
+#[cfg(test)]
+mod tests_cov_fleet_run;
+#[cfg(test)]
+mod tests_cov_infra_dispatch2;
+#[cfg(test)]
+mod tests_cov_check_blocks;

--- a/src/cli/tests_cov_apply_modes.rs
+++ b/src/cli/tests_cov_apply_modes.rs
@@ -1,0 +1,320 @@
+//! Tests: Coverage for apply_mode_exits / apply_early_exits / apply_pre_checks
+//! in dispatch_apply_b.rs, driven through dispatch_apply_cmd (PMAT-088).
+
+use super::commands::*;
+use super::dispatch_apply_b::dispatch_apply_cmd;
+use super::helpers::parse_and_validate;
+use super::helpers_state::load_machine_locks;
+use super::plan::save_plan_file;
+use super::workspace::inject_workspace_param;
+use crate::core::{planner, resolver};
+use std::path::{Path, PathBuf};
+
+/// Local clap wrapper so tests build ApplyArgs from CLI strings.
+#[derive(clap::Parser)]
+#[command(name = "forjar")]
+struct TestCli {
+    #[command(subcommand)]
+    cmd: Commands,
+}
+
+fn apply_cmd(extra: &[String]) -> Commands {
+    let mut argv: Vec<String> = vec!["forjar".into(), "apply".into()];
+    argv.extend(extra.iter().cloned());
+    let cli = <TestCli as clap::Parser>::try_parse_from(argv).expect("clap parse");
+    cli.cmd
+}
+
+/// Dispatch on a 16 MiB stack — the apply pipeline's frames exceed the
+/// default test-thread stack (same pattern as tests_cov_dispatch_5).
+fn run_apply(extra: &[&str]) -> Result<(), String> {
+    let argv: Vec<String> = extra.iter().map(|s| s.to_string()).collect();
+    std::thread::Builder::new()
+        .stack_size(16 * 1024 * 1024)
+        .spawn(move || dispatch_apply_cmd(apply_cmd(&argv), false))
+        .expect("spawn apply thread")
+        .join()
+        .expect("join apply thread")
+}
+
+/// Write a single-machine localhost config whose file resource targets `target`.
+fn write_cfg(dir: &Path, target: &Path) -> PathBuf {
+    let yaml = format!(
+        "version: \"1.0\"\nname: modes\nmachines:\n  m:\n    hostname: m\n    addr: 127.0.0.1\nresources:\n  a:\n    type: file\n    machine: m\n    path: {}\n    content: hello\n",
+        target.display()
+    );
+    let p = dir.join("forjar.yaml");
+    std::fs::write(&p, yaml).unwrap();
+    p
+}
+
+fn setup() -> (tempfile::TempDir, PathBuf, PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("out.txt");
+    let cfg = write_cfg(dir.path(), &target);
+    let sd = dir.path().join("state");
+    std::fs::create_dir_all(&sd).unwrap();
+    (dir, cfg, sd)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s(p: &Path) -> String {
+        p.display().to_string()
+    }
+
+    // ── apply_mode_exits branches ──
+
+    #[test]
+    fn mode_preview_ok() {
+        let (_d, cfg, sd) = setup();
+        let r = run_apply(&["-f", &s(&cfg), "--state-dir", &s(&sd), "--preview"]);
+        assert!(r.is_ok());
+    }
+
+    #[test]
+    fn mode_output_scripts_ok() {
+        let (d, cfg, sd) = setup();
+        let scripts = d.path().join("scripts");
+        let r = run_apply(&[
+            "-f",
+            &s(&cfg),
+            "--state-dir",
+            &s(&sd),
+            "--output-scripts",
+            &s(&scripts),
+        ]);
+        assert!(r.is_ok());
+        assert!(scripts.exists(), "script dir should be created");
+    }
+
+    #[test]
+    fn mode_diff_only_ok() {
+        let (_d, cfg, sd) = setup();
+        let r = run_apply(&["-f", &s(&cfg), "--state-dir", &s(&sd), "--diff-only"]);
+        assert!(r.is_ok());
+    }
+
+    #[test]
+    fn mode_diff_only_json_ok() {
+        let (_d, cfg, sd) = setup();
+        let r = run_apply(&[
+            "-f",
+            &s(&cfg),
+            "--state-dir",
+            &s(&sd),
+            "--diff-only",
+            "--json",
+        ]);
+        assert!(r.is_ok());
+    }
+
+    #[test]
+    fn mode_check_after_apply_ok() {
+        let (_d, cfg, sd) = setup();
+        let applied = run_apply(&["-f", &s(&cfg), "--state-dir", &s(&sd), "--yes"]);
+        assert!(applied.is_ok(), "full apply should converge: {applied:?}");
+        let r = run_apply(&["-f", &s(&cfg), "--state-dir", &s(&sd), "--check"]);
+        assert!(r.is_ok(), "check after converge should pass: {r:?}");
+    }
+
+    #[test]
+    fn mode_check_json_ok() {
+        let (_d, cfg, sd) = setup();
+        // Check scripts are observational (exit 0) — JSON output branch.
+        let r = run_apply(&["-f", &s(&cfg), "--state-dir", &s(&sd), "--check", "--json"]);
+        assert!(r.is_ok());
+    }
+
+    #[test]
+    fn mode_check_invalid_config_err() {
+        let (d, _cfg, sd) = setup();
+        let bad = d.path().join("bad.yaml");
+        std::fs::write(&bad, "not: valid: yaml: [[[").unwrap();
+        let r = run_apply(&["-f", &s(&bad), "--state-dir", &s(&sd), "--check"]);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn mode_refresh_only_empty_state_ok() {
+        let (_d, cfg, sd) = setup();
+        let r = run_apply(&["-f", &s(&cfg), "--state-dir", &s(&sd), "--refresh-only"]);
+        assert!(r.is_ok());
+    }
+
+    #[test]
+    fn mode_plan_file_roundtrip_ok() {
+        let (d, cfg, sd) = setup();
+        // Build the plan exactly as cmd_apply_from_plan reconstructs the config.
+        let mut config = parse_and_validate(&cfg).unwrap();
+        inject_workspace_param(&mut config, Some("pfws"));
+        resolver::resolve_data_sources(&mut config).unwrap();
+        let order = resolver::build_execution_order(&config).unwrap();
+        let locks = load_machine_locks(&config, &sd, None).unwrap();
+        let plan = planner::plan(&config, &order, &locks, None);
+        let plan_path = d.path().join("plan.json");
+        save_plan_file(&plan, &config, &cfg, &plan_path).unwrap();
+
+        let r = run_apply(&[
+            "-f",
+            &s(&cfg),
+            "--state-dir",
+            &s(&sd),
+            "--workspace",
+            "pfws",
+            "--plan-file",
+            &s(&plan_path),
+        ]);
+        assert!(r.is_ok(), "plan-file apply should succeed: {r:?}");
+    }
+
+    // ── apply_early_exits branches ──
+
+    #[test]
+    fn early_dry_run_verbose_ok() {
+        let (_d, cfg, sd) = setup();
+        let r = run_apply(&["-f", &s(&cfg), "--state-dir", &s(&sd), "--dry-run-verbose"]);
+        assert!(r.is_ok());
+    }
+
+    #[test]
+    fn early_dry_run_graph_ok() {
+        let (_d, cfg, sd) = setup();
+        let r = run_apply(&["-f", &s(&cfg), "--state-dir", &s(&sd), "--dry-run-graph"]);
+        assert!(r.is_ok());
+    }
+
+    #[test]
+    fn early_dry_run_cost_ok() {
+        let (_d, cfg, sd) = setup();
+        let r = run_apply(&["-f", &s(&cfg), "--state-dir", &s(&sd), "--dry-run-cost"]);
+        assert!(r.is_ok());
+    }
+
+    #[test]
+    fn early_canary_machine_single_ok() {
+        let (_d, cfg, sd) = setup();
+        // Single machine → canary converges, "No remaining machines" path.
+        let r = run_apply(&[
+            "-f",
+            &s(&cfg),
+            "--state-dir",
+            &s(&sd),
+            "--canary-machine",
+            "m",
+        ]);
+        assert!(r.is_ok(), "canary on single machine should pass: {r:?}");
+    }
+
+    // ── apply_pre_checks branches ──
+
+    #[test]
+    fn pre_confirmation_and_preflight_ok() {
+        let (_d, cfg, sd) = setup();
+        let r = run_apply(&[
+            "-f",
+            &s(&cfg),
+            "--state-dir",
+            &s(&sd),
+            "--confirmation-message",
+            "really?",
+            "--pre-flight",
+            "true",
+            "--preview",
+        ]);
+        assert!(r.is_ok());
+    }
+
+    #[test]
+    fn pre_preflight_failure_err() {
+        let (_d, cfg, sd) = setup();
+        let r = run_apply(&[
+            "-f",
+            &s(&cfg),
+            "--state-dir",
+            &s(&sd),
+            "--pre-flight",
+            "false",
+            "--preview",
+        ]);
+        assert!(r.is_err());
+        assert!(r.unwrap_err().contains("Pre-flight"));
+    }
+
+    #[test]
+    fn pre_script_failure_err() {
+        let (d, cfg, sd) = setup();
+        let script = d.path().join("pre.sh");
+        std::fs::write(&script, "#!/bin/bash\nexit 1\n").unwrap();
+        let r = run_apply(&[
+            "-f",
+            &s(&cfg),
+            "--state-dir",
+            &s(&sd),
+            "--pre-script",
+            &s(&script),
+            "--preview",
+        ]);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn pre_webhook_before_best_effort_ok() {
+        let (_d, cfg, sd) = setup();
+        // Unreachable webhook is best-effort — apply continues into preview.
+        let r = run_apply(&[
+            "-f",
+            &s(&cfg),
+            "--state-dir",
+            &s(&sd),
+            "--webhook-before",
+            "http://127.0.0.1:9/forjar",
+            "--preview",
+        ]);
+        assert!(r.is_ok());
+    }
+
+    #[test]
+    fn pre_abort_on_drift_clean_state_ok() {
+        let (_d, cfg, sd) = setup();
+        let applied = run_apply(&["-f", &s(&cfg), "--state-dir", &s(&sd), "--yes"]);
+        assert!(applied.is_ok());
+        // No drift after converge → proceeds into preview mode.
+        let r = run_apply(&[
+            "-f",
+            &s(&cfg),
+            "--state-dir",
+            &s(&sd),
+            "--abort-on-drift",
+            "--preview",
+        ]);
+        assert!(r.is_ok(), "clean state should not abort: {r:?}");
+    }
+
+    // ── apply_backups + apply_execute ──
+
+    #[test]
+    fn backup_and_snapshot_before_apply_ok() {
+        let (_d, cfg, sd) = setup();
+        let r = run_apply(&[
+            "-f",
+            &s(&cfg),
+            "--state-dir",
+            &s(&sd),
+            "--yes",
+            "--backup",
+            "--snapshot-before",
+            "pre1",
+        ]);
+        assert!(r.is_ok(), "apply with backups should succeed: {r:?}");
+    }
+
+    #[test]
+    fn dry_run_apply_ok() {
+        let (_d, cfg, sd) = setup();
+        let r = run_apply(&["-f", &s(&cfg), "--state-dir", &s(&sd), "--dry-run", "--yes"]);
+        assert!(r.is_ok());
+    }
+}

--- a/src/cli/tests_cov_apply_variants2.rs
+++ b/src/cli/tests_cov_apply_variants2.rs
@@ -1,0 +1,241 @@
+//! Tests: Coverage for cmd_refresh_only and cmd_apply_from_plan in
+//! apply_variants.rs — main paths and error branches (PMAT-088).
+
+use super::apply_variants::*;
+use super::helpers::parse_and_validate;
+use super::helpers_state::load_machine_locks;
+use super::plan::save_plan_file;
+use super::workspace::inject_workspace_param;
+use crate::core::{executor, planner, resolver, types};
+use std::path::{Path, PathBuf};
+
+/// Write a localhost config with one file resource targeting `target`.
+fn write_cfg(dir: &Path, target: &Path, content: &str) -> PathBuf {
+    let yaml = format!(
+        "version: \"1.0\"\nname: variants\nmachines:\n  m:\n    hostname: m\n    addr: 127.0.0.1\nresources:\n  a:\n    type: file\n    machine: m\n    path: {}\n    content: {}\n",
+        target.display(),
+        content
+    );
+    let p = dir.join("forjar.yaml");
+    std::fs::write(&p, yaml).unwrap();
+    p
+}
+
+/// Converge a config against a state dir via the core executor.
+fn apply_local(config: &types::ForjarConfig, sd: &Path) -> Vec<types::ApplyResult> {
+    let cfg = executor::ApplyConfig {
+        config,
+        state_dir: sd,
+        force: false,
+        dry_run: false,
+        machine_filter: None,
+        resource_filter: None,
+        tag_filter: None,
+        group_filter: None,
+        timeout_secs: None,
+        force_unlock: false,
+        progress: false,
+        retry: 0,
+        parallel: None,
+        resource_timeout: None,
+        rollback_on_failure: false,
+        max_parallel: None,
+        trace: false,
+        run_id: None,
+        refresh: false,
+        force_tag: None,
+    };
+    executor::apply(&cfg).expect("apply")
+}
+
+fn converged_setup() -> (tempfile::TempDir, PathBuf, PathBuf, PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("out.txt");
+    let cfg = write_cfg(dir.path(), &target, "hello");
+    let sd = dir.path().join("state");
+    std::fs::create_dir_all(&sd).unwrap();
+    let config = parse_and_validate(&cfg).unwrap();
+    let results = apply_local(&config, &sd);
+    assert_eq!(results[0].resources_converged, 1);
+    (dir, cfg, sd, target)
+}
+
+/// Mirror cmd_apply_from_plan's config mutation, then save a plan file.
+fn save_plan_for(cfg: &Path, sd: &Path, ws: Option<&str>, out: &Path) {
+    let mut config = parse_and_validate(cfg).unwrap();
+    inject_workspace_param(&mut config, ws);
+    resolver::resolve_data_sources(&mut config).unwrap();
+    let order = resolver::build_execution_order(&config).unwrap();
+    let locks = load_machine_locks(&config, sd, None).unwrap();
+    let plan = planner::plan(&config, &order, &locks, None);
+    save_plan_file(&plan, &config, cfg, out).unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── cmd_refresh_only ──
+
+    #[test]
+    fn refresh_invalid_config_err() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("bad.yaml");
+        std::fs::write(&p, "not: valid: yaml: [[[").unwrap();
+        let r = cmd_refresh_only(&p, dir.path(), None, false, None, None, None);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn refresh_empty_state_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("o.txt");
+        let cfg = write_cfg(dir.path(), &target, "x");
+        let sd = dir.path().join("state");
+        std::fs::create_dir_all(&sd).unwrap();
+        let r = cmd_refresh_only(&cfg, &sd, None, false, None, None, None);
+        assert!(r.is_ok());
+    }
+
+    #[test]
+    fn refresh_after_converge_ok() {
+        let (_d, cfg, sd, _t) = converged_setup();
+        let r = cmd_refresh_only(&cfg, &sd, None, false, None, None, None);
+        assert!(r.is_ok(), "refresh on converged state: {r:?}");
+        // Second refresh: live_hash now stored, stable hash → no drift path.
+        let r2 = cmd_refresh_only(&cfg, &sd, None, true, None, None, None);
+        assert!(r2.is_ok());
+    }
+
+    #[test]
+    fn refresh_detects_drift_verbose() {
+        let (_d, cfg, sd, target) = converged_setup();
+        // Seed live_hash, then mutate the target file out-of-band.
+        cmd_refresh_only(&cfg, &sd, None, false, None, None, None).unwrap();
+        std::fs::write(&target, "tampered").unwrap();
+        let r = cmd_refresh_only(&cfg, &sd, None, true, None, None, None);
+        assert!(r.is_ok(), "drift is reported, not an error: {r:?}");
+    }
+
+    #[test]
+    fn refresh_machine_filter_no_match_ok() {
+        let (_d, cfg, sd, _t) = converged_setup();
+        let r = cmd_refresh_only(&cfg, &sd, Some("ghost"), false, None, None, None);
+        assert!(r.is_ok());
+    }
+
+    #[test]
+    fn refresh_with_workspace_param_ok() {
+        let (_d, cfg, sd, _t) = converged_setup();
+        let r = cmd_refresh_only(&cfg, &sd, Some("m"), true, Some(30), None, Some("ws1"));
+        assert!(r.is_ok());
+    }
+
+    #[test]
+    fn refresh_missing_env_file_err() {
+        let (_d, cfg, sd, _t) = converged_setup();
+        let r = cmd_refresh_only(
+            &cfg,
+            &sd,
+            None,
+            false,
+            None,
+            Some(Path::new("/nonexistent/params.env")),
+            None,
+        );
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn refresh_skips_non_converged_resources() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = write_cfg(dir.path(), Path::new("/dev/null/forjar-cov/x"), "y");
+        let sd = dir.path().join("state");
+        std::fs::create_dir_all(&sd).unwrap();
+        let config = parse_and_validate(&cfg).unwrap();
+        let _ = apply_local(&config, &sd); // resource fails → status Failed in lock
+        let r = cmd_refresh_only(&cfg, &sd, None, true, None, None, None);
+        assert!(r.is_ok(), "failed resources are skipped: {r:?}");
+    }
+
+    // ── cmd_apply_from_plan ──
+
+    #[test]
+    fn from_plan_happy_path_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("planned.txt");
+        let cfg = write_cfg(dir.path(), &target, "v1");
+        let sd = dir.path().join("state");
+        std::fs::create_dir_all(&sd).unwrap();
+        let plan_path = dir.path().join("plan.json");
+        save_plan_for(&cfg, &sd, Some("pfws"), &plan_path);
+
+        let r = cmd_apply_from_plan(&cfg, &sd, &plan_path, true, None, Some("pfws"));
+        assert!(r.is_ok(), "saved plan should apply cleanly: {r:?}");
+        assert!(target.exists(), "planned file resource should be created");
+    }
+
+    #[test]
+    fn from_plan_zero_changes_ok() {
+        let (d, cfg, sd, _t) = converged_setup();
+        // Plan built AFTER converge has no pending changes.
+        let plan_path = d.path().join("plan.json");
+        save_plan_for(&cfg, &sd, Some("pfws"), &plan_path);
+        let r = cmd_apply_from_plan(&cfg, &sd, &plan_path, false, None, Some("pfws"));
+        assert!(r.is_ok(), "no-change plan exits early: {r:?}");
+    }
+
+    #[test]
+    fn from_plan_missing_file_err() {
+        let (d, cfg, sd, _t) = converged_setup();
+        let r = cmd_apply_from_plan(
+            &cfg,
+            &sd,
+            &d.path().join("nope.json"),
+            false,
+            None,
+            Some("pfws"),
+        );
+        assert!(r.is_err());
+        assert!(r.unwrap_err().contains("read plan file"));
+    }
+
+    #[test]
+    fn from_plan_bad_format_err() {
+        let (d, cfg, sd, _t) = converged_setup();
+        let plan_path = d.path().join("plan.json");
+        std::fs::write(&plan_path, r#"{"format": "bogus-v9"}"#).unwrap();
+        let r = cmd_apply_from_plan(&cfg, &sd, &plan_path, false, None, Some("pfws"));
+        assert!(r.is_err());
+        assert!(r.unwrap_err().contains("unsupported plan format"));
+    }
+
+    #[test]
+    fn from_plan_config_changed_err() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("c.txt");
+        let cfg = write_cfg(dir.path(), &target, "v1");
+        let sd = dir.path().join("state");
+        std::fs::create_dir_all(&sd).unwrap();
+        let plan_path = dir.path().join("plan.json");
+        save_plan_for(&cfg, &sd, Some("pfws"), &plan_path);
+        // Mutate the config after the plan was saved → hash mismatch.
+        write_cfg(dir.path(), &target, "v2-changed");
+        let r = cmd_apply_from_plan(&cfg, &sd, &plan_path, false, None, Some("pfws"));
+        assert!(r.is_err());
+        assert!(r.unwrap_err().contains("config has changed"));
+    }
+
+    #[test]
+    fn from_plan_failing_resource_err() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = write_cfg(dir.path(), Path::new("/dev/null/forjar-cov/p.txt"), "y");
+        let sd = dir.path().join("state");
+        std::fs::create_dir_all(&sd).unwrap();
+        let plan_path = dir.path().join("plan.json");
+        save_plan_for(&cfg, &sd, Some("pfws"), &plan_path);
+        let r = cmd_apply_from_plan(&cfg, &sd, &plan_path, false, None, Some("pfws"));
+        assert!(r.is_err());
+        assert!(r.unwrap_err().contains("failed"));
+    }
+}

--- a/src/cli/tests_cov_check_blocks.rs
+++ b/src/cli/tests_cov_check_blocks.rs
@@ -1,0 +1,69 @@
+//! Tests: Coverage for run_check_blocks in apply_output.rs — pass, fail,
+//! custom exit codes, unknown machine, and transport errors (PMAT-088).
+
+use super::apply_output::run_check_blocks;
+use crate::core::types;
+
+fn config_with_checks(checks_yaml: &str) -> types::ForjarConfig {
+    let yaml = format!(
+        "version: \"1.0\"\nname: checks\nmachines:\n  m:\n    hostname: m\n    addr: 127.0.0.1\nresources: {{}}\nchecks:\n{checks_yaml}"
+    );
+    serde_yaml_ng::from_str(&yaml).expect("valid checks config")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn checks_all_pass_quiet() {
+        let config = config_with_checks("  ok:\n    machine: m\n    command: \"true\"\n");
+        run_check_blocks(&config, false);
+    }
+
+    #[test]
+    fn checks_all_pass_verbose_with_description() {
+        let config = config_with_checks(
+            "  ok:\n    machine: m\n    command: \"true\"\n    description: health endpoint up\n",
+        );
+        run_check_blocks(&config, true);
+    }
+
+    #[test]
+    fn checks_failure_exit_mismatch() {
+        // `false` exits 1 but 0 is expected → FAIL branch + summary warning.
+        let config = config_with_checks("  bad:\n    machine: m\n    command: \"false\"\n");
+        run_check_blocks(&config, false);
+    }
+
+    #[test]
+    fn checks_custom_expect_exit_passes() {
+        // `false` exits 1 and 1 is expected → PASS with non-default exit.
+        let config = config_with_checks(
+            "  inverse:\n    machine: m\n    command: \"false\"\n    expect_exit: 1\n",
+        );
+        run_check_blocks(&config, true);
+    }
+
+    #[test]
+    fn checks_unknown_machine_warns() {
+        let config = config_with_checks("  ghost:\n    machine: nope\n    command: \"true\"\n");
+        run_check_blocks(&config, false);
+    }
+
+    #[test]
+    fn checks_transport_error_branch() {
+        // `rm -rf /` is rejected by I8 bashrs validation before execution,
+        // so exec_script returns Err → transport-error FAIL branch.
+        let config = config_with_checks("  danger:\n    machine: m\n    command: \"rm -rf /\"\n");
+        run_check_blocks(&config, false);
+    }
+
+    #[test]
+    fn checks_mixed_pass_and_fail_verbose() {
+        let config = config_with_checks(
+            "  ok:\n    machine: m\n    command: \"true\"\n  bad:\n    machine: m\n    command: \"false\"\n    description: should warn\n",
+        );
+        run_check_blocks(&config, true);
+    }
+}

--- a/src/cli/tests_cov_fleet_run.rs
+++ b/src/cli/tests_cov_fleet_run.rs
@@ -1,0 +1,171 @@
+//! Tests: Coverage for cmd_rolling / cmd_canary / cmd_apply_canary_machine
+//! happy paths via localhost transport (PMAT-088).
+
+use super::apply_variants::cmd_apply_canary_machine;
+use super::fleet_ops::{cmd_canary, cmd_rolling};
+use std::path::{Path, PathBuf};
+
+/// Two localhost machines, one file resource each (paths inside `dir`).
+fn write_two_machine_cfg(dir: &Path) -> PathBuf {
+    let yaml = format!(
+        "version: \"1.0\"\nname: fleet\nmachines:\n  m1:\n    hostname: m1\n    addr: 127.0.0.1\n  m2:\n    hostname: m2\n    addr: 127.0.0.1\nresources:\n  a:\n    type: file\n    machine: m1\n    path: {a}\n    content: aa\n  b:\n    type: file\n    machine: m2\n    path: {b}\n    content: bb\n",
+        a = dir.join("a.txt").display(),
+        b = dir.join("b.txt").display()
+    );
+    let p = dir.join("forjar.yaml");
+    std::fs::write(&p, yaml).unwrap();
+    p
+}
+
+/// Single localhost machine with one file resource.
+fn write_one_machine_cfg(dir: &Path) -> PathBuf {
+    let yaml = format!(
+        "version: \"1.0\"\nname: solo\nmachines:\n  m1:\n    hostname: m1\n    addr: 127.0.0.1\nresources:\n  a:\n    type: file\n    machine: m1\n    path: {a}\n    content: aa\n",
+        a = dir.join("solo.txt").display()
+    );
+    let p = dir.join("forjar.yaml");
+    std::fs::write(&p, yaml).unwrap();
+    p
+}
+
+/// Canary machine resource fails (unwritable path); m2 resource is fine.
+fn write_failing_canary_cfg(dir: &Path) -> PathBuf {
+    let yaml = format!(
+        "version: \"1.0\"\nname: failfleet\nmachines:\n  m1:\n    hostname: m1\n    addr: 127.0.0.1\n  m2:\n    hostname: m2\n    addr: 127.0.0.1\nresources:\n  a:\n    type: file\n    machine: m1\n    path: /dev/null/forjar-cov/a.txt\n    content: aa\n  b:\n    type: file\n    machine: m2\n    path: {b}\n    content: bb\n",
+        b = dir.join("b.txt").display()
+    );
+    let p = dir.join("forjar.yaml");
+    std::fs::write(&p, yaml).unwrap();
+    p
+}
+
+fn state_dir(dir: &Path) -> PathBuf {
+    let sd = dir.join("state");
+    std::fs::create_dir_all(&sd).unwrap();
+    sd
+}
+
+/// Run a fleet op on a 16 MiB stack — cmd_apply's frames exceed the default
+/// test-thread stack (same pattern as tests_cov_dispatch_5).
+fn on_big_stack<F>(f: F) -> Result<(), String>
+where
+    F: FnOnce() -> Result<(), String> + Send + 'static,
+{
+    std::thread::Builder::new()
+        .stack_size(16 * 1024 * 1024)
+        .spawn(f)
+        .expect("spawn fleet thread")
+        .join()
+        .expect("join fleet thread")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── cmd_rolling happy + failure paths ──
+
+    #[test]
+    fn rolling_two_machines_batch_one_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = write_two_machine_cfg(dir.path());
+        let sd = state_dir(dir.path());
+        let r = on_big_stack(move || cmd_rolling(&cfg, &sd, 1, &[], None));
+        assert!(r.is_ok(), "rolling deploy should converge: {r:?}");
+        assert!(dir.path().join("a.txt").exists());
+        assert!(dir.path().join("b.txt").exists());
+    }
+
+    #[test]
+    fn rolling_single_batch_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = write_two_machine_cfg(dir.path());
+        let sd = state_dir(dir.path());
+        // Batch larger than fleet → one batch covering all machines.
+        let r = on_big_stack(move || cmd_rolling(&cfg, &sd, 10, &[], Some(60)));
+        assert!(r.is_ok(), "single-batch rolling: {r:?}");
+    }
+
+    #[test]
+    fn rolling_failing_resource_err() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = write_failing_canary_cfg(dir.path());
+        let sd = state_dir(dir.path());
+        let r = on_big_stack(move || cmd_rolling(&cfg, &sd, 1, &[], None));
+        assert!(r.is_err(), "rolling must stop on machine failure");
+    }
+
+    // ── cmd_canary happy + failure paths ──
+
+    #[test]
+    fn canary_single_machine_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = write_one_machine_cfg(dir.path());
+        let sd = state_dir(dir.path());
+        // No remaining machines → early "canary deploy complete" path.
+        let r = on_big_stack(move || cmd_canary(&cfg, &sd, "m1", false, &[], None));
+        assert!(r.is_ok(), "single-machine canary: {r:?}");
+        assert!(dir.path().join("solo.txt").exists());
+    }
+
+    #[test]
+    fn canary_two_machines_manual_proceed_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = write_two_machine_cfg(dir.path());
+        let sd = state_dir(dir.path());
+        let r = on_big_stack(move || cmd_canary(&cfg, &sd, "m1", false, &[], None));
+        assert!(r.is_ok(), "canary + fleet phase: {r:?}");
+        assert!(dir.path().join("b.txt").exists(), "fleet phase ran");
+    }
+
+    #[test]
+    fn canary_two_machines_auto_proceed_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = write_two_machine_cfg(dir.path());
+        let sd = state_dir(dir.path());
+        let r = on_big_stack(move || cmd_canary(&cfg, &sd, "m2", true, &[], Some(60)));
+        assert!(r.is_ok(), "auto-proceed canary: {r:?}");
+    }
+
+    #[test]
+    fn canary_failing_canary_phase_err() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = write_failing_canary_cfg(dir.path());
+        let sd = state_dir(dir.path());
+        let r = on_big_stack(move || cmd_canary(&cfg, &sd, "m1", true, &[], None));
+        assert!(r.is_err(), "failed canary must abort the fleet");
+        // Fleet phase never ran — m2's file should not exist.
+        assert!(!dir.path().join("b.txt").exists());
+    }
+
+    // ── cmd_apply_canary_machine happy + failure paths ──
+
+    #[test]
+    fn apply_canary_machine_single_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = write_one_machine_cfg(dir.path());
+        let sd = state_dir(dir.path());
+        let r = on_big_stack(move || cmd_apply_canary_machine(&cfg, &sd, "m1", &[], None));
+        assert!(r.is_ok(), "single-machine canary apply: {r:?}");
+    }
+
+    #[test]
+    fn apply_canary_machine_two_machines_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = write_two_machine_cfg(dir.path());
+        let sd = state_dir(dir.path());
+        let r = on_big_stack(move || cmd_apply_canary_machine(&cfg, &sd, "m1", &[], Some(60)));
+        assert!(r.is_ok(), "canary + fleet apply: {r:?}");
+        assert!(dir.path().join("a.txt").exists());
+        assert!(dir.path().join("b.txt").exists());
+    }
+
+    #[test]
+    fn apply_canary_machine_failing_err() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = write_failing_canary_cfg(dir.path());
+        let sd = state_dir(dir.path());
+        let r = on_big_stack(move || cmd_apply_canary_machine(&cfg, &sd, "m1", &[], None));
+        assert!(r.is_err(), "failed canary apply must return Err");
+    }
+}

--- a/src/cli/tests_cov_infra_dispatch2.rs
+++ b/src/cli/tests_cov_infra_dispatch2.rs
@@ -1,0 +1,202 @@
+//! Tests: Coverage for dispatch_infra_cmd in dispatch_misc_b.rs, driven
+//! through dispatch_data_cmd's fall-through arm (PMAT-088).
+
+use super::commands::*;
+use super::dispatch_misc_b::dispatch_data_cmd;
+use std::path::{Path, PathBuf};
+
+/// Single localhost machine + one file resource under /etc (privileged path
+/// so fault-inject emits a permission-denied scenario).
+fn write_cfg(dir: &Path) -> PathBuf {
+    let yaml = "version: \"1.0\"\nname: infra\nmachines:\n  m:\n    hostname: m\n    addr: 127.0.0.1\nresources:\n  a:\n    type: file\n    machine: m\n    path: /etc/forjar-cov.conf\n    content: x\n";
+    let p = dir.join("forjar.yaml");
+    std::fs::write(&p, yaml).unwrap();
+    p
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn infra_fault_inject_text_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = write_cfg(dir.path());
+        let r = dispatch_data_cmd(Commands::FaultInject(FaultInjectArgs {
+            file,
+            resource: None,
+            json: false,
+        }));
+        assert!(r.is_ok(), "fault inject report: {r:?}");
+    }
+
+    #[test]
+    fn infra_fault_inject_json_filtered_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = write_cfg(dir.path());
+        let r = dispatch_data_cmd(Commands::FaultInject(FaultInjectArgs {
+            file,
+            resource: Some("a".to_string()),
+            json: true,
+        }));
+        assert!(r.is_ok());
+    }
+
+    #[test]
+    fn infra_fault_inject_bad_config_err() {
+        let r = dispatch_data_cmd(Commands::FaultInject(FaultInjectArgs {
+            file: PathBuf::from("/nonexistent/forjar.yaml"),
+            resource: None,
+            json: false,
+        }));
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn infra_invariants_text_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = write_cfg(dir.path());
+        let r = dispatch_data_cmd(Commands::Invariants(InvariantsArgs {
+            file,
+            state_dir: dir.path().join("state"),
+            json: false,
+        }));
+        assert!(r.is_ok(), "invariants: {r:?}");
+    }
+
+    #[test]
+    fn infra_invariants_json_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = write_cfg(dir.path());
+        let r = dispatch_data_cmd(Commands::Invariants(InvariantsArgs {
+            file,
+            state_dir: dir.path().join("state"),
+            json: true,
+        }));
+        assert!(r.is_ok());
+    }
+
+    #[test]
+    fn infra_iso_export_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = write_cfg(dir.path());
+        let out = dir.path().join("iso");
+        let r = dispatch_data_cmd(Commands::IsoExport(IsoExportArgs {
+            file,
+            state_dir: dir.path().join("state"),
+            output: out.clone(),
+            include_binary: false,
+            json: false,
+        }));
+        assert!(r.is_ok(), "iso export: {r:?}");
+        assert!(out.join("config").join("forjar.yaml").exists());
+    }
+
+    #[test]
+    fn infra_iso_export_json_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = write_cfg(dir.path());
+        let r = dispatch_data_cmd(Commands::IsoExport(IsoExportArgs {
+            file,
+            state_dir: dir.path().join("state"),
+            output: dir.path().join("iso2"),
+            include_binary: false,
+            json: true,
+        }));
+        assert!(r.is_ok());
+    }
+
+    #[test]
+    fn infra_import_brownfield_no_matching_types_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let out = dir.path().join("imported.yaml");
+        // "bogus" scan type parses to nothing → no discovery, still writes config.
+        let r = dispatch_data_cmd(Commands::ImportBrownfield(ImportBrownfieldArgs {
+            machine: "localhost".to_string(),
+            scan_types: vec!["bogus".to_string()],
+            output: Some(out.clone()),
+            json: true,
+        }));
+        assert!(r.is_ok(), "brownfield import: {r:?}");
+        assert!(out.exists(), "generated config should be written");
+    }
+
+    #[test]
+    fn infra_cross_deps_text_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = write_cfg(dir.path());
+        let r = dispatch_data_cmd(Commands::CrossDeps(CrossDepsArgs { file, json: false }));
+        assert!(r.is_ok(), "cross deps: {r:?}");
+    }
+
+    #[test]
+    fn infra_cross_deps_json_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = write_cfg(dir.path());
+        let r = dispatch_data_cmd(Commands::CrossDeps(CrossDepsArgs { file, json: true }));
+        assert!(r.is_ok());
+    }
+
+    fn image_args(file: PathBuf, dir: &Path) -> ImageArgs {
+        ImageArgs {
+            file,
+            machine: None,
+            user_data: true,
+            android: false,
+            base: None,
+            output: Some(dir.join("user-data.yaml")),
+            disk: "auto-lvm".to_string(),
+            locale: "en_US.UTF-8".to_string(),
+            timezone: "Etc/UTC".to_string(),
+            json: false,
+        }
+    }
+
+    #[test]
+    fn infra_image_user_data_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = write_cfg(dir.path());
+        let args = image_args(file, dir.path());
+        let r = dispatch_data_cmd(Commands::Image(args));
+        assert!(r.is_ok(), "user-data image: {r:?}");
+        assert!(dir.path().join("user-data.yaml").exists());
+    }
+
+    #[test]
+    fn infra_image_android_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = write_cfg(dir.path());
+        let mut args = image_args(file, dir.path());
+        args.user_data = false;
+        args.android = true;
+        args.output = Some(dir.path().join("module.zip"));
+        let r = dispatch_data_cmd(Commands::Image(args));
+        assert!(r.is_ok(), "android magisk module: {r:?}");
+        assert!(dir.path().join("module.zip").exists());
+    }
+
+    #[test]
+    fn infra_image_base_iso_missing_err() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = write_cfg(dir.path());
+        let mut args = image_args(file, dir.path());
+        args.user_data = false;
+        args.base = Some(PathBuf::from("/nonexistent/base.iso"));
+        args.output = Some(dir.path().join("out.iso"));
+        let r = dispatch_data_cmd(Commands::Image(args));
+        assert!(r.is_err(), "missing base ISO must fail");
+    }
+
+    #[test]
+    fn infra_fall_through_to_platform_dispatch() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = write_cfg(dir.path());
+        // Not an infra command → routed to dispatch_platform_cmd.
+        let r = dispatch_data_cmd(Commands::StackGraph(StackGraphArgs {
+            file: vec![file],
+            json: true,
+        }));
+        // Outcome depends on platform handler; the arm itself is what we cover.
+        let _ = r;
+    }
+}

--- a/src/core/executor/mod.rs
+++ b/src/core/executor/mod.rs
@@ -55,6 +55,8 @@ mod tests_rolling;
 mod tests_run_capture;
 #[cfg(test)]
 mod tests_waves;
+#[cfg(test)]
+mod tests_waves_cov;
 
 use super::codegen;
 use super::conditions;

--- a/src/core/executor/tests_waves_cov.rs
+++ b/src/core/executor/tests_waves_cov.rs
@@ -1,0 +1,180 @@
+//! PMAT-088: Coverage for record_wave_outcomes — success, unchanged, update,
+//! exit-code failure, and transport-error branches via parallel waves.
+
+use super::*;
+use std::path::Path;
+
+/// ApplyConfig forcing the parallel wave execution path.
+fn parallel_apply_cfg<'a>(config: &'a ForjarConfig, state_dir: &'a Path) -> ApplyConfig<'a> {
+    ApplyConfig {
+        config,
+        state_dir,
+        force: false,
+        dry_run: false,
+        machine_filter: None,
+        resource_filter: None,
+        tag_filter: None,
+        group_filter: None,
+        timeout_secs: None,
+        force_unlock: false,
+        progress: false,
+        retry: 0,
+        parallel: Some(true),
+        resource_timeout: None,
+        rollback_on_failure: false,
+        max_parallel: None,
+        trace: false,
+        run_id: None,
+        refresh: false,
+        force_tag: None,
+    }
+}
+
+/// Localhost config with three independent file resources inside `dir`.
+fn three_file_yaml(dir: &Path, content: &str) -> String {
+    format!(
+        r#"
+version: "1.0"
+name: waves-cov
+machines:
+  local:
+    hostname: localhost
+    addr: 127.0.0.1
+resources:
+  r1:
+    type: file
+    machine: local
+    path: {d}/r1.txt
+    content: "{content}-1"
+  r2:
+    type: file
+    machine: local
+    path: {d}/r2.txt
+    content: "{content}-2"
+  r3:
+    type: file
+    machine: local
+    path: {d}/r3.txt
+    content: "{content}-3"
+"#,
+        d = dir.display()
+    )
+}
+
+#[test]
+fn wave_outcomes_parallel_converge_then_unchanged() {
+    let dir = tempfile::tempdir().unwrap();
+    let state_dir = dir.path().join("state");
+    std::fs::create_dir_all(&state_dir).unwrap();
+
+    let config: ForjarConfig = serde_yaml_ng::from_str(&three_file_yaml(dir.path(), "v1")).unwrap();
+    let cfg = parallel_apply_cfg(&config, &state_dir);
+
+    // Wave 0 of three resources → record_success branch ("create" span).
+    let r1 = apply(&cfg).unwrap();
+    assert_eq!(r1[0].resources_converged, 3);
+    assert_eq!(r1[0].resources_failed, 0);
+
+    // Re-apply: all unchanged → skipped_or_unchanged recording branch.
+    let r2 = apply(&cfg).unwrap();
+    assert_eq!(r2[0].resources_converged, 0);
+    assert_eq!(r2[0].resources_unchanged, 3);
+}
+
+#[test]
+fn wave_outcomes_parallel_update_action() {
+    let dir = tempfile::tempdir().unwrap();
+    let state_dir = dir.path().join("state");
+    std::fs::create_dir_all(&state_dir).unwrap();
+
+    let config1: ForjarConfig =
+        serde_yaml_ng::from_str(&three_file_yaml(dir.path(), "v1")).unwrap();
+    let cfg1 = parallel_apply_cfg(&config1, &state_dir);
+    assert_eq!(apply(&cfg1).unwrap()[0].resources_converged, 3);
+
+    // Changed content → Update action label branch in record_wave_outcomes.
+    let config2: ForjarConfig =
+        serde_yaml_ng::from_str(&three_file_yaml(dir.path(), "v2")).unwrap();
+    let cfg2 = parallel_apply_cfg(&config2, &state_dir);
+    let r = apply(&cfg2).unwrap();
+    assert_eq!(r[0].resources_converged, 3, "all updated in parallel");
+}
+
+#[test]
+fn wave_outcomes_parallel_mixed_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    let state_dir = dir.path().join("state");
+    std::fs::create_dir_all(&state_dir).unwrap();
+
+    let yaml = format!(
+        r#"
+version: "1.0"
+name: waves-fail
+machines:
+  local:
+    hostname: localhost
+    addr: 127.0.0.1
+resources:
+  good:
+    type: file
+    machine: local
+    path: {d}/good.txt
+    content: "fine"
+  bad:
+    type: file
+    machine: local
+    path: /dev/null/forjar-waves/bad.txt
+    content: "doomed"
+"#,
+        d = dir.path().display()
+    );
+    let config: ForjarConfig = serde_yaml_ng::from_str(&yaml).unwrap();
+    let cfg = parallel_apply_cfg(&config, &state_dir);
+
+    let r = apply(&cfg).unwrap();
+    // Exit-code failure branch: Ok(out) with non-zero exit recorded as failed.
+    assert_eq!(r[0].resources_converged, 1, "good file still converges");
+    assert_eq!(r[0].resources_failed, 1, "unwritable path fails");
+    assert!(dir.path().join("good.txt").exists());
+}
+
+#[test]
+fn wave_outcomes_parallel_pre_hook_error_branch() {
+    let dir = tempfile::tempdir().unwrap();
+    let state_dir = dir.path().join("state");
+    std::fs::create_dir_all(&state_dir).unwrap();
+
+    let yaml = format!(
+        r#"
+version: "1.0"
+name: waves-hook
+machines:
+  local:
+    hostname: localhost
+    addr: 127.0.0.1
+resources:
+  h1:
+    type: file
+    machine: local
+    path: {d}/h1.txt
+    content: "x"
+    pre_apply: "false"
+  h2:
+    type: file
+    machine: local
+    path: {d}/h2.txt
+    content: "y"
+    pre_apply: "false"
+"#,
+        d = dir.path().display()
+    );
+    let config: ForjarConfig = serde_yaml_ng::from_str(&yaml).unwrap();
+    let cfg = parallel_apply_cfg(&config, &state_dir);
+
+    let r = apply(&cfg).unwrap();
+    // Failing pre_apply hooks surface as Err(_) exec results →
+    // "transport error" recording branch for every wave member.
+    assert_eq!(r[0].resources_failed, 2, "both hooks fail the resources");
+    assert_eq!(r[0].resources_converged, 0);
+    assert!(!dir.path().join("h1.txt").exists(), "apply never ran");
+}


### PR DESCRIPTION
## Summary

Closes the worst CLI coverage gaps identified in the 2026-06-12 pmat coverage analysis (lib line coverage 96.27%, function coverage 92.37%). All targets previously had only error-path tests or no test references at all; this PR adds 69 focused tests covering main paths **and** error branches.

## Per-target coverage work

| Target | File | Before | Tests added | Branches now covered |
|---|---|---|---|---|
| `apply_mode_exits` (+ `apply_early_exits`, `apply_pre_checks`, `apply_backups`) | `src/cli/dispatch_apply_b.rs` | 23% | 20 | preview, output-scripts, diff-only(+json), check(+json/err), refresh-only, plan-file, dry-run-{verbose,graph,cost}, canary-machine, confirmation, pre-flight ok/fail, pre-script fail, webhook-before, abort-on-drift, backup/snapshot, dry-run apply |
| `cmd_canary` / `cmd_rolling` | `src/cli/fleet_ops.rs` | ~24% | 10 | rolling batch=1/batch>fleet/failure-stop; canary single-machine, manual+auto proceed fleet phase, canary-phase failure aborts fleet |
| `dispatch_infra_cmd` | `src/cli/dispatch_misc_b.rs` | 6% | 14 | FaultInject (text/json/filter/err), Invariants (text/json), IsoExport (+json), ImportBrownfield, CrossDeps (text/json), Image user-data/android/base-iso-err, platform fall-through |
| `cmd_refresh_only` / `cmd_apply_canary_machine` / `cmd_apply_from_plan` | `src/cli/apply_variants.rs` | 0–25% | 14 + 3 | refresh: converge→refresh, drift detect, machine filter, workspace, env-file err, non-converged skip; from-plan: happy path, zero changes, missing/bad-format/config-changed/failing-resource errors; canary-machine: single, two-machine fleet, failing canary |
| `run_check_blocks` | `src/cli/apply_output.rs` | low | 7 | pass quiet/verbose, exit mismatch FAIL, custom `expect_exit`, unknown machine, I8 transport error, mixed pass+fail |
| `record_wave_outcomes` | `src/core/executor/machine_wave.rs` | low | 4 | parallel-wave converge (create span), unchanged recording, update action label, exit-code failure, pre-hook `Err(_)` transport-error branch |

## Notes

- Follows the existing `tests_cov_*` in-module lib-test pattern (tempdir configs + localhost transport, exit-code/output/state-file assertions); new files registered in `mod_test_decl_c.rs` and `executor/mod.rs`.
- One-line visibility change: `run_check_blocks` → `pub(super)` for sibling-module testing (same convention as `dispatch_apply.rs` helpers).
- Heavy `cmd_apply` paths run on 16 MiB stacks via `std::thread::Builder`, following the existing `tests_cov_dispatch_5.rs` precedent (default test-thread stack overflows in the apply pipeline).
- All new files <500 lines; helpers are trivial (complexity ≤10).
- Did not touch `cmd_dist` (covered by #139/#143) or files owned by other agents.

## Validation

- `cargo test --lib` — **12205 passed, 0 failed, 3 ignored**
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `cargo deny check advisories` — ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)