### PR TITLE
chore(release): prep v1.5.0 — dist verification suite complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2026-06-13
+
+### Added
+
+- **`forjar dist --verify` — Tier 1 static installer verification**
+  (#146, FJ-3607/F-3609, Phase D of spec 25): generates artifacts to a
+  temp dir and verifies `sh -n` parse, zero bashrs lint errors
+  (in-process via the existing purifier wrapper), required
+  checksum/arch-detection snippets, and download-URL structure.
+  A deliberately broken asset template fails verification with a
+  non-zero exit (F-3609). Tier 2 container execution is a follow-up.
+- `forjar schema` now emits the `dist:` property block (mirrors
+  DistConfig/targets/homebrew/nix, with a keep-in-sync pin test) —
+  the spec claimed this existed; now it does (#146).
+- `dist.source` validation: values other than `github_release`
+  (local/url/s3) return a clear "not yet supported" error instead of
+  generating artifacts with broken URLs (#146).
+
+### Fixed
+
+- **Coverage workflow de-flaked** (#147, closes #141): sandbox dirs in
+  `run_convergence_test` were named from a wall-clock nanosecond read;
+  concurrent threads on coarse-tick runners collided, and the first
+  finisher's cleanup deleted the sibling's working dir mid-cycle
+  (reproduced 32/240 trials). Names now include a process-wide atomic
+  sequence — also hardens parallel `forjar check` in production.
+- Release cargo cache keyed by runner image (#145): v1.4.4's
+  x86_64-gnu leg failed linking 24.04-cached objects (glibc 2.38
+  `__isoc23_*` symbols) on the new 22.04 baseline runner.
+
+### Changed
+
+- +69 lib tests closing the worst CLI coverage gaps (apply modes,
+  canary/rolling fleet ops, infra dispatch, apply variants, check
+  blocks, wave outcomes) — suite now 12,205 tests (#148).
+- Spec 25 status reconciled from PROPOSED to per-phase reality
+  (A-C implemented, D Tier 1 implemented, Tier 2 pending) (#146).
+
 ## [1.4.4] - 2026-06-12
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1092,7 +1092,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "forjar"
-version = "1.4.4"
+version = "1.5.0"
 dependencies = [
  "age",
  "aprender-contracts",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forjar"
-version = "1.4.4"
+version = "1.5.0"
 edition.workspace = true
 rust-version = "1.89.0"
 authors = ["Pragmatic AI Labs"]

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -1350,11 +1350,11 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'REL-5: Tag v1.4.4 — working install path release'
-  status: inprogress
+  status: completed
   priority: high
   assigned_to: null
   created: 2026-06-12T12:00:00Z
-  updated: 2026-06-12T22:30:00Z
+  updated: 2026-06-13T00:30:00Z
   spec: null
   acceptance_criteria:
   - v1.4.4 tagged after INST-1/INST-2 merge; release auto-created with binaries + SHA256SUMS + install.sh verified
@@ -1466,11 +1466,11 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'REL-6: Tag v1.5.0 + Friday crates.io publish (2026-06-19)'
-  status: pending
+  status: inprogress
   priority: high
   assigned_to: null
   created: 2026-06-12T12:00:00Z
-  updated: 2026-06-12T12:00:00Z
+  updated: 2026-06-13T00:30:00Z
   spec: null
   acceptance_criteria:
   - v1.5.0 tagged Thursday 2026-06-18 evening after DIST/CONTRACT items merge; GitHub release green
@@ -1523,11 +1523,11 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'COV-1: Close CLI coverage gaps — cmd_dist, fleet_ops canary/rolling, apply_variants, dispatch_infra'
-  status: pending
+  status: completed
   priority: medium
   assigned_to: null
   created: 2026-06-12T12:00:00Z
-  updated: 2026-06-12T12:00:00Z
+  updated: 2026-06-13T00:30:00Z
   spec: null
   acceptance_criteria:
   - Lib tests added per tests_cov_* pattern for cmd_dist (0%), apply_mode_exits (23%), cmd_canary/cmd_rolling (24%), dispatch_infra_cmd (6%)


### PR DESCRIPTION
Release prep for **v1.5.0** (PMAT-085): minor bump for the new `forjar dist` feature suite — `--verify` Tier 1 (FJ-3607/F-3609), `--version`/`--checksums-file` real checksum resolution (F-3608/F-3610, shipped in 1.4.4), `dist.source` validation, and the `dist:` schema block. Plus the Coverage de-flake (#147), cache-key fix (#145), and +69 coverage tests (#148).

After merge: tag v1.5.0 → hosted-runner release. **crates.io publish deferred to Friday 2026-06-19** per the Friday-only rule (scheduled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)