### PR TITLE
fix(dist): unique verify temp dir — PID-only name raced concurrent tests

### DIFF
--- a/src/cli/dist_verify.rs
+++ b/src/cli/dist_verify.rs
@@ -45,7 +45,13 @@ pub(crate) fn run_verify(
     dist: &DistConfig,
     args: &super::commands::DistArgs,
 ) -> Result<(), String> {
-    let tmp = std::env::temp_dir().join(format!("forjar-dist-verify-{}", std::process::id()));
+    // PID alone collides across threads in one process — a concurrent
+    // caller's cleanup would delete this dir mid-verify (same race as
+    // convergence_runner, GH-141/#147). Atomic counter guarantees
+    // in-process uniqueness.
+    static VERIFY_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = VERIFY_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = std::env::temp_dir().join(format!("forjar-dist-verify-{}-{seq}", std::process::id()));
     std::fs::create_dir_all(&tmp).map_err(|e| format!("cannot create {}: {e}", tmp.display()))?;
     let result = verify_in_dir(dist, args, &tmp);
     let _ = std::fs::remove_dir_all(&tmp);


### PR DESCRIPTION
Coverage on main (run at b35b75ec) failed in `cli::dist_verify::tests::run_verify_passes_on_valid_dist`: `sh -n` couldn't open `/tmp/forjar-dist-verify-<pid>/install.sh` — `run_verify` (#146) named its temp dir by **bare PID**, so concurrent tests in one process collided and one's cleanup deleted the other's dir mid-verify.

Identical failure class to GH-141 (#147, convergence sandbox dirs), fixed with the same pattern: a process-wide `AtomicU64` sequence in the dir name.

Evidence: 30× `cargo test --lib dist_verify -- --test-threads=8` → zero failures; clippy/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)