### PR TITLE
ci: bump actions/checkout v4→v6.0.3, upload-artifact v4→v7.0.1

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -15,7 +15,7 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: Install cargo-deny
         run: cargo install --locked cargo-deny

--- a/.github/workflows/behavior.yml
+++ b/.github/workflows/behavior.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -49,7 +49,7 @@ jobs:
 
       - name: Upload test artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: behavior-results
           path: state/test-artifacts/behavior/

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -17,7 +17,7 @@ jobs:
   benchmark:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: Install Rust toolchain
         run: rustup show

--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -121,7 +121,7 @@ jobs:
           echo "Building forjar for $TAG → ${{ matrix.target }}"
 
       - name: Checkout at tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           ref: ${{ steps.tag.outputs.tag }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       - name: Verify Cargo.lock is committed and current
         run: cargo package --locked --no-verify
 

--- a/.github/workflows/convergence.yml
+++ b/.github/workflows/convergence.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -41,7 +41,7 @@ jobs:
 
       - name: Upload test artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: convergence-results
           path: state/test-artifacts/convergence/

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,7 +17,7 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: Install Rust toolchain
         run: rustup show

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,7 @@ jobs:
     env:
       MDBOOK_VERSION: v0.4.40
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: Install mdbook (pinned prebuilt binary)
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
         # which is unreliable on GH runners. Sovereign-ci handles lint on Linux.
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: Install Rust toolchain
         run: rustup show

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -17,7 +17,7 @@ jobs:
   msrv:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: Install MSRV toolchain
         # rust: 1.89.0 (bumped from 1.88 — aprender-contracts 0.30 requires 1.89)

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -40,7 +40,7 @@ jobs:
 
       - name: Upload mutation report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: mutation-results
           path: mutants.out/

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,7 +26,7 @@ jobs:
       has_commits: ${{ steps.check.outputs.has_commits }}
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           fetch-depth: 0
 
@@ -78,7 +78,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -121,7 +121,7 @@ jobs:
 
       - name: Upload artifact (unix)
         if: runner.os != 'Windows'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: forjar-${{ matrix.target }}
           path: |
@@ -130,7 +130,7 @@ jobs:
 
       - name: Upload artifact (windows)
         if: runner.os == 'Windows'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: forjar-${{ matrix.target }}
           path: |
@@ -143,7 +143,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: Download all artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
       has_binaries: ${{ steps.bincheck.outputs.has_binaries }}
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: Parse tag and verify version
         id: parse
@@ -160,7 +160,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: Install Rust toolchain (macOS)
         if: contains(matrix.target, 'darwin')
@@ -222,7 +222,7 @@ jobs:
           done
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: binaries-${{ matrix.target }}
           path: /tmp/release-staging/*.tar.gz
@@ -265,7 +265,7 @@ jobs:
     runs-on: [self-hosted, clean-room]
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: Generate distribution artifacts
         run: |
@@ -284,7 +284,7 @@ jobs:
             --clobber
 
       - name: Upload dist artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: dist-artifacts
           path: /tmp/dist-output/
@@ -297,7 +297,7 @@ jobs:
     runs-on: [self-hosted, clean-room]
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: Download dist artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         iteration: [1, 2, 3]
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: Install Rust toolchain
         run: rustup show


### PR DESCRIPTION
## Summary

Fresh replacement for the two stale dependabot branches the 2026-06 triage flagged as the only revivable PRs (**#16** checkout v4→v6, **#69** upload-artifact v4→v7). Both were ~3 months behind and conflicting after the provable-contracts workflow rewrite, so reviving the branches wasn't worth it — this is a clean re-bump instead. These were the **last two action laggards**: `cache`→v5 (#122), `download-artifact`→v8 (#121), and `action-gh-release`→v3 (#128) already landed.

SHA-pinned (repo convention) across all 14 workflows that use them — 19 `checkout` + 7 `upload-artifact` sites:
- `actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3`
- `actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1`

## Breaking-change review

All breaking changes across these majors are **runtime/security, not API or artifact-format**:
- **Node 24 default runtime** (v5+), requiring Actions Runner ≥ **2.327.1**.
- **checkout v6** moves credential storage from git config to `$RUNNER_TEMP` file-based storage (`includeIf` for worktrees); container-action scenarios need runner ≥ **2.329.0**.
- **upload-artifact v7** is an ESM module upgrade; adds an opt-in `archive` parameter (default behavior unchanged).
- **No artifact storage-format change.** upload-artifact has used the v4-era backend since v4, so upload **v7** stays compatible with the already-merged download-**v8** in the `release.yml`/`nightly.yml` upload→download pairs. (Verified against the upstream release notes — the disruptive backend change was v3→v4, which this repo already adopted.)

## ⚠️ One untested surface (needs your eyes before merge)

GitHub-hosted runners (ubuntu-latest/22.04) are well past the Node-24 minimum, so PR CI exercises that path. But **release.yml, nightly.yml, and stress.yml run partly on `[self-hosted, clean-room]` runners and only trigger on tags/schedule — not on this PR.** If those self-hosted agents are older than **2.329.0**, checkout v6 / upload-artifact v7 could fail there (Node 24 won't launch, or container-action credential handling breaks). Worth confirming the clean-room runner agent version before the next tag, or watching the first post-merge `release`/`nightly` run.

## Test plan
- [x] No old pins remain; exactly two distinct SHAs; all 14 workflow files valid YAML
- [x] SHAs dereferenced from the authoritative `v6.0.3` / `v7.0.1` tags via the GitHub API
- [ ] PR CI green (exercises checkout v6 + upload-artifact v7 on hosted runners)
- [ ] First post-merge tag/nightly confirms self-hosted runners accept Node 24

Closes #16, closes #69.

🤖 Generated with [Claude Code](https://claude.com/claude-code)