### PR TITLE
feat(coverage): L3-L5 test-coverage persistence + promotion (PMAT-088)

### DIFF
--- a/src/cli/check_test_runners.rs
+++ b/src/cli/check_test_runners.rs
@@ -3,6 +3,10 @@
 //! Extracted from check_test.rs for 500-line limit compliance.
 
 use super::check_test::check_verify_assertions;
+use super::coverage_promote::{
+    coverage_entry, coverage_state_dir, persist_convergence_coverage, persist_mutation_coverage,
+    print_coverage_summary,
+};
 use super::helpers::*;
 use crate::core::types::SandboxBackend;
 use crate::core::{codegen, resolver};
@@ -97,6 +101,9 @@ pub(crate) fn cmd_test_mutation(file: &Path, opts: &RunnerOpts) -> Result<(), St
     print!("{}", mutation_runner::format_mutation_run(&report));
     println!("Completed in {:.1}s", elapsed.as_secs_f64());
 
+    // PMAT-088: Persist L4 results so `test coverage` can promote resources.
+    persist_mutation_coverage(file, &config, &report);
+
     // Grade F with errors = scripts require real infra (expected in local mode).
     // Grade F with zero errors = mutations genuinely undetected (real failure).
     if report.score.grade() == 'F' && report.score.errored == 0 {
@@ -173,6 +180,9 @@ pub(crate) fn cmd_test_convergence(file: &Path, opts: &RunnerOpts) -> Result<(),
     );
     println!("Completed in {:.1}s", elapsed.as_secs_f64());
 
+    // PMAT-088: Persist L3/L5 results so `test coverage` can promote resources.
+    persist_convergence_coverage(file, &config, &results, test_config.test_pairs);
+
     // Distinguish real failures (scripts ran but state diverged) from
     // environment errors (scripts can't run locally — need real machines).
     let env_errors = results.iter().filter(|r| r.error.is_some()).count();
@@ -213,35 +223,27 @@ fn discover_spec_resources(spec_dir: &Path) -> std::collections::HashSet<String>
     result
 }
 
-/// FJ-2602: Resource-level coverage report.
+/// FJ-2602 / PMAT-088: Resource-level coverage report with L3-L5 promotion.
 pub(crate) fn cmd_test_coverage(file: &Path) -> Result<(), String> {
-    use crate::core::types::{CoverageLevel, CoverageReport, ResourceCoverage};
+    use crate::core::types::{CoverageReport, ResourceCoverage};
 
     let config = parse_and_validate(file)?;
     let spec_dir = file.parent().unwrap_or(Path::new("."));
     let spec_resources = discover_spec_resources(spec_dir);
+    let records = crate::core::store::coverage_persist::load_records(&coverage_state_dir(file));
 
     let execution_order = resolver::build_execution_order(&config)?;
     let entries: Vec<ResourceCoverage> = execution_order
         .iter()
         .filter_map(|rid| {
             let resource = config.resources.get(rid)?;
-            let resolved =
-                resolver::resolve_resource_templates(resource, &config.params, &config.machines)
-                    .unwrap_or_else(|_| resource.clone());
-            let has_check = codegen::check_script(&resolved).is_ok();
-            let has_spec = spec_resources.contains(rid);
-            let level = match (has_spec, has_check) {
-                (true, true) => CoverageLevel::L2,
-                (_, true) => CoverageLevel::L1,
-                _ => CoverageLevel::L0,
-            };
-            let rtype = format!("{:?}", resource.resource_type).to_lowercase();
-            Some(ResourceCoverage {
-                resource_id: rid.clone(),
-                level,
-                resource_type: rtype,
-            })
+            Some(coverage_entry(
+                rid,
+                resource,
+                &config,
+                &spec_resources,
+                &records,
+            ))
         })
         .collect();
 
@@ -256,14 +258,7 @@ pub(crate) fn cmd_test_coverage(file: &Path) -> Result<(), String> {
             entry.resource_type
         );
     }
-    println!(
-        "\nMin: {}, Avg: {:.1}, L0: {}, L1: {}, L2: {}",
-        report.min_level.label(),
-        report.avg_level,
-        report.histogram[0],
-        report.histogram[1],
-        report.histogram[2]
-    );
+    print_coverage_summary(&report);
     Ok(())
 }
 

--- a/src/cli/coverage_promote.rs
+++ b/src/cli/coverage_promote.rs
@@ -1,0 +1,180 @@
+//! PMAT-088 (FALSIFICATION E9): L3-L5 coverage persistence + promotion helpers.
+//!
+//! These helpers bridge the convergence/mutation test runners to the
+//! `test-coverage.jsonl` log (see `core::store::coverage_persist`) and
+//! drive the read-back + hash-gated promotion used by `forjar test coverage`.
+//! Extracted from `check_test_runners.rs` to keep both files under the
+//! 500-line limit.
+
+use crate::core::store::convergence_runner::ConvergenceResult;
+use crate::core::store::coverage_persist::{
+    append_records, convergence_record, mutation_record, promote_level, ConvergenceOutcome,
+    TestCoverageRecord,
+};
+use crate::core::types::{
+    CoverageLevel, CoverageReport, ForjarConfig, MutationReport, Resource, ResourceCoverage,
+};
+use crate::core::{codegen, resolver};
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+/// PMAT-088: Derive the coverage state dir for a config file.
+///
+/// Test commands operate on a config file and have no `--state-dir` flag, so
+/// the persisted coverage log lives in a `state/` subdirectory next to the
+/// config (matching the `--state-dir state` default used elsewhere). This
+/// keeps the log co-located with the config and makes tests hermetic
+/// (tempdir config → tempdir state).
+pub(crate) fn coverage_state_dir(file: &Path) -> PathBuf {
+    file.parent().unwrap_or(Path::new(".")).join("state")
+}
+
+/// PMAT-088: Map each resource id to its current desired-state hash.
+///
+/// This is the hash a persisted L3-L5 record must match to still count.
+fn resource_hashes(config: &ForjarConfig) -> HashMap<String, String> {
+    config
+        .resources
+        .iter()
+        .map(|(rid, resource)| {
+            let resolved =
+                resolver::resolve_resource_templates(resource, &config.params, &config.machines)
+                    .unwrap_or_else(|_| resource.clone());
+            (
+                rid.clone(),
+                crate::core::planner::hash_desired_state(&resolved),
+            )
+        })
+        .collect()
+}
+
+/// PMAT-088: Persist convergence/preservation results as coverage records.
+///
+/// Each passing result becomes an L3 record (or L5 when pairwise preservation
+/// was enabled and passed), stamped with the resource's current desired-state
+/// hash so a later config change invalidates the high-water mark.
+pub(crate) fn persist_convergence_coverage(
+    file: &Path,
+    config: &ForjarConfig,
+    results: &[ConvergenceResult],
+    pairwise: bool,
+) {
+    let hashes = resource_hashes(config);
+    let records: Vec<_> = results
+        .iter()
+        .filter_map(|r| {
+            let hash = hashes.get(&r.resource_id)?;
+            let outcome = ConvergenceOutcome {
+                converged: r.converged,
+                idempotent: r.idempotent,
+                preserved: r.preserved,
+                errored: r.error.is_some(),
+                pairwise_enabled: pairwise,
+            };
+            convergence_record(&r.resource_id, outcome, hash)
+        })
+        .collect();
+    if records.is_empty() {
+        return;
+    }
+    let _ = append_records(&coverage_state_dir(file), &records);
+}
+
+/// Per-resource mutation tallies: (attempted, detected, errored).
+type MutationTally = (usize, usize, usize);
+
+/// PMAT-088: Aggregate mutation results into per-resource tallies.
+fn tally_mutations(report: &MutationReport) -> HashMap<String, MutationTally> {
+    let mut tallies: HashMap<String, MutationTally> = HashMap::new();
+    for r in &report.results {
+        let entry = tallies.entry(r.resource_id.clone()).or_default();
+        entry.0 += 1;
+        if r.error.is_some() {
+            entry.2 += 1;
+        } else if r.detected {
+            entry.1 += 1;
+        }
+    }
+    tallies
+}
+
+/// PMAT-088: Persist mutation results as L4 coverage records.
+///
+/// A resource earns an L4 record when every applicable mutation was detected
+/// (no survivors, no errors), stamped with its current desired-state hash.
+pub(crate) fn persist_mutation_coverage(
+    file: &Path,
+    config: &ForjarConfig,
+    report: &MutationReport,
+) {
+    let hashes = resource_hashes(config);
+    let tallies = tally_mutations(report);
+    let records: Vec<_> = tallies
+        .iter()
+        .filter_map(|(rid, (attempted, detected, errored))| {
+            let hash = hashes.get(rid)?;
+            mutation_record(rid, *attempted, *detected, *errored, hash)
+        })
+        .collect();
+    if records.is_empty() {
+        return;
+    }
+    let _ = append_records(&coverage_state_dir(file), &records);
+}
+
+/// Compute the static L0-L2 base level for a resource.
+fn static_coverage_level(resolved: &Resource, has_spec: bool) -> CoverageLevel {
+    let has_check = codegen::check_script(resolved).is_ok();
+    match (has_spec, has_check) {
+        (true, true) => CoverageLevel::L2,
+        (_, true) => CoverageLevel::L1,
+        _ => CoverageLevel::L0,
+    }
+}
+
+/// PMAT-088: Build a promoted coverage entry for one resource.
+///
+/// Starts from the static L0-L2 base, then promotes to the highest persisted,
+/// passing, hash-matching L3-L5 record (stale records are ignored).
+pub(crate) fn coverage_entry(
+    rid: &str,
+    resource: &Resource,
+    config: &ForjarConfig,
+    spec_resources: &HashSet<String>,
+    records: &[TestCoverageRecord],
+) -> ResourceCoverage {
+    let resolved = resolver::resolve_resource_templates(resource, &config.params, &config.machines)
+        .unwrap_or_else(|_| resource.clone());
+    let base = static_coverage_level(&resolved, spec_resources.contains(rid));
+    let current_hash = crate::core::planner::hash_desired_state(&resolved);
+    let level = promote_level(base, records, rid, &current_hash);
+    ResourceCoverage {
+        resource_id: rid.to_string(),
+        level,
+        resource_type: format!("{:?}", resource.resource_type).to_lowercase(),
+    }
+}
+
+/// PMAT-088: Print the coverage summary including L3-L5 buckets.
+pub(crate) fn print_coverage_summary(report: &CoverageReport) {
+    let total = report.resources.len();
+    let h = &report.histogram;
+    let at_l3_plus = h[3] + h[4] + h[5];
+    let at_l4_plus = h[4] + h[5];
+    println!(
+        "\nMin: {}, Avg: {:.1}, L0: {}, L1: {}, L2: {}, L3: {}, L4: {}, L5: {}",
+        report.min_level.label(),
+        report.avg_level,
+        h[0],
+        h[1],
+        h[2],
+        h[3],
+        h[4],
+        h[5],
+    );
+    println!("Coverage: {at_l3_plus}/{total} at L3+, {at_l4_plus}/{total} at L4+");
+}
+
+#[cfg(test)]
+#[path = "coverage_promote_tests.rs"]
+mod tests;

--- a/src/cli/coverage_promote_tests.rs
+++ b/src/cli/coverage_promote_tests.rs
@@ -1,0 +1,219 @@
+//! PMAT-088: End-to-end tests for coverage persistence + hash-gated promotion.
+//!
+//! Hermetic: parse a synthetic config, write synthetic records into a tempdir
+//! state directory, then assert the promoted coverage level. No sandbox,
+//! network, or docker — the persist/read/promote logic is exercised directly.
+
+use super::*;
+use crate::core::parser::parse_config;
+use crate::core::store::convergence_runner::ConvergenceResult;
+use crate::core::store::coverage_persist::{append_record, load_records, TestCoverageRecord};
+use crate::core::types::{CoverageLevel, ForjarConfig, MutationReport, MutationResult};
+use std::collections::HashSet;
+
+const CONFIG_YAML: &str = r#"
+version: "1.0"
+name: cov-stack
+machines:
+  m:
+    hostname: m
+    addr: 127.0.0.1
+resources:
+  pkg:
+    type: file
+    machine: m
+    path: /etc/forjar/pkg.conf
+    content: "original"
+"#;
+
+fn parse() -> ForjarConfig {
+    parse_config(CONFIG_YAML).expect("config parses")
+}
+
+/// Current desired-state hash for resource `rid` in the parsed config.
+fn current_hash(config: &ForjarConfig, rid: &str) -> String {
+    let r = config.resources.get(rid).expect("resource exists");
+    let resolved =
+        crate::core::resolver::resolve_resource_templates(r, &config.params, &config.machines)
+            .unwrap_or_else(|_| r.clone());
+    crate::core::planner::hash_desired_state(&resolved)
+}
+
+/// Build a coverage entry for `pkg` against the given state dir.
+fn entry_for(config: &ForjarConfig, state_dir: &std::path::Path) -> CoverageLevel {
+    let records = load_records(state_dir);
+    let spec: HashSet<String> = HashSet::new();
+    let r = config.resources.get("pkg").unwrap();
+    coverage_entry("pkg", r, config, &spec, &records).level
+}
+
+// ── (a) A fresh resource (no records) reports its static L0-L2 level ──
+
+#[test]
+fn falsify_a_fresh_resource_is_static_level() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = parse();
+    // file resource with a path → has a check script → static L1.
+    let level = entry_for(&config, dir.path());
+    assert_eq!(level, CoverageLevel::L1, "fresh resource must be static L1");
+    assert!(level < CoverageLevel::L3, "fresh resource is never L3+");
+}
+
+// ── (b) A passing L3 record (hash match) promotes to L3 ──
+
+#[test]
+fn falsify_b_passing_l3_record_promotes() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = parse();
+    let hash = current_hash(&config, "pkg");
+    append_record(
+        dir.path(),
+        &TestCoverageRecord::new("pkg", CoverageLevel::L3, true, hash),
+    )
+    .unwrap();
+    assert_eq!(entry_for(&config, dir.path()), CoverageLevel::L3);
+}
+
+// ── (c) A config change (hash mismatch) demotes back to the static level ──
+
+#[test]
+fn falsify_c_config_change_demotes() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = parse();
+    // Record stamped with a STALE hash (resource has since changed).
+    append_record(
+        dir.path(),
+        &TestCoverageRecord::new("pkg", CoverageLevel::L5, true, "stale-hash"),
+    )
+    .unwrap();
+    let level = entry_for(&config, dir.path());
+    assert_eq!(
+        level,
+        CoverageLevel::L1,
+        "stale high-water mark must not survive a config change"
+    );
+}
+
+// ── (d) An L5 record implies L3/L4 (subsumes lower levels) ──
+
+#[test]
+fn falsify_d_l5_record_implies_l3_l4() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = parse();
+    let hash = current_hash(&config, "pkg");
+    append_record(
+        dir.path(),
+        &TestCoverageRecord::new("pkg", CoverageLevel::L5, true, hash),
+    )
+    .unwrap();
+    let level = entry_for(&config, dir.path());
+    assert_eq!(level, CoverageLevel::L5);
+    assert!(level >= CoverageLevel::L3, "L5 implies L3");
+    assert!(level >= CoverageLevel::L4, "L5 implies L4");
+}
+
+// ── persist_convergence_coverage writes L3 / L5 records ──
+
+fn conv_result(rid: &str, converged: bool, idempotent: bool, preserved: bool) -> ConvergenceResult {
+    ConvergenceResult {
+        resource_id: rid.into(),
+        resource_type: "file".into(),
+        converged,
+        idempotent,
+        preserved,
+        duration_ms: 1,
+        error: None,
+    }
+}
+
+#[test]
+fn persist_convergence_writes_l3_on_pass() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = parse();
+    let file = dir.path().join("forjar.yaml");
+    // coverage_state_dir(file) == dir/state — write the record there.
+    let results = vec![conv_result("pkg", true, true, true)];
+    persist_convergence_coverage(&file, &config, &results, false);
+    let records = load_records(&coverage_state_dir(&file));
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].level, CoverageLevel::L3);
+    assert_eq!(records[0].config_hash, current_hash(&config, "pkg"));
+}
+
+#[test]
+fn persist_convergence_writes_l5_when_pairwise() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = parse();
+    let file = dir.path().join("forjar.yaml");
+    let results = vec![conv_result("pkg", true, true, true)];
+    persist_convergence_coverage(&file, &config, &results, true);
+    let records = load_records(&coverage_state_dir(&file));
+    assert_eq!(records[0].level, CoverageLevel::L5);
+}
+
+#[test]
+fn persist_convergence_writes_nothing_on_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = parse();
+    let file = dir.path().join("forjar.yaml");
+    let results = vec![conv_result("pkg", false, true, false)];
+    persist_convergence_coverage(&file, &config, &results, false);
+    assert!(load_records(&coverage_state_dir(&file)).is_empty());
+}
+
+// ── persist_mutation_coverage writes L4 records ──
+
+fn mut_result(rid: &str, detected: bool) -> MutationResult {
+    use crate::core::types::MutationOperator;
+    MutationResult {
+        resource_id: rid.into(),
+        resource_type: "file".into(),
+        operator: MutationOperator::DeleteFile,
+        detected,
+        reconverged: None,
+        duration_ms: 1,
+        error: None,
+    }
+}
+
+#[test]
+fn persist_mutation_writes_l4_when_all_detected() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = parse();
+    let file = dir.path().join("forjar.yaml");
+    let report =
+        MutationReport::from_results(vec![mut_result("pkg", true), mut_result("pkg", true)]);
+    persist_mutation_coverage(&file, &config, &report);
+    let records = load_records(&coverage_state_dir(&file));
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].level, CoverageLevel::L4);
+}
+
+#[test]
+fn persist_mutation_writes_nothing_with_survivor() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = parse();
+    let file = dir.path().join("forjar.yaml");
+    let report =
+        MutationReport::from_results(vec![mut_result("pkg", true), mut_result("pkg", false)]);
+    persist_mutation_coverage(&file, &config, &report);
+    assert!(load_records(&coverage_state_dir(&file)).is_empty());
+}
+
+// ── End-to-end: convergence then coverage read-back promotes ──
+
+#[test]
+fn end_to_end_convergence_then_coverage_promotes() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = parse();
+    let file = dir.path().join("forjar.yaml");
+    let results = vec![conv_result("pkg", true, true, true)];
+    persist_convergence_coverage(&file, &config, &results, false);
+
+    // Now read back from the SAME state dir coverage_state_dir(file) resolves to.
+    let records = load_records(&coverage_state_dir(&file));
+    let spec: HashSet<String> = HashSet::new();
+    let r = config.resources.get("pkg").unwrap();
+    let level = coverage_entry("pkg", r, &config, &spec, &records).level;
+    assert_eq!(level, CoverageLevel::L3);
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -22,6 +22,7 @@ mod complexity_analysis;
 mod config_merge;
 mod contracts;
 mod cost_estimate;
+mod coverage_promote;
 mod cross_machine_deps;
 mod data_freshness;
 mod data_validate;

--- a/src/core/store/coverage_persist.rs
+++ b/src/core/store/coverage_persist.rs
@@ -1,0 +1,456 @@
+//! PMAT-088 (FALSIFICATION E9): Persist L3-L5 test-coverage results.
+//!
+//! `forjar test coverage` historically reported only the static L0-L2 level
+//! derived from "has check script" + "has behavior spec". Nothing ever
+//! promoted a resource to L3 (convergence tested), L4 (mutation tested), or
+//! L5 (preservation tested), even after those sandbox tests actually passed.
+//!
+//! This module closes that gap with an append-only `test-coverage.jsonl` log
+//! under the state dir, mirroring the `events.jsonl` provenance pattern:
+//!
+//! * Convergence/mutation/preservation runners **append** a per-resource
+//!   record `{resource_id, level, passed, timestamp, config_hash}` when a
+//!   test for that resource completes.
+//! * `forjar test coverage` **reads back** the log and promotes each resource
+//!   to the highest level with a `passed` record **whose `config_hash` matches
+//!   the resource's CURRENT desired-state hash**. A changed resource (hash
+//!   mismatch) falls back to its static L0-L2 level — a stale high-water mark
+//!   is a correctness bug, not a feature.
+
+use crate::core::types::CoverageLevel;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+/// PMAT-088: A single persisted test-coverage result for one resource.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TestCoverageRecord {
+    /// Resource identifier this result applies to.
+    pub resource_id: String,
+    /// Coverage level proven by the test (L3/L4/L5).
+    pub level: CoverageLevel,
+    /// Whether the test passed (only passing records promote).
+    pub passed: bool,
+    /// ISO 8601 timestamp the record was written.
+    pub timestamp: String,
+    /// Desired-state hash of the resource at the time the test ran.
+    ///
+    /// A record only counts toward promotion if this matches the resource's
+    /// CURRENT hash — otherwise the resource changed and the result is stale.
+    pub config_hash: String,
+}
+
+impl TestCoverageRecord {
+    /// Build a record stamped with the current time.
+    pub fn new(
+        resource_id: impl Into<String>,
+        level: CoverageLevel,
+        passed: bool,
+        config_hash: impl Into<String>,
+    ) -> Self {
+        Self {
+            resource_id: resource_id.into(),
+            level,
+            passed,
+            timestamp: crate::tripwire::eventlog::now_iso8601(),
+            config_hash: config_hash.into(),
+        }
+    }
+}
+
+/// PMAT-088: Path to the test-coverage log within the state directory.
+pub fn coverage_log_path(state_dir: &Path) -> PathBuf {
+    state_dir.join("test-coverage.jsonl")
+}
+
+/// PMAT-088: Append a single coverage record to the log (append-only JSONL).
+pub fn append_record(state_dir: &Path, record: &TestCoverageRecord) -> Result<(), String> {
+    let path = coverage_log_path(state_dir);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("cannot create state dir: {e}"))?;
+    }
+
+    let json = serde_json::to_string(record).map_err(|e| format!("JSON serialize error: {e}"))?;
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .map_err(|e| format!("cannot open coverage log {}: {}", path.display(), e))?;
+    writeln!(file, "{json}").map_err(|e| format!("write error: {e}"))?;
+    Ok(())
+}
+
+/// PMAT-088: Append a batch of records. Best-effort: stops at the first error.
+pub fn append_records(state_dir: &Path, records: &[TestCoverageRecord]) -> Result<(), String> {
+    for record in records {
+        append_record(state_dir, record)?;
+    }
+    Ok(())
+}
+
+/// PMAT-088: Load every coverage record from the log.
+///
+/// Missing log → empty vec. Malformed lines are skipped (tolerant read: a
+/// partially-written final line must not poison the whole history).
+pub fn load_records(state_dir: &Path) -> Vec<TestCoverageRecord> {
+    let path = coverage_log_path(state_dir);
+    let content = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(_) => return Vec::new(),
+    };
+    content
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .filter_map(|line| serde_json::from_str::<TestCoverageRecord>(line).ok())
+        .collect()
+}
+
+/// PMAT-088: Highest level a record set proves for one resource, hash-gated.
+///
+/// Returns `None` if no passing record matches `current_hash`. Only passing
+/// records whose `config_hash == current_hash` are considered; the maximum of
+/// their levels is returned (L5 implies L4/L3/... by `CoverageLevel` ordering).
+pub fn proven_level(
+    records: &[TestCoverageRecord],
+    resource_id: &str,
+    current_hash: &str,
+) -> Option<CoverageLevel> {
+    records
+        .iter()
+        .filter(|r| r.resource_id == resource_id && r.passed && r.config_hash == current_hash)
+        .map(|r| r.level)
+        .max()
+}
+
+/// PMAT-088: Promote a static base level using the persisted, hash-gated log.
+///
+/// The result is the maximum of the static base level and the highest proven
+/// (passing, hash-matching) level. A resource never regresses below its static
+/// L0-L2 assessment, and a stale (hash-mismatched) high-water mark is ignored.
+pub fn promote_level(
+    base: CoverageLevel,
+    records: &[TestCoverageRecord],
+    resource_id: &str,
+    current_hash: &str,
+) -> CoverageLevel {
+    match proven_level(records, resource_id, current_hash) {
+        Some(proven) => base.max(proven),
+        None => base,
+    }
+}
+
+/// PMAT-088: The convergence outcome for one resource, used to derive a level.
+///
+/// Decouples `coverage_persist` from the runner's `ConvergenceResult` type and
+/// keeps record-building to a single argument (clippy `too_many_arguments`).
+#[derive(Debug, Clone, Copy)]
+pub struct ConvergenceOutcome {
+    /// First apply reached the desired state.
+    pub converged: bool,
+    /// Second apply was a no-op.
+    pub idempotent: bool,
+    /// State was preserved after co-located resources applied.
+    pub preserved: bool,
+    /// The test itself errored (environment/script failure).
+    pub errored: bool,
+    /// Pairwise preservation testing was actually enabled for this run.
+    pub pairwise_enabled: bool,
+}
+
+impl ConvergenceOutcome {
+    /// Whether this outcome earns the L3 (convergence) level.
+    ///
+    /// L3 requires convergence + idempotency with no execution error.
+    /// Preservation is tracked separately (L5).
+    pub fn proves_l3(&self) -> bool {
+        self.converged && self.idempotent && !self.errored
+    }
+
+    /// Whether this outcome earns the L5 (preservation) level.
+    ///
+    /// Only meaningful when pairwise preservation testing was actually run; a
+    /// single-resource run cannot prove preservation against co-located ones.
+    pub fn proves_l5(&self) -> bool {
+        self.pairwise_enabled && self.proves_l3() && self.preserved
+    }
+
+    /// The highest level this outcome proves, if any.
+    pub fn proven_level(&self) -> Option<CoverageLevel> {
+        if self.proves_l5() {
+            Some(CoverageLevel::L5)
+        } else if self.proves_l3() {
+            Some(CoverageLevel::L3)
+        } else {
+            None
+        }
+    }
+}
+
+/// PMAT-088: Build a convergence coverage record for one resource.
+///
+/// Records L5 when pairwise preservation passed, else L3 when convergence +
+/// idempotency passed. Returns `None` when the resource did not even reach L3
+/// (no record is written for a non-result, keeping the log signal-only).
+pub fn convergence_record(
+    resource_id: &str,
+    outcome: ConvergenceOutcome,
+    config_hash: &str,
+) -> Option<TestCoverageRecord> {
+    outcome
+        .proven_level()
+        .map(|level| TestCoverageRecord::new(resource_id, level, true, config_hash))
+}
+
+/// PMAT-088: Build an L4 (mutation) coverage record for one resource.
+///
+/// A resource is L4 when at least one mutation was attempted and every
+/// applicable mutation was detected (zero survivors, zero errors). A resource
+/// with no mutations attempted, survivors, or errors earns no record.
+pub fn mutation_record(
+    resource_id: &str,
+    attempted: usize,
+    detected: usize,
+    errored: usize,
+    config_hash: &str,
+) -> Option<TestCoverageRecord> {
+    if attempted > 0 && errored == 0 && detected == attempted {
+        Some(TestCoverageRecord::new(
+            resource_id,
+            CoverageLevel::L4,
+            true,
+            config_hash,
+        ))
+    } else {
+        None
+    }
+}
+
+/// PMAT-088: Index records by resource id for repeated promotion lookups.
+///
+/// Builds a `resource_id -> highest passing level per config_hash` map is
+/// unnecessary here; promotion needs the current hash to gate, so callers pass
+/// the loaded records directly. This helper instead groups the latest hash seen
+/// per resource, used only for diagnostics/tests.
+pub fn latest_hash_by_resource(records: &[TestCoverageRecord]) -> HashMap<String, String> {
+    let mut map: HashMap<String, String> = HashMap::new();
+    for r in records {
+        map.insert(r.resource_id.clone(), r.config_hash.clone());
+    }
+    map
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rec(id: &str, level: CoverageLevel, passed: bool, hash: &str) -> TestCoverageRecord {
+        TestCoverageRecord {
+            resource_id: id.into(),
+            level,
+            passed,
+            timestamp: "2026-06-13T00:00:00Z".into(),
+            config_hash: hash.into(),
+        }
+    }
+
+    #[test]
+    fn append_then_load_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let r = rec("pkg", CoverageLevel::L3, true, "abc");
+        append_record(dir.path(), &r).unwrap();
+        let loaded = load_records(dir.path());
+        assert_eq!(loaded, vec![r]);
+    }
+
+    #[test]
+    fn load_missing_log_is_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(load_records(dir.path()).is_empty());
+    }
+
+    #[test]
+    fn load_skips_malformed_lines() {
+        let dir = tempfile::tempdir().unwrap();
+        let r = rec("pkg", CoverageLevel::L4, true, "h1");
+        append_record(dir.path(), &r).unwrap();
+        // Simulate a torn final write by appending garbage.
+        let path = coverage_log_path(dir.path());
+        let mut f = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap();
+        writeln!(f, "{{not valid json").unwrap();
+        let loaded = load_records(dir.path());
+        assert_eq!(loaded, vec![r]);
+    }
+
+    #[test]
+    fn append_records_batch() {
+        let dir = tempfile::tempdir().unwrap();
+        let recs = vec![
+            rec("a", CoverageLevel::L3, true, "h"),
+            rec("b", CoverageLevel::L4, true, "h"),
+        ];
+        append_records(dir.path(), &recs).unwrap();
+        assert_eq!(load_records(dir.path()).len(), 2);
+    }
+
+    #[test]
+    fn proven_level_picks_max_matching() {
+        let recs = vec![
+            rec("pkg", CoverageLevel::L3, true, "h1"),
+            rec("pkg", CoverageLevel::L4, true, "h1"),
+        ];
+        assert_eq!(
+            proven_level(&recs, "pkg", "h1"),
+            Some(CoverageLevel::L4),
+            "should pick the highest passing matching level"
+        );
+    }
+
+    #[test]
+    fn proven_level_ignores_hash_mismatch() {
+        let recs = vec![rec("pkg", CoverageLevel::L5, true, "old-hash")];
+        assert_eq!(proven_level(&recs, "pkg", "new-hash"), None);
+    }
+
+    #[test]
+    fn proven_level_ignores_failures() {
+        let recs = vec![rec("pkg", CoverageLevel::L4, false, "h1")];
+        assert_eq!(proven_level(&recs, "pkg", "h1"), None);
+    }
+
+    #[test]
+    fn proven_level_ignores_other_resources() {
+        let recs = vec![rec("other", CoverageLevel::L5, true, "h1")];
+        assert_eq!(proven_level(&recs, "pkg", "h1"), None);
+    }
+
+    // ── Falsification-style tests (PMAT-088 / E9) ──
+
+    #[test]
+    fn falsify_a_fresh_resource_stays_at_base() {
+        // (a) No records → a fresh L1 resource is NOT promoted.
+        let recs: Vec<TestCoverageRecord> = vec![];
+        assert_eq!(
+            promote_level(CoverageLevel::L1, &recs, "pkg", "h1"),
+            CoverageLevel::L1
+        );
+        assert_eq!(
+            promote_level(CoverageLevel::L0, &recs, "pkg", "h1"),
+            CoverageLevel::L0
+        );
+    }
+
+    #[test]
+    fn falsify_b_passing_l3_promotes() {
+        // (b) A passing L3 record (hash match) promotes L2 → L3.
+        let recs = vec![rec("pkg", CoverageLevel::L3, true, "h1")];
+        assert_eq!(
+            promote_level(CoverageLevel::L2, &recs, "pkg", "h1"),
+            CoverageLevel::L3
+        );
+    }
+
+    #[test]
+    fn falsify_c_config_change_demotes() {
+        // (c) Config change (hash mismatch) demotes back to static base.
+        let recs = vec![rec("pkg", CoverageLevel::L3, true, "old-hash")];
+        assert_eq!(
+            promote_level(CoverageLevel::L2, &recs, "pkg", "new-hash"),
+            CoverageLevel::L2,
+            "stale high-water mark must not survive a config change"
+        );
+    }
+
+    #[test]
+    fn falsify_d_l5_implies_l3_and_l4() {
+        // (d) An L5 record promotes a resource to L5 (which subsumes L3/L4).
+        let recs = vec![rec("pkg", CoverageLevel::L5, true, "h1")];
+        let level = promote_level(CoverageLevel::L1, &recs, "pkg", "h1");
+        assert_eq!(level, CoverageLevel::L5);
+        assert!(level >= CoverageLevel::L3, "L5 implies L3");
+        assert!(level >= CoverageLevel::L4, "L5 implies L4");
+    }
+
+    #[test]
+    fn promote_never_regresses_below_base() {
+        // A lower proven level than the static base does not regress the base.
+        let recs = vec![rec("pkg", CoverageLevel::L3, true, "h1")];
+        assert_eq!(
+            promote_level(CoverageLevel::L4, &recs, "pkg", "h1"),
+            CoverageLevel::L4,
+            "base L4 must not regress to a proven L3"
+        );
+    }
+
+    fn outcome(
+        converged: bool,
+        idempotent: bool,
+        preserved: bool,
+        errored: bool,
+        pairwise_enabled: bool,
+    ) -> ConvergenceOutcome {
+        ConvergenceOutcome {
+            converged,
+            idempotent,
+            preserved,
+            errored,
+            pairwise_enabled,
+        }
+    }
+
+    #[test]
+    fn convergence_record_l3_on_pass() {
+        let r = convergence_record("pkg", outcome(true, true, true, false, false), "h");
+        assert_eq!(r.unwrap().level, CoverageLevel::L3);
+    }
+
+    #[test]
+    fn convergence_record_l5_when_pairwise_preserved() {
+        let r = convergence_record("pkg", outcome(true, true, true, false, true), "h");
+        assert_eq!(r.unwrap().level, CoverageLevel::L5);
+    }
+
+    #[test]
+    fn convergence_record_l3_when_pairwise_off_even_if_preserved() {
+        // preserved=true but pairwise not enabled → only L3, not L5.
+        let r = convergence_record("pkg", outcome(true, true, true, false, false), "h");
+        assert_eq!(r.unwrap().level, CoverageLevel::L3);
+    }
+
+    #[test]
+    fn convergence_record_none_on_failure() {
+        assert!(
+            convergence_record("pkg", outcome(false, true, false, false, false), "h").is_none()
+        );
+        assert!(
+            convergence_record("pkg", outcome(true, false, false, false, false), "h").is_none()
+        );
+        assert!(convergence_record("pkg", outcome(true, true, true, true, false), "h").is_none());
+    }
+
+    #[test]
+    fn mutation_record_l4_when_all_detected() {
+        let r = mutation_record("pkg", 5, 5, 0, "h");
+        assert_eq!(r.unwrap().level, CoverageLevel::L4);
+    }
+
+    #[test]
+    fn mutation_record_none_on_survivor_or_error_or_empty() {
+        assert!(mutation_record("pkg", 5, 4, 0, "h").is_none()); // survivor
+        assert!(mutation_record("pkg", 5, 5, 1, "h").is_none()); // errored
+        assert!(mutation_record("pkg", 0, 0, 0, "h").is_none()); // nothing attempted
+    }
+
+    #[test]
+    fn latest_hash_by_resource_tracks_last_seen() {
+        let recs = vec![
+            rec("pkg", CoverageLevel::L3, true, "h1"),
+            rec("pkg", CoverageLevel::L3, true, "h2"),
+        ];
+        let map = latest_hash_by_resource(&recs);
+        assert_eq!(map.get("pkg"), Some(&"h2".to_string()));
+    }
+}

--- a/src/core/store/mod.rs
+++ b/src/core/store/mod.rs
@@ -16,6 +16,7 @@ pub mod convergence_container;
 pub mod convergence_runner;
 pub mod convert;
 pub mod convert_exec;
+pub mod coverage_persist;
 pub mod db;
 pub mod derivation;
 pub mod derivation_exec;


### PR DESCRIPTION
## The gap (FALSIFICATION-REPORT E9 / PMAT-088 stretch)

`CoverageLevel` fully defines **L3** (convergence tested), **L4** (mutation tested),
and **L5** (preservation tested) — with `label()`/`value()` — but nothing ever
promoted a resource above the static L0-L2 level that `cmd_test_coverage` assigned
via `match (has_spec, has_check)`. Convergence, mutation, and preservation tests
could pass for a resource and `forjar test coverage` would still report L1/L2.

The spec (`docs/specifications/platform/14-testing-strategy.md`, Phase 33) marked
"Five-level resource coverage tracking (L0-L5)" and the `forjar test coverage`
report as **IMPLEMENTED**, and shows the target output `Coverage: 3/5 at L3+,
1/5 at L4+`. That claim was aspirational: L3-L5 were unreachable. This PR makes
it true.

## Design — persist / hash-gate / promote

**Persist** (`src/core/store/coverage_persist.rs`): an append-only
`test-coverage.jsonl` log under the state dir (mirrors the `events.jsonl`
provenance pattern), with per-resource records
`{resource_id, level, passed, timestamp, config_hash}`.

- `forjar test --group convergence` appends an **L3** record per passing
  resource — or **L5** when pairwise preservation (`--pairs`) is enabled and the
  preservation property also holds.
- `forjar test --group mutation` appends an **L4** record per resource whose
  applicable mutations were all detected (no survivors, no errors).

**Hash-gate**: each record is stamped with the resource's `hash_desired_state`
at test time. A persisted L3-L5 result only counts toward promotion when its
`config_hash` matches the resource's **current** desired-state hash. A changed
resource therefore falls back to its static L0-L2 level — stale high-water marks
are a correctness bug, not a feature.

**Promote + read-back**: `forjar test --group coverage` loads the log and
promotes each resource to the highest passing, hash-matching level
(`promote_level`, with L5 subsuming L4/L3 via `CoverageLevel` ordering), then
prints the L3/L4/L5 histogram buckets and the spec's
`Coverage: N/M at L3+, K/M at L4+` summary line.

Records live in a `state/` subdir next to the config (matching the
`--state-dir state` default used elsewhere). Promotion/persistence helpers live
in `src/cli/coverage_promote.rs`, extracted to keep both CLI files under the
500-line limit.

## Spec reconciliation

The spec's Phase-33 checklist claimed L0-L5 tracking was implemented; in reality
only L0-L2 were ever reachable (the E9 gap). The L3/L4/L5 definitions and the
target output format in the spec are unchanged and now actually achievable. No
spec text required correction — the code now matches the documented behaviour.

## Test plan

All hermetic — tempdir state dirs, synthetic records/configs, **no sandbox /
network / docker** (those patterns hang in the proxied CI container).

Falsification-style coverage (in `coverage_persist.rs` + `coverage_promote_tests.rs`):
- (a) a fresh resource with no records reports its static L0-L2 level
- (b) a passing L3 record (hash match) promotes L2 → L3
- (c) a config change (hash mismatch) demotes back to the static level
- (d) an L5 record implies L3/L4 (subsumes lower levels)

Plus: append/load JSONL roundtrip, tolerant read of torn final lines,
`convergence_record`/`mutation_record` derivation, and an end-to-end
persist-then-read-back promotion test.

- `cargo test --lib`: **12284 passed, 0 failed** (30 new tests)
- `cargo clippy --all-targets -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean
- Manual binary smoke test confirmed L1 → L3 promotion after a convergence run,
  and L3 → L1 demotion after editing the resource (hash mismatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)