### PR TITLE
fix(apply): stop reporting success on pre-apply-hook, OCI-push HTTP, and coverage-gate failures (Refs #154)

### DIFF
--- a/src/core/executor/resource_ops.rs
+++ b/src/core/executor/resource_ops.rs
@@ -200,17 +200,23 @@ fn execute_resource(
     let resource_start = Instant::now();
 
     // FJ-265: pre_apply hook
+    // Bug-hunt #3 (Refs #154): a failing pre_apply hook must surface as a real
+    // Failed outcome (propagating jidoka's should_stop), NOT Skipped. Returning
+    // Skipped here is a no-op in MachineCounters::record, so the sequential /
+    // single-resource-wave path left counters.failed == 0 → apply exited 0
+    // reporting success, rollback was skipped, and dependents ran as if the
+    // prerequisite had succeeded. Mirror the post_apply branch below.
     if let Some(ref pre_hook) = resolved.pre_apply {
         if let Some(error) = run_pre_apply_hook(machine, pre_hook, ctx.timeout_secs) {
             let duration = resource_start.elapsed().as_secs_f64();
-            record_failure(
+            let should_stop = record_failure(
                 ctx,
                 &change.resource_id,
                 &resource.resource_type,
                 duration,
                 &error,
             );
-            return Ok(ResourceOutcome::Skipped);
+            return Ok(ResourceOutcome::Failed { should_stop });
         }
     }
 

--- a/src/core/executor/tests_hooks.rs
+++ b/src/core/executor/tests_hooks.rs
@@ -59,8 +59,14 @@ resources:
     let _ = std::fs::remove_dir_all(&tmp);
 }
 
+// Bug-hunt #3 (Refs #154): a failing pre_apply hook on the SEQUENTIAL apply
+// path must be counted as FAILED (not silently Skipped). Previously
+// execute_resource returned ResourceOutcome::Skipped here, which is a no-op in
+// MachineCounters::record, so resources_failed stayed 0 and apply reported
+// success on a real failure. The single-resource case below exercises the
+// sequential path (parallel kicks in only for >1 change).
 #[test]
-fn test_fj265_pre_apply_failure_skips() {
+fn test_fj265_pre_apply_failure_counts_as_failed() {
     let tmp = std::env::temp_dir().join(format!("fj265-pre-fail-{}", std::process::id()));
     let state_dir = tmp.join("state");
     let _ = std::fs::create_dir_all(&state_dir);
@@ -107,9 +113,92 @@ resources:
         force_tag: None,
     };
     let results = apply(&cfg).unwrap();
-    // pre_apply failure → resource skipped, not applied
+    // pre_apply failure → resource recorded as FAILED, main script never ran.
+    assert_eq!(
+        results[0].resources_failed, 1,
+        "pre_apply failure must count as a failed resource (not Skipped)"
+    );
     assert_eq!(results[0].resources_converged, 0);
-    assert!(!path.exists());
+    assert!(
+        !path.exists(),
+        "main script must not run after pre_apply fails"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+// Bug-hunt #3 (Refs #154): on the sequential path, a pre_apply failure must
+// cascade-skip dependents (FJ-63), and dependents must themselves be counted
+// as failed — they must NOT run as if the prerequisite had succeeded.
+#[test]
+fn test_fj265_pre_apply_failure_cascades_to_dependents() {
+    let tmp = std::env::temp_dir().join(format!("fj265-pre-cascade-{}", std::process::id()));
+    let state_dir = tmp.join("state");
+    let _ = std::fs::create_dir_all(&state_dir);
+    let base = tmp.join("base.txt");
+    let child = tmp.join("child.txt");
+    let yaml = format!(
+        r#"
+version: "1.0"
+name: test
+policy:
+  parallel_resources: false
+machines:
+  local:
+    hostname: localhost
+    addr: 127.0.0.1
+resources:
+  base:
+    type: file
+    machine: local
+    path: {base}
+    content: "base"
+    pre_apply: "exit 1"
+  child:
+    type: file
+    machine: local
+    path: {child}
+    content: "child"
+    depends_on: [base]
+"#,
+        base = base.display(),
+        child = child.display(),
+    );
+    let config: ForjarConfig = serde_yaml_ng::from_str(&yaml).unwrap();
+    let cfg = ApplyConfig {
+        config: &config,
+        state_dir: &state_dir,
+        force: false,
+        dry_run: false,
+        machine_filter: None,
+        resource_filter: None,
+        tag_filter: None,
+        group_filter: None,
+        timeout_secs: None,
+        force_unlock: false,
+        progress: false,
+        retry: 0,
+        // Force sequential so the bug-prone path is the one under test.
+        parallel: Some(false),
+        resource_timeout: None,
+        rollback_on_failure: false,
+        max_parallel: None,
+        trace: false,
+        run_id: None,
+        refresh: false,
+        force_tag: None,
+    };
+    let results = apply(&cfg).unwrap();
+    // base failed pre_apply, child cascade-skipped ⇒ both counted as failed.
+    assert_eq!(
+        results[0].resources_failed, 2,
+        "base + cascade-skipped child both count as failed"
+    );
+    assert_eq!(results[0].resources_converged, 0);
+    assert!(!base.exists(), "base main script must not run");
+    assert!(
+        !child.exists(),
+        "dependent must NOT run after prerequisite's pre_apply failed"
+    );
     let _ = std::fs::remove_dir_all(&tmp);
 }
 

--- a/src/core/promotion.rs
+++ b/src/core/promotion.rs
@@ -154,6 +154,25 @@ fn evaluate_policy_gate(config_file: &Path) -> GateResult {
     }
 }
 
+/// Outcome of probing `cargo llvm-cov`.
+///
+/// Bug-hunt #5 (Refs #154): the old `run_llvm_cov() -> Option<String>` collapsed
+/// two very different situations into `None` — (a) the tool is not installed
+/// (spawn/ENOENT failure) and (b) the tool ran but exited non-zero because the
+/// build or tests actually failed. `evaluate_coverage_gate_inner` then treated
+/// any `None` as an advisory PASS, so a broken build silently passed the gate.
+/// Keeping them distinct lets the gate advisory-pass only when coverage is
+/// genuinely unavailable, and FAIL when the present tool reported failure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CovProbe {
+    /// Tool could not be spawned (not installed) — advisory pass.
+    Unavailable,
+    /// Tool ran and exited 0; carries stdout for coverage parsing.
+    Ran(String),
+    /// Tool ran but exited non-zero (build/test failure) — gate failure.
+    Failed { code: Option<i32> },
+}
+
 /// Coverage gate: checks minimum test coverage threshold.
 ///
 /// Attempts to parse coverage from `cargo llvm-cov --summary-only`.
@@ -163,44 +182,91 @@ fn evaluate_coverage_gate(min_coverage: u32) -> GateResult {
 }
 
 /// Inner coverage gate logic, injectable for testing.
-fn evaluate_coverage_gate_inner(min_coverage: u32, runner: fn() -> Option<String>) -> GateResult {
-    let output = runner();
-    match output.and_then(|s| parse_coverage_from_output(&s)) {
-        Some(actual) => {
-            if actual >= min_coverage as f64 {
-                GateResult {
-                    gate_type: "coverage".into(),
-                    passed: true,
-                    message: format!("coverage {actual:.1}% >= {min_coverage}%"),
-                }
-            } else {
-                GateResult {
-                    gate_type: "coverage".into(),
-                    passed: false,
-                    message: format!("coverage {actual:.1}% < {min_coverage}% required"),
-                }
-            }
-        }
-        None => GateResult {
-            gate_type: "coverage".into(),
-            passed: true,
-            message: format!(
-                "coverage gate: minimum {min_coverage}% (advisory — llvm-cov not available)"
-            ),
+fn evaluate_coverage_gate_inner(min_coverage: u32, runner: fn() -> CovProbe) -> GateResult {
+    match runner() {
+        CovProbe::Ran(stdout) => match parse_coverage_from_output(&stdout) {
+            Some(actual) => coverage_threshold_result(actual, min_coverage),
+            // Tool ran cleanly but no TOTAL line — treat as advisory.
+            None => coverage_advisory_result(min_coverage),
         },
+        // Bug-hunt #5 (Refs #154): tool present but exited non-zero ⇒ a real
+        // failure signal (broken build / failing tests). Fail the gate instead
+        // of vacuously passing it.
+        CovProbe::Failed { code } => GateResult {
+            gate_type: "coverage".into(),
+            passed: false,
+            message: match code {
+                Some(c) => format!("coverage gate failed: cargo llvm-cov exited with code {c}"),
+                None => "coverage gate failed: cargo llvm-cov terminated by signal".into(),
+            },
+        },
+        CovProbe::Unavailable => coverage_advisory_result(min_coverage),
     }
 }
 
-/// Run `cargo llvm-cov --summary-only` and return stdout.
-fn run_llvm_cov() -> Option<String> {
-    let output = std::process::Command::new("cargo")
-        .args(["llvm-cov", "--summary-only"])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
+/// Build a pass/fail GateResult from a parsed coverage percentage.
+fn coverage_threshold_result(actual: f64, min_coverage: u32) -> GateResult {
+    if actual >= min_coverage as f64 {
+        GateResult {
+            gate_type: "coverage".into(),
+            passed: true,
+            message: format!("coverage {actual:.1}% >= {min_coverage}%"),
+        }
+    } else {
+        GateResult {
+            gate_type: "coverage".into(),
+            passed: false,
+            message: format!("coverage {actual:.1}% < {min_coverage}% required"),
+        }
     }
-    Some(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+/// Advisory pass used only when coverage is genuinely unavailable.
+fn coverage_advisory_result(min_coverage: u32) -> GateResult {
+    GateResult {
+        gate_type: "coverage".into(),
+        passed: true,
+        message: format!(
+            "coverage gate: minimum {min_coverage}% (advisory — llvm-cov not available)"
+        ),
+    }
+}
+
+/// Run `cargo llvm-cov --summary-only`, distinguishing absence from failure.
+fn run_llvm_cov() -> CovProbe {
+    classify_llvm_cov(
+        std::process::Command::new("cargo")
+            .args(["llvm-cov", "--summary-only"])
+            .output(),
+    )
+}
+
+/// Map a spawn `Result` into a [`CovProbe`] by decomposing the `Output` and
+/// delegating the actual decision to the pure [`classify_exit`] helper.
+fn classify_llvm_cov(spawn: std::io::Result<std::process::Output>) -> CovProbe {
+    match spawn {
+        Err(_) => CovProbe::Unavailable,
+        Ok(output) => classify_exit(
+            output.status.success(),
+            output.status.code(),
+            String::from_utf8_lossy(&output.stdout).to_string(),
+        ),
+    }
+}
+
+/// Pure spawn-vs-exit decision over an already-spawned process's result.
+///
+/// Bug-hunt #5 (Refs #154): factored out so it can be unit-tested without
+/// invoking any tool or spawning a subprocess (hermetic, no loopback shell).
+/// A clean exit (`success`) yields `Ran(stdout)` for coverage parsing; a
+/// present tool that exited non-zero yields `Failed` (gate failure). Spawn
+/// failure (tool absent) is handled by the caller as `Unavailable`.
+fn classify_exit(success: bool, code: Option<i32>, stdout: String) -> CovProbe {
+    if success {
+        CovProbe::Ran(stdout)
+    } else {
+        CovProbe::Failed { code }
+    }
 }
 
 /// Parse line coverage percentage from llvm-cov summary output.
@@ -250,191 +316,9 @@ fn evaluate_script_gate(script: &str) -> GateResult {
     }
 }
 
+// Tests live in `promotion_tests.rs` (split out to keep this file under the
+// 500-line health limit). Included as a `#[path]` child `mod tests` so they
+// retain access to the module's private gate helpers (`classify_exit`, etc.).
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::core::types::environment::*;
-    use tempfile::TempDir;
-
-    fn write_valid_config(dir: &Path) -> std::path::PathBuf {
-        let path = dir.join("forjar.yaml");
-        std::fs::write(
-            &path,
-            r#"
-version: "1.0"
-name: test
-machines:
-  m1:
-    hostname: m1
-    addr: 127.0.0.1
-resources:
-  pkg:
-    type: package
-    machine: m1
-    provider: apt
-    packages: [curl]
-"#,
-        )
-        .unwrap();
-        path
-    }
-
-    #[test]
-    fn validate_gate_passes() {
-        let dir = TempDir::new().unwrap();
-        let cfg = write_valid_config(dir.path());
-        let result = evaluate_validate_gate(&cfg, false);
-        assert!(result.passed, "gate failed: {}", result.message);
-        assert_eq!(result.gate_type, "validate");
-    }
-
-    #[test]
-    fn validate_gate_fails() {
-        let dir = TempDir::new().unwrap();
-        let cfg = dir.path().join("forjar.yaml");
-        std::fs::write(&cfg, "invalid: yaml: [").unwrap();
-        let result = evaluate_validate_gate(&cfg, false);
-        assert!(!result.passed);
-    }
-
-    #[test]
-    fn policy_gate_no_policies() {
-        let dir = TempDir::new().unwrap();
-        let cfg = write_valid_config(dir.path());
-        let result = evaluate_policy_gate(&cfg);
-        assert!(result.passed);
-    }
-
-    #[test]
-    fn script_gate_passes() {
-        let result = evaluate_script_gate("true");
-        assert!(result.passed);
-        assert_eq!(result.gate_type, "script");
-    }
-
-    #[test]
-    fn script_gate_fails() {
-        let result = evaluate_script_gate("false");
-        assert!(!result.passed);
-    }
-
-    #[test]
-    fn coverage_gate_advisory_no_tool() {
-        fn no_tool() -> Option<String> {
-            None
-        }
-        let result = evaluate_coverage_gate_inner(95, no_tool);
-        assert!(result.passed);
-        assert!(result.message.contains("95%"));
-        assert!(result.message.contains("advisory"));
-    }
-
-    #[test]
-    fn coverage_gate_passes_threshold() {
-        fn mock_output() -> Option<String> {
-            Some("  TOTAL                          1234   1111   96.5%\n".into())
-        }
-        let result = evaluate_coverage_gate_inner(95, mock_output);
-        assert!(result.passed);
-        assert!(result.message.contains("96.5%"));
-    }
-
-    #[test]
-    fn coverage_gate_fails_threshold() {
-        fn mock_output() -> Option<String> {
-            Some("  TOTAL                          1234   900   72.9%\n".into())
-        }
-        let result = evaluate_coverage_gate_inner(95, mock_output);
-        assert!(!result.passed);
-        assert!(result.message.contains("72.9%"));
-        assert!(result.message.contains("95%"));
-    }
-
-    #[test]
-    fn parse_coverage_from_llvm_output() {
-        let output = r#"
-Filename                      Regions    Missed Regions     Cover   Functions  Missed Functions  Executed       Lines      Missed Lines     Cover    Branches   Missed Branches     Cover
----
-  TOTAL                          5432           432    92.0%        1234            56    95.5%       18234          912    95.0%         0             0         -
-"#;
-        let pct = parse_coverage_from_output(output);
-        assert!(pct.is_some());
-        // Last percentage on TOTAL line
-    }
-
-    #[test]
-    fn parse_coverage_no_total_line() {
-        let pct = parse_coverage_from_output("no total here\n");
-        assert!(pct.is_none());
-    }
-
-    #[test]
-    fn evaluate_all_gates() {
-        let dir = TempDir::new().unwrap();
-        let cfg = write_valid_config(dir.path());
-        let promotion = PromotionConfig {
-            from: "dev".into(),
-            gates: vec![
-                PromotionGate {
-                    validate: Some(ValidateGateOptions {
-                        deep: false,
-                        exhaustive: false,
-                    }),
-                    ..Default::default()
-                },
-                PromotionGate {
-                    script: Some("true".into()),
-                    ..Default::default()
-                },
-            ],
-            auto_approve: false,
-            rollout: None,
-        };
-
-        let result = evaluate_gates(&cfg, "staging", &promotion);
-        assert_eq!(result.from, "dev");
-        assert_eq!(result.to, "staging");
-        assert_eq!(result.gates.len(), 2);
-        assert!(result.all_passed);
-        assert_eq!(result.passed_count(), 2);
-        assert_eq!(result.failed_count(), 0);
-    }
-
-    #[test]
-    fn evaluate_gates_with_failure() {
-        let dir = TempDir::new().unwrap();
-        let cfg = write_valid_config(dir.path());
-        let promotion = PromotionConfig {
-            from: "dev".into(),
-            gates: vec![
-                PromotionGate {
-                    validate: Some(ValidateGateOptions {
-                        deep: false,
-                        exhaustive: false,
-                    }),
-                    ..Default::default()
-                },
-                PromotionGate {
-                    script: Some("false".into()),
-                    ..Default::default()
-                },
-            ],
-            auto_approve: true,
-            rollout: None,
-        };
-
-        let result = evaluate_gates(&cfg, "prod", &promotion);
-        assert!(!result.all_passed);
-        assert_eq!(result.failed_count(), 1);
-        assert!(result.auto_approve);
-    }
-
-    #[test]
-    fn unknown_gate_type() {
-        let dir = TempDir::new().unwrap();
-        let cfg = write_valid_config(dir.path());
-        let result = evaluate_single_gate(&cfg, &PromotionGate::default());
-        assert!(!result.passed);
-        assert_eq!(result.gate_type, "unknown");
-    }
-}
+#[path = "promotion_tests.rs"]
+mod tests;

--- a/src/core/promotion_tests.rs
+++ b/src/core/promotion_tests.rs
@@ -1,0 +1,262 @@
+//! Tests for FJ-3505 promotion gate evaluation (split from promotion.rs to
+//! keep that file under the 500-line health limit). Declared as a `#[path]`
+//! child `mod tests` of `promotion` so it sees the private gate helpers.
+use super::*;
+use crate::core::types::environment::*;
+use tempfile::TempDir;
+
+fn write_valid_config(dir: &Path) -> std::path::PathBuf {
+    let path = dir.join("forjar.yaml");
+    std::fs::write(
+        &path,
+        r#"
+version: "1.0"
+name: test
+machines:
+  m1:
+    hostname: m1
+    addr: 127.0.0.1
+resources:
+  pkg:
+    type: package
+    machine: m1
+    provider: apt
+    packages: [curl]
+"#,
+    )
+    .unwrap();
+    path
+}
+
+#[test]
+fn validate_gate_passes() {
+    let dir = TempDir::new().unwrap();
+    let cfg = write_valid_config(dir.path());
+    let result = evaluate_validate_gate(&cfg, false);
+    assert!(result.passed, "gate failed: {}", result.message);
+    assert_eq!(result.gate_type, "validate");
+}
+
+#[test]
+fn validate_gate_fails() {
+    let dir = TempDir::new().unwrap();
+    let cfg = dir.path().join("forjar.yaml");
+    std::fs::write(&cfg, "invalid: yaml: [").unwrap();
+    let result = evaluate_validate_gate(&cfg, false);
+    assert!(!result.passed);
+}
+
+#[test]
+fn policy_gate_no_policies() {
+    let dir = TempDir::new().unwrap();
+    let cfg = write_valid_config(dir.path());
+    let result = evaluate_policy_gate(&cfg);
+    assert!(result.passed);
+}
+
+#[test]
+fn script_gate_passes() {
+    let result = evaluate_script_gate("true");
+    assert!(result.passed);
+    assert_eq!(result.gate_type, "script");
+}
+
+#[test]
+fn script_gate_fails() {
+    let result = evaluate_script_gate("false");
+    assert!(!result.passed);
+}
+
+#[test]
+fn coverage_gate_advisory_no_tool() {
+    fn no_tool() -> CovProbe {
+        CovProbe::Unavailable
+    }
+    let result = evaluate_coverage_gate_inner(95, no_tool);
+    assert!(result.passed);
+    assert!(result.message.contains("95%"));
+    assert!(result.message.contains("advisory"));
+}
+
+#[test]
+fn coverage_gate_passes_threshold() {
+    fn mock_output() -> CovProbe {
+        CovProbe::Ran("  TOTAL                          1234   1111   96.5%\n".into())
+    }
+    let result = evaluate_coverage_gate_inner(95, mock_output);
+    assert!(result.passed);
+    assert!(result.message.contains("96.5%"));
+}
+
+#[test]
+fn coverage_gate_fails_threshold() {
+    fn mock_output() -> CovProbe {
+        CovProbe::Ran("  TOTAL                          1234   900   72.9%\n".into())
+    }
+    let result = evaluate_coverage_gate_inner(95, mock_output);
+    assert!(!result.passed);
+    assert!(result.message.contains("72.9%"));
+    assert!(result.message.contains("95%"));
+}
+
+// Bug-hunt #5 (Refs #154): a present tool that exits non-zero (broken
+// build / failing tests) must FAIL the gate, not vacuously pass it.
+#[test]
+fn coverage_gate_fails_on_tool_nonzero_exit() {
+    fn tool_failed() -> CovProbe {
+        CovProbe::Failed { code: Some(101) }
+    }
+    let result = evaluate_coverage_gate_inner(95, tool_failed);
+    assert!(!result.passed, "broken build must not pass the gate");
+    assert!(result.message.contains("failed"));
+    assert!(result.message.contains("101"));
+}
+
+#[test]
+fn coverage_gate_fails_on_tool_signal() {
+    fn tool_signal() -> CovProbe {
+        CovProbe::Failed { code: None }
+    }
+    let result = evaluate_coverage_gate_inner(95, tool_signal);
+    assert!(!result.passed);
+    assert!(result.message.contains("signal"));
+}
+
+// The two None-causes are distinguished: spawn failure ⇒ Unavailable
+// (advisory), present-tool non-zero exit ⇒ Failed (gate failure).
+// Hermetic: no subprocess is spawned — the spawn-vs-exit decision lives in
+// the pure `classify_exit`, and the spawn-error arm is exercised with a
+// synthetic `io::Error` (no loopback shell, safe under proxied CI).
+#[test]
+fn classify_llvm_cov_spawn_error_is_unavailable() {
+    let err = Err(std::io::Error::new(
+        std::io::ErrorKind::NotFound,
+        "no such file",
+    ));
+    assert_eq!(classify_llvm_cov(err), CovProbe::Unavailable);
+}
+
+#[test]
+fn classify_exit_nonzero_is_failed() {
+    // Present tool exited non-zero (e.g. build/test failure).
+    assert_eq!(
+        classify_exit(false, Some(101), String::new()),
+        CovProbe::Failed { code: Some(101) }
+    );
+}
+
+#[test]
+fn classify_exit_signal_is_failed_no_code() {
+    // Terminated by signal: success=false, code=None.
+    assert_eq!(
+        classify_exit(false, None, String::new()),
+        CovProbe::Failed { code: None }
+    );
+}
+
+#[test]
+fn classify_exit_success_is_ran() {
+    match classify_exit(true, Some(0), "TOTAL 99.0%".into()) {
+        CovProbe::Ran(s) => assert!(s.contains("TOTAL")),
+        other => panic!("expected Ran, got {other:?}"),
+    }
+}
+
+// Tool ran cleanly but produced no parseable TOTAL ⇒ advisory pass.
+#[test]
+fn coverage_gate_advisory_when_ran_but_unparseable() {
+    fn ran_no_total() -> CovProbe {
+        CovProbe::Ran("no coverage data here\n".into())
+    }
+    let result = evaluate_coverage_gate_inner(95, ran_no_total);
+    assert!(result.passed);
+    assert!(result.message.contains("advisory"));
+}
+
+#[test]
+fn parse_coverage_from_llvm_output() {
+    let output = r#"
+Filename                      Regions    Missed Regions     Cover   Functions  Missed Functions  Executed       Lines      Missed Lines     Cover    Branches   Missed Branches     Cover
+---
+  TOTAL                          5432           432    92.0%        1234            56    95.5%       18234          912    95.0%         0             0         -
+"#;
+    let pct = parse_coverage_from_output(output);
+    assert!(pct.is_some());
+    // Last percentage on TOTAL line
+}
+
+#[test]
+fn parse_coverage_no_total_line() {
+    let pct = parse_coverage_from_output("no total here\n");
+    assert!(pct.is_none());
+}
+
+#[test]
+fn evaluate_all_gates() {
+    let dir = TempDir::new().unwrap();
+    let cfg = write_valid_config(dir.path());
+    let promotion = PromotionConfig {
+        from: "dev".into(),
+        gates: vec![
+            PromotionGate {
+                validate: Some(ValidateGateOptions {
+                    deep: false,
+                    exhaustive: false,
+                }),
+                ..Default::default()
+            },
+            PromotionGate {
+                script: Some("true".into()),
+                ..Default::default()
+            },
+        ],
+        auto_approve: false,
+        rollout: None,
+    };
+
+    let result = evaluate_gates(&cfg, "staging", &promotion);
+    assert_eq!(result.from, "dev");
+    assert_eq!(result.to, "staging");
+    assert_eq!(result.gates.len(), 2);
+    assert!(result.all_passed);
+    assert_eq!(result.passed_count(), 2);
+    assert_eq!(result.failed_count(), 0);
+}
+
+#[test]
+fn evaluate_gates_with_failure() {
+    let dir = TempDir::new().unwrap();
+    let cfg = write_valid_config(dir.path());
+    let promotion = PromotionConfig {
+        from: "dev".into(),
+        gates: vec![
+            PromotionGate {
+                validate: Some(ValidateGateOptions {
+                    deep: false,
+                    exhaustive: false,
+                }),
+                ..Default::default()
+            },
+            PromotionGate {
+                script: Some("false".into()),
+                ..Default::default()
+            },
+        ],
+        auto_approve: true,
+        rollout: None,
+    };
+
+    let result = evaluate_gates(&cfg, "prod", &promotion);
+    assert!(!result.all_passed);
+    assert_eq!(result.failed_count(), 1);
+    assert!(result.auto_approve);
+}
+
+#[test]
+fn unknown_gate_type() {
+    let dir = TempDir::new().unwrap();
+    let cfg = write_valid_config(dir.path());
+    let result = evaluate_single_gate(&cfg, &PromotionGate::default());
+    assert!(!result.passed);
+    assert_eq!(result.gate_type, "unknown");
+}

--- a/src/core/store/mod.rs
+++ b/src/core/store/mod.rs
@@ -42,6 +42,7 @@ pub mod purity;
 pub mod query;
 pub mod reference;
 pub mod registry_push;
+pub mod registry_push_fmt;
 pub mod repro_score;
 pub mod sandbox;
 pub mod sandbox_exec;

--- a/src/core/store/registry_push.rs
+++ b/src/core/store/registry_push.rs
@@ -71,17 +71,19 @@ pub fn upload_initiate_command(registry: &str, name: &str) -> String {
 }
 
 /// Generate the curl command for completing a blob upload.
+/// `--fail-with-body`: see [`monolithic_put_args`] (Bug-hunt #4, Refs #154).
 pub fn upload_complete_command(upload_url: &str, digest: &str, blob_path: &str) -> String {
     format!(
-        "curl -s -X PUT -H 'Content-Type: application/octet-stream' \
+        "curl -s --fail-with-body -X PUT -H 'Content-Type: application/octet-stream' \
          --data-binary '@{blob_path}' '{upload_url}?digest={digest}'"
     )
 }
 
 /// Generate the curl command for pushing a manifest.
+/// `--fail-with-body`: see [`manifest_put_args`] (Bug-hunt #4, Refs #154).
 pub fn manifest_put_command(registry: &str, name: &str, tag: &str, manifest_path: &str) -> String {
     format!(
-        "curl -s -X PUT -H 'Content-Type: application/vnd.oci.image.manifest.v1+json' \
+        "curl -s --fail-with-body -X PUT -H 'Content-Type: application/vnd.oci.image.manifest.v1+json' \
          --data-binary '@{manifest_path}' 'https://{registry}/v2/{name}/manifests/{tag}'"
     )
 }
@@ -152,30 +154,56 @@ fn initiate_upload(registry: &str, name: &str) -> Result<String, String> {
         .ok_or_else(|| "no Location header in upload response".to_string())
 }
 
+/// Build the curl argv for a monolithic blob PUT. Bug-hunt #4 (Refs #154):
+/// `--fail-with-body` makes curl exit non-zero on HTTP >= 400 (401/404/413/5xx)
+/// — without it a failed PUT was reported as a successful push while the
+/// registry stored nothing. Extracted so the flag is unit-testable (no network).
+pub(crate) fn monolithic_put_args(upload_url: &str, digest: &str, blob_path: &str) -> Vec<String> {
+    vec![
+        "-s".into(),
+        "--fail-with-body".into(),
+        "-X".into(),
+        "PUT".into(),
+        "-H".into(),
+        "Content-Type: application/octet-stream".into(),
+        "--data-binary".into(),
+        format!("@{blob_path}"),
+        format!("{upload_url}?digest={digest}"),
+    ]
+}
+
 /// Monolithic PUT upload for small blobs (< 64 MB).
 fn push_blob_monolithic(upload_url: &str, blob: &BlobDescriptor) -> Result<(), String> {
     let blob_path = blob.path.display().to_string();
+    let args = monolithic_put_args(upload_url, &blob.digest, &blob_path);
     let output = std::process::Command::new("curl")
-        .args([
-            "-s",
-            "-X",
-            "PUT",
-            "-H",
-            "Content-Type: application/octet-stream",
-            "--data-binary",
-            &format!("@{blob_path}"),
-            &format!("{upload_url}?digest={}", blob.digest),
-        ])
+        .args(&args)
         .output()
         .map_err(|e| format!("blob upload complete: {e}"))?;
 
     if !output.status.success() {
         return Err(format!(
-            "blob upload failed: {}",
-            String::from_utf8_lossy(&output.stderr)
+            "blob upload failed (HTTP error): {}",
+            curl_error_detail(&output)
         ));
     }
     Ok(())
+}
+
+/// Compose curl failure detail. With `--fail-with-body` curl prints the HTTP
+/// response body to stdout on a >= 400 status; stderr carries transport-level
+/// diagnostics. Surface both so the registry error (401 token, 413, …) shows.
+fn curl_error_detail(output: &std::process::Output) -> String {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let body = stdout.trim();
+    let err = stderr.trim();
+    match (body.is_empty(), err.is_empty()) {
+        (false, false) => format!("{err}: {body}"),
+        (false, true) => body.to_string(),
+        (true, false) => err.to_string(),
+        (true, true) => "no response body".to_string(),
+    }
 }
 
 /// E14: Chunked PATCH upload for large blobs (>= 64 MB).
@@ -196,6 +224,7 @@ pub(crate) fn push_blob_chunked(upload_url: &str, blob: &BlobDescriptor) -> Resu
         let output = std::process::Command::new("curl")
             .args([
                 "-s",
+                "--fail-with-body", // Bug-hunt #4 (Refs #154): gate on HTTP status.
                 "-X",
                 "PATCH",
                 "-D",
@@ -217,8 +246,8 @@ pub(crate) fn push_blob_chunked(upload_url: &str, blob: &BlobDescriptor) -> Resu
 
         if !output.status.success() {
             return Err(format!(
-                "chunked upload failed at range {range}: {}",
-                String::from_utf8_lossy(&output.stderr)
+                "chunked upload failed at range {range} (HTTP error): {}",
+                curl_error_detail(&output)
             ));
         }
 
@@ -235,6 +264,7 @@ pub(crate) fn push_blob_chunked(upload_url: &str, blob: &BlobDescriptor) -> Resu
     let output = std::process::Command::new("curl")
         .args([
             "-s",
+            "--fail-with-body", // Bug-hunt #4 (Refs #154): gate on HTTP status.
             "-X",
             "PUT",
             "-H",
@@ -246,11 +276,28 @@ pub(crate) fn push_blob_chunked(upload_url: &str, blob: &BlobDescriptor) -> Resu
 
     if !output.status.success() {
         return Err(format!(
-            "chunked upload finalize failed: {}",
-            String::from_utf8_lossy(&output.stderr)
+            "chunked upload finalize failed (HTTP error): {}",
+            curl_error_detail(&output)
         ));
     }
     Ok(())
+}
+
+/// Build the curl argv for a manifest PUT. `--fail-with-body`: see
+/// [`monolithic_put_args`] (Bug-hunt #4, Refs #154) — the manifest PUT is the
+/// final, release-critical step, so a silent 401/404/5xx here is the worst case.
+pub(crate) fn manifest_put_args(manifest_json: &str, url: &str) -> Vec<String> {
+    vec![
+        "-s".into(),
+        "--fail-with-body".into(),
+        "-X".into(),
+        "PUT".into(),
+        "-H".into(),
+        "Content-Type: application/vnd.oci.image.manifest.v1+json".into(),
+        "-d".into(),
+        manifest_json.into(),
+        url.into(),
+    ]
 }
 
 /// Push a manifest to the registry.
@@ -263,27 +310,20 @@ pub fn push_manifest(
 ) -> Result<PushResult, String> {
     let start = Instant::now();
 
+    let url = format!(
+        "https://{}/v2/{}/manifests/{}",
+        config.registry, config.name, config.tag
+    );
+    let args = manifest_put_args(manifest_json, &url);
     let output = std::process::Command::new("curl")
-        .args([
-            "-s",
-            "-X",
-            "PUT",
-            "-H",
-            "Content-Type: application/vnd.oci.image.manifest.v1+json",
-            "-d",
-            manifest_json,
-            &format!(
-                "https://{}/v2/{}/manifests/{}",
-                config.registry, config.name, config.tag
-            ),
-        ])
+        .args(&args)
         .output()
         .map_err(|e| format!("manifest push: {e}"))?;
 
     if !output.status.success() {
         return Err(format!(
-            "manifest push failed: {}",
-            String::from_utf8_lossy(&output.stderr)
+            "manifest push failed (HTTP error): {}",
+            curl_error_detail(&output)
         ));
     }
 
@@ -422,59 +462,7 @@ pub(crate) fn parse_location_header(headers: &str) -> Option<String> {
     None
 }
 
-/// Validate a registry push config.
-pub fn validate_push_config(config: &RegistryPushConfig) -> Vec<String> {
-    let mut errors = Vec::new();
-    if config.registry.is_empty() {
-        errors.push("registry hostname is required".into());
-    }
-    if config.name.is_empty() {
-        errors.push("image name is required".into());
-    }
-    if config.tag.is_empty() {
-        errors.push("image tag is required".into());
-    }
-    if config.registry.contains("://") {
-        errors.push("registry should be hostname only, not a URL".into());
-    }
-    errors
-}
-
-/// Format a push summary for CLI output.
-pub fn format_push_summary(results: &[PushResult]) -> String {
-    let mut out = String::new();
-    let uploaded: Vec<_> = results.iter().filter(|r| !r.existed).collect();
-    let skipped: Vec<_> = results.iter().filter(|r| r.existed).collect();
-
-    out.push_str(&format!(
-        "Push complete: {} uploaded, {} skipped (already exist)\n",
-        uploaded.len(),
-        skipped.len(),
-    ));
-
-    let total_bytes: u64 = uploaded.iter().map(|r| r.size).sum();
-    let total_secs: f64 = uploaded.iter().map(|r| r.duration_secs).sum();
-    if !uploaded.is_empty() {
-        out.push_str(&format!(
-            "  Uploaded {:.1} MB in {:.1}s\n",
-            total_bytes as f64 / (1024.0 * 1024.0),
-            total_secs,
-        ));
-    }
-
-    for r in results {
-        let status = if r.existed { "skip" } else { "push" };
-        let kind = match r.kind {
-            PushKind::Layer => "layer",
-            PushKind::Config => "config",
-            PushKind::Manifest => "manifest",
-            PushKind::Index => "index",
-        };
-        out.push_str(&format!(
-            "  [{status}] {kind}: {} ({} bytes)\n",
-            r.digest, r.size
-        ));
-    }
-
-    out
-}
+// `validate_push_config` and `format_push_summary` live in `registry_push_fmt`
+// (split out to keep this file under the 500-line health limit). Re-exported so
+// existing `super::registry_push::*` callers keep working unchanged.
+pub use super::registry_push_fmt::{format_push_summary, validate_push_config};

--- a/src/core/store/registry_push_fmt.rs
+++ b/src/core/store/registry_push_fmt.rs
@@ -1,0 +1,64 @@
+//! FJ-2105: Registry-push config validation and CLI summary formatting.
+//!
+//! Split out of `registry_push.rs` to keep that file under the 500-line health
+//! limit; pure (no I/O, no network), so trivially unit-testable.
+
+use super::registry_push::RegistryPushConfig;
+use crate::core::types::{PushKind, PushResult};
+
+/// Validate a registry push config.
+pub fn validate_push_config(config: &RegistryPushConfig) -> Vec<String> {
+    let mut errors = Vec::new();
+    if config.registry.is_empty() {
+        errors.push("registry hostname is required".into());
+    }
+    if config.name.is_empty() {
+        errors.push("image name is required".into());
+    }
+    if config.tag.is_empty() {
+        errors.push("image tag is required".into());
+    }
+    if config.registry.contains("://") {
+        errors.push("registry should be hostname only, not a URL".into());
+    }
+    errors
+}
+
+/// Format a push summary for CLI output.
+pub fn format_push_summary(results: &[PushResult]) -> String {
+    let mut out = String::new();
+    let uploaded: Vec<_> = results.iter().filter(|r| !r.existed).collect();
+    let skipped: Vec<_> = results.iter().filter(|r| r.existed).collect();
+
+    out.push_str(&format!(
+        "Push complete: {} uploaded, {} skipped (already exist)\n",
+        uploaded.len(),
+        skipped.len(),
+    ));
+
+    let total_bytes: u64 = uploaded.iter().map(|r| r.size).sum();
+    let total_secs: f64 = uploaded.iter().map(|r| r.duration_secs).sum();
+    if !uploaded.is_empty() {
+        out.push_str(&format!(
+            "  Uploaded {:.1} MB in {:.1}s\n",
+            total_bytes as f64 / (1024.0 * 1024.0),
+            total_secs,
+        ));
+    }
+
+    for r in results {
+        let status = if r.existed { "skip" } else { "push" };
+        let kind = match r.kind {
+            PushKind::Layer => "layer",
+            PushKind::Config => "config",
+            PushKind::Manifest => "manifest",
+            PushKind::Index => "index",
+        };
+        out.push_str(&format!(
+            "  [{status}] {kind}: {} ({} bytes)\n",
+            r.digest, r.size
+        ));
+    }
+
+    out
+}

--- a/src/core/store/tests_registry_push.rs
+++ b/src/core/store/tests_registry_push.rs
@@ -102,6 +102,73 @@ fn manifest_put_command_format() {
     assert!(cmd.contains("@/tmp/manifest.json"));
 }
 
+// Bug-hunt #4 (Refs #154): each push curl must gate on HTTP status, not just
+// the process exit code. `--fail-with-body` makes curl exit non-zero on HTTP
+// >= 400 (401/404/413/5xx) so a failed push is no longer reported as success.
+// Hermetic: asserts the generated command string only — no registry is hit.
+#[test]
+fn blob_upload_command_fails_on_http_error() {
+    let cmd = upload_complete_command(
+        "https://docker.io/v2/library/alpine/blobs/uploads/uuid-123",
+        "sha256:abc",
+        "/tmp/layer.tar.gz",
+    );
+    assert!(
+        cmd.contains("--fail-with-body"),
+        "blob upload PUT must use --fail-with-body to surface HTTP errors: {cmd}"
+    );
+}
+
+#[test]
+fn manifest_put_command_fails_on_http_error() {
+    let cmd = manifest_put_command("ghcr.io", "myorg/app", "v1.0", "/tmp/manifest.json");
+    assert!(
+        cmd.contains("--fail-with-body"),
+        "manifest PUT must use --fail-with-body to surface HTTP errors: {cmd}"
+    );
+}
+
+// The HEAD existence check intentionally does NOT use --fail-with-body: it
+// reads the http_code itself (a 404 is a normal "blob absent" answer, not an
+// error). Guard against accidentally breaking it.
+#[test]
+fn head_check_command_does_not_fail_on_404() {
+    let cmd = head_check_command("ghcr.io", "myorg/app", "sha256:abc123");
+    assert!(!cmd.contains("--fail"));
+    assert!(cmd.contains("%{http_code}"));
+}
+
+// Bug-hunt #4 (Refs #154): assert the *actual* argv used by the push functions
+// (push_blob_monolithic / push_manifest) carries --fail-with-body, so a
+// regression in the real code path — not just the doc-string builder — is
+// caught. Hermetic: only the argv vector is inspected, no curl is run.
+#[test]
+fn monolithic_put_argv_uses_fail_with_body() {
+    let args = monolithic_put_args(
+        "https://docker.io/v2/library/alpine/blobs/uploads/uuid-123",
+        "sha256:abc",
+        "/tmp/layer.tar.gz",
+    );
+    assert!(args.iter().any(|a| a == "--fail-with-body"));
+    assert!(args.iter().any(|a| a == "PUT"));
+    assert!(args.iter().any(|a| a.contains("digest=sha256:abc")));
+    assert!(args.iter().any(|a| a == "@/tmp/layer.tar.gz"));
+}
+
+#[test]
+fn manifest_put_argv_uses_fail_with_body() {
+    let args = manifest_put_args(
+        r#"{"schemaVersion":2}"#,
+        "https://ghcr.io/v2/myorg/app/manifests/v1.0",
+    );
+    assert!(args.iter().any(|a| a == "--fail-with-body"));
+    assert!(args.iter().any(|a| a == "PUT"));
+    assert!(args
+        .iter()
+        .any(|a| a.contains("application/vnd.oci.image.manifest.v1+json")));
+    assert!(args.iter().any(|a| a.contains("/manifests/v1.0")));
+}
+
 #[test]
 fn parse_location_header_found() {
     let headers = "HTTP/1.1 202 Accepted\r\n\


### PR DESCRIPTION
Fixes three APPLY SUCCESS-MASKING defects (bug-hunt #3, #4, #5) for v1.5.1. Refs #154.

Each defect made `forjar` report success on a real failure on a release-critical path.

## #3 (HIGH) pre_apply hook failure reported as Skipped — `src/core/executor/resource_ops.rs`
When a resource's `pre_apply:` hook failed, `execute_resource` recorded a `Failed` lock + event but then `return Ok(ResourceOutcome::Skipped)`, discarding `record_failure`'s `should_stop`. In the sequential / single-resource-wave path, `Skipped` is a no-op in `MachineCounters::record`, so `counters.failed` stayed `0` ⇒ apply exited `0` reporting success, generation rollback was skipped, and dependents ran as if the prerequisite had succeeded. (The parallel-wave path already handled it.)

**Fix:** return `ResourceOutcome::Failed { should_stop }` (propagating `should_stop` from `record_failure`), matching the `post_apply` branch and the wave path. The failed resource is now counted, dependents cascade-skip (FJ-63), and rollback fires.

## #4 (HIGH) OCI registry push gated only on curl exit — `src/core/store/registry_push.rs`
`push_blob_monolithic` (PUT), `push_blob_chunked` (PATCH + PUT finalize), and `push_manifest` (PUT) ran `curl -s` and gated only on `output.status.success()`. curl exits `0` on HTTP `401/404/413/5xx`, so a failed push was reported successful while the registry stored nothing (a later pull fails).

**Fix:** add `--fail-with-body` to each push curl (curl now exits non-zero on HTTP >= 400 while still printing the response body) and surface the status + body on failure. `check_blob_exists`, which already reads `%{http_code}` itself (a 404 is a normal "blob absent" answer), is left untouched. The monolithic / manifest PUT argv was extracted into pure `monolithic_put_args` / `manifest_put_args` builders so the flag is unit-testable without a registry.

## #5 (medium) Coverage promotion gate passes vacuously on tool failure — `src/core/promotion.rs`
`run_llvm_cov` returned `None` both when the binary was MISSING and when it RAN but exited non-zero (build/test failure); `evaluate_coverage_gate_inner` mapped any `None` to `passed: true` advisory ⇒ a broken build passed the gate.

**Fix:** distinguish the two via `enum CovProbe { Unavailable, Ran(String), Failed { code } }` with a pure `classify_exit` helper. Spawn failure / ENOENT ⇒ `Unavailable` (advisory pass); a present tool exiting non-zero ⇒ `Failed` (gate failure). A clean run with no parseable `TOTAL` stays advisory.

## Tests (deterministic, hermetic — no real network/registry/llvm-cov, no loopback shell spawns)
- **#3:** `test_fj265_pre_apply_failure_counts_as_failed` (sequential path, `resources_failed == 1`, main script never ran) and `test_fj265_pre_apply_failure_cascades_to_dependents` (`resources_failed == 2`, dependent does NOT run). Local `bash` transport + tempdir state (no loopback TCP).
- **#4:** assert the `monolithic_put_args` / `manifest_put_args` argv and the doc-string builders contain `--fail-with-body`; guard that the HEAD check does NOT (it reads `%{http_code}`).
- **#5:** unit-test `classify_exit` (the two None-causes are distinguished) and the gate-failure / advisory mappings, with no subprocess spawned.

## Housekeeping
Split promotion tests into `promotion_tests.rs` (`#[path]` child module) and registry-push fmt helpers into `registry_push_fmt.rs` to keep both files under the 500-line health limit.

Full `cargo test --lib`: 12269 passed, 0 failed. `cargo clippy --all-targets -D warnings` clean. `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)