### PR TITLE
fix(store): validate blob digests, atomic state-encryption writes, refresh lock sidecar on defrag (Refs #154)

### DIFF
--- a/src/cli/lock_lifecycle.rs
+++ b/src/cli/lock_lifecycle.rs
@@ -129,6 +129,17 @@ pub(crate) fn cmd_lock_snapshot(state_dir: &Path, json: bool) -> Result<(), Stri
     Ok(())
 }
 
+/// Atomically rewrite a lock file (temp + rename) and refresh its BLAKE3 `.b3`
+/// integrity sidecar so the next `forjar apply` integrity check passes.
+fn write_lock_and_sidecar(lock_path: &Path, content: &str) -> Result<(), String> {
+    let tmp_path = lock_path.with_extension("yaml.tmp");
+    std::fs::write(&tmp_path, content).map_err(|e| format!("Failed to write lock: {e}"))?;
+    std::fs::rename(&tmp_path, lock_path)
+        .map_err(|e| format!("Failed to rename lock into place: {e}"))?;
+    crate::core::state::integrity::write_b3_sidecar(lock_path)
+        .map_err(|e| format!("Failed to refresh integrity sidecar: {e}"))
+}
+
 /// FJ-575: Defragment lock files (reorder resources alphabetically).
 pub(crate) fn cmd_lock_defrag(state_dir: &Path, json: bool) -> Result<(), String> {
     let machines = discover_machines(state_dir);
@@ -155,8 +166,12 @@ pub(crate) fn cmd_lock_defrag(state_dir: &Path, json: bool) -> Result<(), String
 
             let new_content = serde_yaml_ng::to_string(&lock)
                 .map_err(|e| format!("Failed to serialize lock: {e}"))?;
-            std::fs::write(&lock_path, &new_content)
-                .map_err(|e| format!("Failed to write lock: {e}"))?;
+            // FJ-154 (#20): a raw `std::fs::write` here left the BLAKE3 `.b3`
+            // sidecar holding the pre-defrag hash, so the next `forjar apply`
+            // hard-failed its integrity check and effectively bricked the stack
+            // until a manual reseal. Write atomically and refresh the sidecar
+            // (mirrors state::save_lock / reseal) so defrag → apply round-trips.
+            write_lock_and_sidecar(&lock_path, &new_content)?;
             defragged += 1;
         }
     }
@@ -169,4 +184,76 @@ pub(crate) fn cmd_lock_defrag(state_dir: &Path, json: bool) -> Result<(), String
         println!("Defragmented {defragged} lock files (resources reordered alphabetically)");
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::state::integrity;
+
+    /// A minimal valid `StateLock` YAML with resources deliberately out of
+    /// alphabetical order (`zebra` before `alpha`) so defrag actually rewrites.
+    fn sample_lock_yaml() -> String {
+        "\
+schema: v1
+machine: testbox
+hostname: testbox
+generated_at: '2026-06-13T00:00:00Z'
+generator: forjar-test
+blake3_version: '1'
+resources:
+  zebra:
+    type: package
+    status: converged
+    hash: aaaa
+    details: {}
+  alpha:
+    type: file
+    status: converged
+    hash: bbbb
+    details: {}
+"
+        .to_string()
+    }
+
+    #[test]
+    fn defrag_refreshes_b3_sidecar_so_integrity_passes() {
+        let state_dir = tempfile::tempdir().unwrap();
+        let machine_dir = state_dir.path().join("testbox");
+        std::fs::create_dir_all(&machine_dir).unwrap();
+        let lock_path = machine_dir.join("state.lock.yaml");
+        std::fs::write(&lock_path, sample_lock_yaml()).unwrap();
+
+        // Write a STALE sidecar (hash of unrelated content). Before the fix,
+        // defrag's raw write left this stale, so the next apply hard-failed.
+        let sidecar = {
+            let mut p = lock_path.as_os_str().to_owned();
+            p.push(".b3");
+            std::path::PathBuf::from(p)
+        };
+        std::fs::write(&sidecar, blake3::hash(b"stale").to_hex().as_str()).unwrap();
+
+        cmd_lock_defrag(state_dir.path(), true).unwrap();
+
+        // The sidecar now matches the rewritten lock contents.
+        let rewritten = std::fs::read(&lock_path).unwrap();
+        let expected = blake3::hash(&rewritten).to_hex().to_string();
+        let on_disk = std::fs::read_to_string(&sidecar).unwrap();
+        assert_eq!(on_disk.trim(), expected);
+
+        // And the full integrity check (what apply runs) reports no errors.
+        let results = integrity::verify_state_integrity(state_dir.path());
+        assert!(
+            !integrity::has_errors(&results),
+            "defrag → apply integrity check should pass, got {results:?}"
+        );
+
+        // Resources were actually reordered (alpha before zebra) and no temp
+        // file was left behind.
+        let content = String::from_utf8(rewritten).unwrap();
+        let alpha = content.find("alpha").unwrap();
+        let zebra = content.find("zebra").unwrap();
+        assert!(alpha < zebra, "resources should be sorted alphabetically");
+        assert!(!lock_path.with_extension("yaml.tmp").exists());
+    }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -81,6 +81,8 @@ mod tests_scoring_b;
 mod tests_secrets;
 #[cfg(test)]
 mod tests_security_scanner;
+#[cfg(all(test, feature = "encryption"))]
+mod tests_state_encryption_enc;
 #[cfg(test)]
 mod tests_watch_daemon;
 mod verus_spec;

--- a/src/core/state_encryption.rs
+++ b/src/core/state_encryption.rs
@@ -64,11 +64,28 @@ pub fn read_metadata(path: &Path) -> Result<EncryptionMeta, String> {
     serde_json::from_str(&content).map_err(|e| format!("parse metadata: {e}"))
 }
 
-/// Write encryption metadata to a sidecar file.
+/// Write encryption metadata to a sidecar file (atomically).
 pub fn write_metadata(path: &Path, meta: &EncryptionMeta) -> Result<(), String> {
     let meta_path = meta_path_for(path);
     let json = serde_json::to_string_pretty(meta).map_err(|e| format!("serialize: {e}"))?;
-    std::fs::write(&meta_path, json).map_err(|e| format!("write {}: {e}", meta_path.display()))
+    atomic_write(&meta_path, json.as_bytes())
+}
+
+/// Atomically replace the contents of `path`: write to a temp file in the same
+/// directory, then `fs::rename` into place.
+///
+/// `std::fs::write` truncates-then-writes, so a crash/SIGKILL/full-disk between
+/// truncate and the full write leaves a half-written file. For state lock files
+/// (and their encryption metadata) that corruption is unrecoverable, so we
+/// mirror the temp-write-then-rename pattern used by `state::save_lock` and
+/// `store::meta::write_meta`.
+fn atomic_write(path: &Path, bytes: &[u8]) -> Result<(), String> {
+    let mut tmp = path.as_os_str().to_owned();
+    tmp.push(".tmp");
+    let tmp_path = std::path::PathBuf::from(tmp);
+    std::fs::write(&tmp_path, bytes).map_err(|e| format!("write {}: {e}", tmp_path.display()))?;
+    std::fs::rename(&tmp_path, path)
+        .map_err(|e| format!("rename {} → {}: {e}", tmp_path.display(), path.display()))
 }
 
 /// Get the sidecar metadata file path for an encrypted file.
@@ -130,8 +147,12 @@ pub fn encrypt_state_file(path: &Path, passphrase: &str) -> Result<EncryptionMet
     let key = derive_key(passphrase);
     let meta = create_metadata(&plaintext, &ciphertext, &key);
 
-    std::fs::write(path, &ciphertext).map_err(|e| format!("write encrypted: {e}"))?;
+    // Write the metadata sidecar (atomically) BEFORE swapping the data file so
+    // a crash never leaves ciphertext on disk without matching metadata. Both
+    // writes use temp-file-then-rename, so the original lock is replaced by a
+    // single atomic rename rather than an in-place truncate-then-write.
     write_metadata(path, &meta)?;
+    atomic_write(path, &ciphertext)?;
 
     Ok(meta)
 }
@@ -153,9 +174,10 @@ pub fn decrypt_state_file(path: &Path, passphrase: &str) -> Result<Vec<u8>, Stri
         return Err(format!("plaintext hash mismatch for {}", path.display()));
     }
 
-    std::fs::write(path, &plaintext).map_err(|e| format!("write: {e}"))?;
-
-    // Remove metadata sidecar
+    // Atomically swap ciphertext for plaintext, then drop the now-stale sidecar.
+    // Removing the sidecar last means a crash before removal leaves the data and
+    // its metadata consistent (still readable as encrypted), never orphaned.
+    atomic_write(path, &plaintext)?;
     let _ = std::fs::remove_file(meta_path_for(path));
 
     Ok(plaintext)
@@ -386,102 +408,6 @@ mod tests {
     #[test]
     fn stub_decrypt_data_returns_error() {
         let result = decrypt_data(b"not valid", "pass");
-        assert!(result.is_err());
-    }
-}
-
-#[cfg(all(test, feature = "encryption"))]
-mod tests_encryption {
-    use super::*;
-
-    #[test]
-    fn encrypt_decrypt_roundtrip() {
-        let plaintext = b"hello world, this is state data!";
-        let passphrase = "test-passphrase-42";
-        let ciphertext = encrypt_data(plaintext, passphrase).unwrap();
-        assert_ne!(&ciphertext, &plaintext[..]);
-        assert!(ciphertext.len() > plaintext.len()); // age adds overhead
-        let decrypted = decrypt_data(&ciphertext, passphrase).unwrap();
-        assert_eq!(decrypted, plaintext);
-    }
-
-    #[test]
-    fn encrypt_decrypt_empty_data() {
-        let plaintext = b"";
-        let passphrase = "empty-test";
-        let ciphertext = encrypt_data(plaintext, passphrase).unwrap();
-        let decrypted = decrypt_data(&ciphertext, passphrase).unwrap();
-        assert_eq!(decrypted, plaintext);
-    }
-
-    #[test]
-    fn decrypt_wrong_passphrase() {
-        let plaintext = b"secret state data";
-        let ciphertext = encrypt_data(plaintext, "correct-pass").unwrap();
-        let result = decrypt_data(&ciphertext, "wrong-pass");
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn decrypt_corrupted_data() {
-        let result = decrypt_data(b"not valid age data", "pass");
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn encrypt_state_file_roundtrip() {
-        let dir = tempfile::tempdir().unwrap();
-        let file = dir.path().join("state.lock.yaml");
-        let original = "resources:\n  pkg:\n    state: converged\n";
-        std::fs::write(&file, original).unwrap();
-
-        let passphrase = "file-test-pass";
-
-        // Encrypt
-        let meta = encrypt_state_file(&file, passphrase).unwrap();
-        assert!(is_encrypted(&file));
-        assert_eq!(meta.version, 1);
-        assert_eq!(meta.plaintext_hash, hash_data(original.as_bytes()));
-
-        let encrypted_content = std::fs::read(&file).unwrap();
-        assert_ne!(encrypted_content, original.as_bytes());
-
-        // Decrypt
-        let plaintext = decrypt_state_file(&file, passphrase).unwrap();
-        assert_eq!(plaintext, original.as_bytes());
-        assert!(!is_encrypted(&file)); // sidecar removed
-    }
-
-    #[test]
-    fn encrypt_state_file_metadata_written() {
-        let dir = tempfile::tempdir().unwrap();
-        let file = dir.path().join("test.lock.yaml");
-        std::fs::write(&file, "data").unwrap();
-
-        let meta = encrypt_state_file(&file, "pass").unwrap();
-        let loaded = read_metadata(&file).unwrap();
-        assert_eq!(loaded.plaintext_hash, meta.plaintext_hash);
-        assert_eq!(loaded.ciphertext_hmac, meta.ciphertext_hmac);
-    }
-
-    #[test]
-    fn decrypt_state_file_wrong_passphrase() {
-        let dir = tempfile::tempdir().unwrap();
-        let file = dir.path().join("state.lock.yaml");
-        std::fs::write(&file, "secret").unwrap();
-
-        encrypt_state_file(&file, "right-pass").unwrap();
-        let result = decrypt_state_file(&file, "wrong-pass");
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn decrypt_state_file_missing_metadata() {
-        let dir = tempfile::tempdir().unwrap();
-        let file = dir.path().join("state.lock.yaml");
-        std::fs::write(&file, "data").unwrap();
-        // No metadata sidecar
-        let result = decrypt_state_file(&file, "pass");
         assert!(result.is_err());
     }
 }

--- a/src/core/store/base_image.rs
+++ b/src/core/store/base_image.rs
@@ -6,6 +6,33 @@
 use crate::core::types::{OciDescriptor, OciImageConfig, OciIndex, OciManifest};
 use std::path::Path;
 
+/// Validate that `digest` is a `sha256:`-prefixed lowercase 64-char hex digest
+/// and return the bare hex portion.
+///
+/// The OCI layout under `state/images/<image>` is populated from an externally
+/// pulled image (e.g. `skopeo copy`), so the digests inside `index.json` and the
+/// manifest are untrusted. Without validation a crafted digest such as
+/// `sha256:../../../../etc/passwd` would escape `blobs/sha256/` and cause an
+/// arbitrary file read (and, in `copy_base_blobs`, an arbitrary file write).
+///
+/// A strict `^[0-9a-f]{64}$` check rejects other algorithms, uppercase, wrong
+/// lengths, and any `/` or `.` path separators, so the returned hex is safe to
+/// join onto a path.
+fn validate_sha256_hex(digest: &str) -> Result<&str, String> {
+    let hex = digest
+        .strip_prefix("sha256:")
+        .ok_or_else(|| format!("unsupported digest algorithm: {digest}"))?;
+    if hex.len() == 64
+        && hex
+            .bytes()
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+    {
+        Ok(hex)
+    } else {
+        Err(format!("invalid sha256 digest: {digest}"))
+    }
+}
+
 /// Extracted base image information.
 #[derive(Debug, Clone)]
 pub struct BaseImageLayers {
@@ -81,9 +108,7 @@ pub fn extract_base_layers(layout_dir: &Path) -> Result<BaseImageLayers, String>
 
 /// Read a blob from the OCI layout's blobs directory.
 fn read_blob(layout_dir: &Path, digest: &str) -> Result<Vec<u8>, String> {
-    let hex = digest
-        .strip_prefix("sha256:")
-        .ok_or_else(|| format!("unsupported digest algorithm: {digest}"))?;
+    let hex = validate_sha256_hex(digest)?;
     let blob_path = layout_dir.join(format!("blobs/sha256/{hex}"));
     std::fs::read(&blob_path).map_err(|e| format!("read blob {digest}: {e}"))
 }
@@ -95,12 +120,11 @@ pub fn verify_base_blobs(layout_dir: &Path, layers: &BaseImageLayers) -> Vec<Str
     layers
         .layers
         .iter()
-        .filter(|layer| {
-            let hex = layer
-                .digest
-                .strip_prefix("sha256:")
-                .unwrap_or(&layer.digest);
-            !layout_dir.join(format!("blobs/sha256/{hex}")).exists()
+        .filter(|layer| match validate_sha256_hex(&layer.digest) {
+            // An invalid/traversal digest is treated as missing: it does not
+            // correspond to a legitimate blob inside `blobs/sha256/`.
+            Ok(hex) => !layout_dir.join(format!("blobs/sha256/{hex}")).exists(),
+            Err(_) => true,
         })
         .map(|layer| layer.digest.clone())
         .collect()
@@ -120,10 +144,7 @@ pub fn copy_base_blobs(
 
     let mut bytes_copied: u64 = 0;
     for layer in &layers.layers {
-        let hex = layer
-            .digest
-            .strip_prefix("sha256:")
-            .unwrap_or(&layer.digest);
+        let hex = validate_sha256_hex(&layer.digest)?;
         let dst_path = dst_blobs.join(hex);
         if dst_path.exists() {
             continue;
@@ -282,6 +303,84 @@ mod tests {
         assert!(info.contains("arm64/linux"));
         assert!(info.contains("2 layers"));
         assert!(info.contains("MB"));
+    }
+
+    #[test]
+    fn validate_sha256_hex_accepts_valid() {
+        let digest = format!("sha256:{CONFIG_HEX}");
+        assert_eq!(validate_sha256_hex(&digest).unwrap(), CONFIG_HEX);
+    }
+
+    #[test]
+    fn validate_sha256_hex_rejects_traversal() {
+        assert!(validate_sha256_hex("sha256:../../../../etc/passwd").is_err());
+    }
+
+    #[test]
+    fn validate_sha256_hex_rejects_wrong_algorithm() {
+        assert!(validate_sha256_hex(&format!("sha512:{CONFIG_HEX}")).is_err());
+        // No prefix at all.
+        assert!(validate_sha256_hex(CONFIG_HEX).is_err());
+    }
+
+    #[test]
+    fn validate_sha256_hex_rejects_uppercase() {
+        assert!(validate_sha256_hex(&format!("sha256:{}", CONFIG_HEX.to_uppercase())).is_err());
+    }
+
+    #[test]
+    fn validate_sha256_hex_rejects_wrong_length() {
+        assert!(validate_sha256_hex("sha256:abc123").is_err());
+        // 63 chars (one short).
+        assert!(validate_sha256_hex(&format!("sha256:{}", &CONFIG_HEX[..63])).is_err());
+        // 65 chars (one long).
+        assert!(validate_sha256_hex(&format!("sha256:{CONFIG_HEX}a")).is_err());
+    }
+
+    #[test]
+    fn read_blob_rejects_traversal_digest() {
+        let dir = tempfile::tempdir().unwrap();
+        create_test_layout(dir.path());
+        let result = read_blob(dir.path(), "sha256:../../../../etc/passwd");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("invalid sha256 digest"));
+    }
+
+    #[test]
+    fn extract_base_layers_rejects_traversal_manifest_digest() {
+        // A crafted index.json whose manifest digest escapes blobs/sha256/.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("blobs/sha256")).unwrap();
+        let index = OciIndex::single(OciDescriptor {
+            media_type: "application/vnd.oci.image.manifest.v1+json".into(),
+            digest: "sha256:../../../../etc/passwd".into(),
+            size: 0,
+            annotations: std::collections::HashMap::new(),
+        });
+        std::fs::write(
+            dir.path().join("index.json"),
+            serde_json::to_vec(&index).unwrap(),
+        )
+        .unwrap();
+        let result = extract_base_layers(dir.path());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("invalid sha256 digest"));
+    }
+
+    #[test]
+    fn copy_base_blobs_rejects_traversal_digest() {
+        let src = tempfile::tempdir().unwrap();
+        create_test_layout(src.path());
+        let mut layers = extract_base_layers(src.path()).unwrap();
+        // A malicious source layout supplies a layer digest with `..`.
+        layers.layers.push(OciDescriptor::gzip_layer(
+            "sha256:../../../../tmp/forjar-traversal-write".into(),
+            100,
+        ));
+        let dst = tempfile::tempdir().unwrap();
+        let result = copy_base_blobs(src.path(), dst.path(), &layers);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("invalid sha256 digest"));
     }
 
     #[test]

--- a/src/core/tests_state_encryption_enc.rs
+++ b/src/core/tests_state_encryption_enc.rs
@@ -1,0 +1,151 @@
+//! Encryption-gated tests for `state_encryption.rs` (feature = "encryption").
+//!
+//! Extracted to a sibling file to keep `state_encryption.rs` under the 500-line
+//! source-file limit.
+
+use super::state_encryption::*;
+
+#[test]
+fn encrypt_decrypt_roundtrip() {
+    let plaintext = b"hello world, this is state data!";
+    let passphrase = "test-passphrase-42";
+    let ciphertext = encrypt_data(plaintext, passphrase).unwrap();
+    assert_ne!(&ciphertext, &plaintext[..]);
+    assert!(ciphertext.len() > plaintext.len()); // age adds overhead
+    let decrypted = decrypt_data(&ciphertext, passphrase).unwrap();
+    assert_eq!(decrypted, plaintext);
+}
+
+#[test]
+fn encrypt_decrypt_empty_data() {
+    let plaintext = b"";
+    let passphrase = "empty-test";
+    let ciphertext = encrypt_data(plaintext, passphrase).unwrap();
+    let decrypted = decrypt_data(&ciphertext, passphrase).unwrap();
+    assert_eq!(decrypted, plaintext);
+}
+
+#[test]
+fn decrypt_wrong_passphrase() {
+    let plaintext = b"secret state data";
+    let ciphertext = encrypt_data(plaintext, "correct-pass").unwrap();
+    let result = decrypt_data(&ciphertext, "wrong-pass");
+    assert!(result.is_err());
+}
+
+#[test]
+fn decrypt_corrupted_data() {
+    let result = decrypt_data(b"not valid age data", "pass");
+    assert!(result.is_err());
+}
+
+#[test]
+fn encrypt_state_file_roundtrip() {
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("state.lock.yaml");
+    let original = "resources:\n  pkg:\n    state: converged\n";
+    std::fs::write(&file, original).unwrap();
+
+    let passphrase = "file-test-pass";
+
+    // Encrypt
+    let meta = encrypt_state_file(&file, passphrase).unwrap();
+    assert!(is_encrypted(&file));
+    assert_eq!(meta.version, 1);
+    assert_eq!(meta.plaintext_hash, hash_data(original.as_bytes()));
+
+    let encrypted_content = std::fs::read(&file).unwrap();
+    assert_ne!(encrypted_content, original.as_bytes());
+
+    // Decrypt
+    let plaintext = decrypt_state_file(&file, passphrase).unwrap();
+    assert_eq!(plaintext, original.as_bytes());
+    assert!(!is_encrypted(&file)); // sidecar removed
+}
+
+#[test]
+fn encrypt_state_file_metadata_written() {
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("test.lock.yaml");
+    std::fs::write(&file, "data").unwrap();
+
+    let meta = encrypt_state_file(&file, "pass").unwrap();
+    let loaded = read_metadata(&file).unwrap();
+    assert_eq!(loaded.plaintext_hash, meta.plaintext_hash);
+    assert_eq!(loaded.ciphertext_hmac, meta.ciphertext_hmac);
+}
+
+#[test]
+fn decrypt_state_file_wrong_passphrase() {
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("state.lock.yaml");
+    std::fs::write(&file, "secret").unwrap();
+
+    encrypt_state_file(&file, "right-pass").unwrap();
+    let result = decrypt_state_file(&file, "wrong-pass");
+    assert!(result.is_err());
+}
+
+/// FJ-154 (#10): encryption must write atomically (temp + rename), leaving no
+/// in-place truncate window and no orphaned temp files.
+#[test]
+fn encrypt_state_file_uses_atomic_write_no_temp_left() {
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("state.lock.yaml");
+    std::fs::write(&file, "resources: {}\n").unwrap();
+
+    encrypt_state_file(&file, "atomic-test").unwrap();
+
+    // The atomic write must clean up its temp file: no `.tmp` sibling and no
+    // `.enc.meta.json.tmp` sidecar temp should remain after a successful run.
+    let data_tmp = {
+        let mut p = file.as_os_str().to_owned();
+        p.push(".tmp");
+        std::path::PathBuf::from(p)
+    };
+    assert!(!data_tmp.exists(), "data temp file leaked: {data_tmp:?}");
+    let meta_tmp = {
+        let mut p = meta_path_for(&file).as_os_str().to_owned();
+        p.push(".tmp");
+        std::path::PathBuf::from(p)
+    };
+    assert!(!meta_tmp.exists(), "meta temp file leaked: {meta_tmp:?}");
+
+    // Metadata sidecar exists (written before the data swap).
+    assert!(is_encrypted(&file));
+    // And the on-disk file is real ciphertext (single atomic rename, not a
+    // truncated in-place write).
+    let on_disk = std::fs::read(&file).unwrap();
+    assert_ne!(on_disk, b"resources: {}\n");
+}
+
+/// FJ-154 (#10): round-trip preserves content and metadata across the atomic
+/// encrypt → decrypt path.
+#[test]
+fn encrypt_decrypt_roundtrip_preserves_content_and_metadata() {
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("state.lock.yaml");
+    let original = "resources:\n  pkg:\n    state: converged\n";
+    std::fs::write(&file, original).unwrap();
+
+    let meta = encrypt_state_file(&file, "round-trip").unwrap();
+    // Metadata persisted and matches the freshly computed plaintext hash.
+    let loaded = read_metadata(&file).unwrap();
+    assert_eq!(loaded.plaintext_hash, meta.plaintext_hash);
+    assert_eq!(loaded.plaintext_hash, hash_data(original.as_bytes()));
+    assert_eq!(loaded.ciphertext_hmac, meta.ciphertext_hmac);
+
+    let plaintext = decrypt_state_file(&file, "round-trip").unwrap();
+    assert_eq!(plaintext, original.as_bytes());
+    assert!(!is_encrypted(&file)); // sidecar removed after decrypt
+}
+
+#[test]
+fn decrypt_state_file_missing_metadata() {
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("state.lock.yaml");
+    std::fs::write(&file, "data").unwrap();
+    // No metadata sidecar
+    let result = decrypt_state_file(&file, "pass");
+    assert!(result.is_err());
+}


### PR DESCRIPTION
## STORAGE-INTEGRITY defects (bug-hunt #9, #10, #20) — Fixes #154

Three storage-integrity defects for v1.5.1.

### #9 — OCI base-image blob path built from untrusted manifest digest (HIGH)
`src/core/store/base_image.rs`. Blob paths were built from a digest taken out of an externally-pulled OCI layout (`index.json`/manifest) with no validation: `layout_dir.join(format!("blobs/sha256/{hex}"))`. A crafted digest like `sha256:../../../../etc/passwd` escaped `blobs/sha256/`, enabling **arbitrary file read** (`read_blob` → `extract_base_layers`, reachable from `forjar build-image`) and **arbitrary file write** via `std::fs::copy` in `copy_base_blobs`.

**Fix:** new shared `validate_sha256_hex()` helper that requires the post-`sha256:` remainder to match `^[0-9a-f]{64}$` (rejecting other algorithms, uppercase, wrong length, and any `/`/`.`). Used in `read_blob`, `verify_base_blobs` (invalid digest ⇒ treated as missing), and `copy_base_blobs` (invalid digest ⇒ `Err`).

### #10 — State encryption rewrites lock file in place, non-atomic
`src/core/state_encryption.rs`. `encrypt_state_file`/`decrypt_state_file` used `std::fs::write` (truncate-then-write) in place and wrote the `.meta` sidecar *after* the data. A crash/SIGKILL/full-disk between truncate and full write left a half-written lock with no matching metadata ⇒ unrecoverable on next decrypt.

**Fix:** new `atomic_write()` helper (temp file in same dir + `fs::rename`, mirroring `state::save_lock`/`store::meta::write_meta`). Encrypt now writes the metadata sidecar **before** swapping the data file; decrypt swaps atomically then drops the stale sidecar — a partial run never leaves data without matching metadata.

### #20 — `cmd_lock_defrag` rewrites lock without refreshing `.b3` sidecar (HIGH)
`src/cli/lock_lifecycle.rs`. Defrag re-serialized the lock and wrote it with a raw `std::fs::write`, bypassing the only writer that refreshes the BLAKE3 `.b3` sidecar. The sidecar kept the pre-defrag hash, so the next `forjar apply` hard-failed its integrity check — effectively bricking the stack until a manual `reseal`.

**Fix:** new `write_lock_and_sidecar()` helper writes atomically (temp + rename) and calls `integrity::write_b3_sidecar`, so defrag → apply round-trips pass integrity.

### Tests (deterministic, hermetic, tempdirs — no network)
- **#9:** `validate_sha256_hex` accepts a 64-hex digest; rejects `../..`, `sha512:…`, uppercase, and wrong lengths. `read_blob`, `extract_base_layers`, and `copy_base_blobs` return `Err` on a traversal digest (tiny fake layout dir).
- **#10** (gated `feature = "encryption"`, extracted to `tests_state_encryption_enc.rs` to keep the source file < 500 lines): encrypt uses atomic write (no leftover `.tmp`, sidecar present); encrypt → decrypt round-trip preserves content + metadata.
- **#20:** build a lock + stale `.b3` sidecar in a tempdir, run defrag, assert the sidecar matches the rewritten lock and `verify_state_integrity` reports no errors.

### Verification
- `cargo test --lib` — 12263 passed (default), 12352 passed (`--features encryption`), 0 failed.
- `cargo clippy --all-targets -- -D warnings` clean (default and `--features encryption`).
- `cargo fmt --all -- --check` clean. All changed files < 500 lines; new functions TDG A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
