### PR TITLE
fix(core): close concurrency races and process/temp-dir leaks (Refs #154)

### DIFF
--- a/src/cli/tests_cov_transport.rs
+++ b/src/cli/tests_cov_transport.rs
@@ -163,7 +163,7 @@ resources:
             cost: 0,
             allowed_operators: vec![],
         };
-        let result = transport::pepita::exec_pepita(&machine, "echo ok");
+        let result = transport::pepita::exec_pepita(&machine, "echo ok", None);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("no pepita config"));
     }
@@ -190,7 +190,7 @@ resources:
             cost: 0,
             allowed_operators: vec![],
         };
-        let result = transport::pepita::exec_pepita(&machine, "echo hi");
+        let result = transport::pepita::exec_pepita(&machine, "echo hi", None);
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(err.contains("pidfile") || err.contains("cannot read"));
@@ -218,7 +218,7 @@ resources:
             cost: 0,
             allowed_operators: vec![],
         };
-        let result = transport::pepita::exec_pepita(&machine, "echo hi");
+        let result = transport::pepita::exec_pepita(&machine, "echo hi", None);
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(
@@ -250,7 +250,7 @@ resources:
             allowed_operators: vec![],
         };
         // Will fail reading the pidfile, but exercises the config extraction path
-        let result = transport::pepita::exec_pepita(&machine, "");
+        let result = transport::pepita::exec_pepita(&machine, "", None);
         assert!(result.is_err());
     }
 

--- a/src/core/state/mod.rs
+++ b/src/core/state/mod.rs
@@ -262,37 +262,92 @@ pub(super) fn process_lock_path(state_dir: &Path) -> PathBuf {
 
 /// Acquire an exclusive process lock. Returns an error if another apply is running.
 /// Stale locks (PID no longer running) are automatically removed.
+///
+/// FJ-266/#154: Acquisition is atomic. `OpenOptions::create_new` is a single
+/// O_EXCL syscall, so two concurrent `forjar apply` processes can never both
+/// observe the file absent and both win — the loser gets `AlreadyExists` and
+/// then evaluates the stale-PID branch before retrying. The previous
+/// exists→read→remove→write sequence had a TOCTOU window in which both
+/// processes wrote the lock and ran concurrently, corrupting state.
 pub fn acquire_process_lock(state_dir: &Path) -> Result<(), String> {
     std::fs::create_dir_all(state_dir).map_err(|e| format!("cannot create state dir: {e}"))?;
 
     let lock_path = process_lock_path(state_dir);
+    let content = process_lock_content();
 
-    // Check for existing lock
-    if lock_path.exists() {
-        let content = std::fs::read_to_string(&lock_path)
-            .map_err(|e| format!("cannot read lock file: {e}"))?;
-        if let Some(pid) = parse_lock_pid(&content) {
-            if is_pid_running(pid) {
-                return Err(format!(
-                    "state directory is locked by PID {} ({}). \
-                     If this is stale, run: forjar apply --force-unlock",
-                    pid,
-                    lock_path.display()
-                ));
+    loop {
+        match try_create_lock(&lock_path, &content) {
+            Ok(()) => return Ok(()),
+            Err(LockAcquireError::Io(e)) => return Err(e),
+            // Lost the race / pre-existing lock: evaluate staleness atomically.
+            Err(LockAcquireError::AlreadyExists) => {
+                reap_or_reject_stale_lock(&lock_path)?;
+                // Stale lock removed (or vanished) — retry the create_new.
             }
-            // Stale lock — PID no longer running, remove it
         }
-        let _ = std::fs::remove_file(&lock_path);
     }
+}
 
-    // Write our PID
-    let pid = std::process::id();
-    let content = format!(
+/// Build the lock-file content (our PID + start timestamp).
+fn process_lock_content() -> String {
+    format!(
         "pid: {}\nstarted_at: {}\n",
-        pid,
+        std::process::id(),
         crate::tripwire::eventlog::now_iso8601()
-    );
-    std::fs::write(&lock_path, content).map_err(|e| format!("cannot write lock file: {e}"))?;
+    )
+}
+
+/// Outcome of an atomic lock-file creation attempt.
+enum LockAcquireError {
+    /// The lock file already exists (lost the race or a held/stale lock).
+    AlreadyExists,
+    /// A non-recoverable I/O error (already formatted for the caller).
+    Io(String),
+}
+
+/// Atomically create the lock file with O_EXCL semantics.
+fn try_create_lock(lock_path: &Path, content: &str) -> Result<(), LockAcquireError> {
+    use std::io::Write;
+    match std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(lock_path)
+    {
+        Ok(mut f) => f
+            .write_all(content.as_bytes())
+            .map_err(|e| LockAcquireError::Io(format!("cannot write lock file: {e}"))),
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            Err(LockAcquireError::AlreadyExists)
+        }
+        Err(e) => Err(LockAcquireError::Io(format!(
+            "cannot create lock file: {e}"
+        ))),
+    }
+}
+
+/// Given an existing lock file, reject it if the owning PID is still running,
+/// otherwise remove it so the caller can retry the atomic create.
+fn reap_or_reject_stale_lock(lock_path: &Path) -> Result<(), String> {
+    // The file may have vanished between create_new and read (the holder
+    // released it) — treat a missing file as "retry the create".
+    let content = match std::fs::read_to_string(lock_path) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(format!("cannot read lock file: {e}")),
+    };
+
+    if let Some(pid) = parse_lock_pid(&content) {
+        if is_pid_running(pid) {
+            return Err(format!(
+                "state directory is locked by PID {} ({}). \
+                 If this is stale, run: forjar apply --force-unlock",
+                pid,
+                lock_path.display()
+            ));
+        }
+        // Stale lock — PID no longer running, fall through to remove it.
+    }
+    let _ = std::fs::remove_file(lock_path);
     Ok(())
 }
 

--- a/src/core/state/tests_process_lock.rs
+++ b/src/core/state/tests_process_lock.rs
@@ -83,3 +83,53 @@ fn test_fj266_lock_creates_state_dir() {
     assert!(process_lock_path(&nested).exists());
     release_process_lock(&nested);
 }
+
+// #154: atomic acquisition — second acquire fails while held by a live PID.
+#[test]
+fn test_154_second_acquire_blocked_while_held() {
+    let dir = tempfile::tempdir().unwrap();
+    // First acquire writes our own (live) PID atomically.
+    acquire_process_lock(dir.path()).unwrap();
+    // A second acquire in the same (live) process must be rejected.
+    let blocked = acquire_process_lock(dir.path());
+    assert!(blocked.is_err());
+    assert!(blocked.unwrap_err().contains("locked by PID"));
+    // Releasing then re-acquiring must succeed.
+    release_process_lock(dir.path());
+    acquire_process_lock(dir.path()).unwrap();
+    release_process_lock(dir.path());
+    assert!(!process_lock_path(dir.path()).exists());
+}
+
+// #154: a lock owned by a dead PID is reaped, then we acquire atomically.
+#[test]
+fn test_154_stale_pid_reaped_then_acquired() {
+    let dir = tempfile::tempdir().unwrap();
+    let lock_path = process_lock_path(dir.path());
+    // 999999999 is almost certainly not a running PID.
+    std::fs::write(&lock_path, "pid: 999999999\nstarted_at: x\n").unwrap();
+    acquire_process_lock(dir.path()).unwrap();
+    let content = std::fs::read_to_string(&lock_path).unwrap();
+    assert!(content.contains(&format!("pid: {}", std::process::id())));
+    release_process_lock(dir.path());
+}
+
+// #154: a lock file whose content has no parseable PID is treated as stale.
+#[test]
+fn test_154_unparseable_lock_reaped() {
+    let dir = tempfile::tempdir().unwrap();
+    let lock_path = process_lock_path(dir.path());
+    std::fs::write(&lock_path, "garbage with no pid line\n").unwrap();
+    // No PID parsed → not "running" → reaped → acquire succeeds.
+    acquire_process_lock(dir.path()).unwrap();
+    release_process_lock(dir.path());
+}
+
+// #154: a lock that vanishes between create_new and read is retried, not failed.
+#[test]
+fn test_154_reap_missing_lock_is_ok() {
+    let dir = tempfile::tempdir().unwrap();
+    let lock_path = process_lock_path(dir.path());
+    // No file present at all — reap helper must report "retry" (Ok).
+    reap_or_reject_stale_lock(&lock_path).unwrap();
+}

--- a/src/core/store/container_build.rs
+++ b/src/core/store/container_build.rs
@@ -52,36 +52,34 @@ pub fn build_image_in_container(
     let base_image = plan.base_image.as_deref().unwrap_or("debian:bookworm-slim");
     let container_name = format!("forjar-build-{}", plan.tag.replace([':', '/'], "-"));
 
-    // Step 1: Start container from base image
+    // Step 1: Start container from base image.
+    //
+    // FJ-#154: A `ContainerGuard` tears the container down on EVERY early
+    // return (e.g. a failed `create_dir_all` of the extract dir), not just the
+    // apply-script branch — otherwise the container leaks, running its full
+    // `sleep 300`.
     start_container(&runtime, &container_name, base_image)?;
+    let container = ContainerGuard::new(&runtime, &container_name);
 
     // Step 2: Execute apply scripts
-    let exec_result = execute_scripts(&runtime, &container_name, apply_scripts);
-    if let Err(e) = exec_result {
-        cleanup_container(&runtime, &container_name);
-        return Err(format!("apply script failed: {e}"));
-    }
+    execute_scripts(&runtime, &container_name, apply_scripts)
+        .map_err(|e| format!("apply script failed: {e}"))?;
 
-    // Step 3: Extract changed files (unique dir per invocation)
-    let unique_id = format!(
-        "{:x}{:x}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_nanos(),
-        std::process::id(),
-    );
-    let extract_dir = std::env::temp_dir().join(format!("forjar-build-{unique_id}"));
+    // Step 3: Extract changed files (unique dir per invocation).
+    //
+    // FJ-#154: A `TempDirGuard` removes the extract dir on every return path,
+    // including a `scan_overlay_upper` failure that previously leaked the temp
+    // dir full of copied container files.
+    let extract_dir = std::env::temp_dir().join(format!("forjar-build-{}", build_unique_id()));
     std::fs::create_dir_all(&extract_dir).map_err(|e| format!("create extract dir: {e}"))?;
-    let changed = extract_changes(&runtime, &container_name, &extract_dir);
-    cleanup_container(&runtime, &container_name);
-    let changed_files = changed?;
+    let _extract_guard = TempDirGuard(extract_dir.clone());
+    let changed_files = extract_changes(&runtime, &container_name, &extract_dir)?;
+    // Filesystem changes are captured; the container is no longer needed.
+    drop(container);
 
     // Step 4: Scan extracted files through overlay_export
     let scan = overlay_export::scan_overlay_upper(&extract_dir, &extract_dir)
         .map_err(|e| format!("overlay scan: {e}"))?;
-    // Clean up extract dir
-    let _ = std::fs::remove_dir_all(&extract_dir);
     let entries = overlay_export::merge_overlay_entries(&scan);
 
     // Step 5: Assemble OCI image
@@ -147,7 +145,6 @@ fn start_container(runtime: &str, container_name: &str, base_image: &str) -> Res
 
 /// Execute apply scripts inside a running container.
 fn execute_scripts(runtime: &str, container_name: &str, scripts: &[String]) -> Result<(), String> {
-    use std::io::Write;
     use std::process::Stdio;
 
     for (i, script) in scripts.iter().enumerate() {
@@ -162,11 +159,9 @@ fn execute_scripts(runtime: &str, container_name: &str, scripts: &[String]) -> R
             .spawn()
             .map_err(|e| format!("exec script {i}: {e}"))?;
 
-        if let Some(ref mut stdin) = child.stdin {
-            stdin
-                .write_all(script.as_bytes())
-                .map_err(|e| format!("stdin write: {e}"))?;
-        }
+        // FJ-#154: reap the child if stdin write fails (no zombie on early return).
+        crate::transport::write_stdin_or_reap(&mut child, script)
+            .map_err(|e| format!("script {i}: {e}"))?;
 
         let output = child
             .wait_with_output()
@@ -253,6 +248,52 @@ fn cleanup_container(runtime: &str, container_name: &str) {
         .output();
 }
 
+/// Build a process-unique id for the extract temp directory.
+fn build_unique_id() -> String {
+    format!(
+        "{:x}{:x}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos(),
+        std::process::id(),
+    )
+}
+
+/// FJ-#154: RAII guard that tears down the ephemeral build container on drop.
+///
+/// Guarantees `cleanup_container` runs on every early return. `drop` it
+/// explicitly once the container's filesystem changes have been extracted.
+struct ContainerGuard {
+    runtime: String,
+    name: String,
+}
+
+impl ContainerGuard {
+    fn new(runtime: &str, name: &str) -> Self {
+        Self {
+            runtime: runtime.to_string(),
+            name: name.to_string(),
+        }
+    }
+}
+
+impl Drop for ContainerGuard {
+    fn drop(&mut self) {
+        cleanup_container(&self.runtime, &self.name);
+    }
+}
+
+/// FJ-#154: RAII guard that removes a temp directory on drop, so a failure in
+/// `scan_overlay_upper` (or any later step) never leaks the extract dir.
+struct TempDirGuard(std::path::PathBuf);
+
+impl Drop for TempDirGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
 /// Format a container build result for CLI output.
 pub fn format_container_build(result: &ContainerBuildResult) -> String {
     format!(
@@ -329,5 +370,47 @@ mod tests {
         let scripts = vec!["echo 'hello' > /test.txt".to_string()];
         let result = build_image_in_container(&plan, &scripts, &output_dir);
         assert!(result.is_ok() || result.is_err());
+    }
+
+    // --- FJ-#154: leak guards (no Docker required) ---
+
+    /// #8: TempDirGuard removes its directory on drop, even on an error path.
+    #[test]
+    fn temp_dir_guard_removes_on_drop() {
+        let base = tempfile::tempdir().unwrap();
+        let dir = base.path().join("forjar-build-leaktest");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("copied-file"), b"data").unwrap();
+        assert!(dir.exists());
+        {
+            let _guard = TempDirGuard(dir.clone());
+            // Simulate scan_overlay_upper failing: we just leave the scope.
+        }
+        assert!(!dir.exists(), "extract dir must be removed by the guard");
+    }
+
+    /// #8: dropping TempDirGuard on an already-missing dir is harmless.
+    #[test]
+    fn temp_dir_guard_missing_is_ok() {
+        let base = tempfile::tempdir().unwrap();
+        let dir = base.path().join("never-created");
+        let _guard = TempDirGuard(dir);
+        // Drop at end of scope must not panic.
+    }
+
+    /// #8: ContainerGuard invokes cleanup on drop. Using `true` as the
+    /// "runtime" makes the cleanup command a deterministic no-op (no Docker).
+    #[test]
+    fn container_guard_cleans_up_on_drop() {
+        // Constructing and dropping must not panic; cleanup runs `true rm -f`.
+        let _guard = ContainerGuard::new("true", "forjar-build-guardtest");
+    }
+
+    /// #8: build_unique_id is non-empty and PID-suffixed.
+    #[test]
+    fn build_unique_id_is_nonempty() {
+        let id = build_unique_id();
+        assert!(!id.is_empty());
+        assert!(id.ends_with(&format!("{:x}", std::process::id())));
     }
 }

--- a/src/core/store/convergence_container.rs
+++ b/src/core/store/convergence_container.rs
@@ -22,7 +22,6 @@ pub fn detect_container_runtime() -> Option<String> {
 
 /// Execute a script inside an ephemeral container and return stdout.
 fn container_exec(runtime: &str, container_name: &str, script: &str) -> Result<String, String> {
-    use std::io::Write;
     use std::process::{Command, Stdio};
 
     let mut child = Command::new(runtime)
@@ -33,11 +32,8 @@ fn container_exec(runtime: &str, container_name: &str, script: &str) -> Result<S
         .spawn()
         .map_err(|e| format!("container exec failed: {e}"))?;
 
-    if let Some(ref mut stdin) = child.stdin {
-        stdin
-            .write_all(script.as_bytes())
-            .map_err(|e| format!("stdin write: {e}"))?;
-    }
+    // FJ-#154: reap the child if stdin write fails (no zombie on early return).
+    crate::transport::write_stdin_or_reap(&mut child, script)?;
 
     let output = child.wait_with_output().map_err(|e| format!("wait: {e}"))?;
 

--- a/src/core/store/mutation_container.rs
+++ b/src/core/store/mutation_container.rs
@@ -9,7 +9,6 @@ use crate::core::types::{MutationOperator, MutationResult};
 
 /// Execute a script inside a container and return stdout.
 fn container_exec(runtime: &str, container_name: &str, script: &str) -> Result<String, String> {
-    use std::io::Write;
     use std::process::{Command, Stdio};
 
     let mut child = Command::new(runtime)
@@ -20,11 +19,8 @@ fn container_exec(runtime: &str, container_name: &str, script: &str) -> Result<S
         .spawn()
         .map_err(|e| format!("container exec failed: {e}"))?;
 
-    if let Some(ref mut stdin) = child.stdin {
-        stdin
-            .write_all(script.as_bytes())
-            .map_err(|e| format!("stdin write: {e}"))?;
-    }
+    // FJ-#154: reap the child if stdin write fails (no zombie on early return).
+    crate::transport::write_stdin_or_reap(&mut child, script)?;
 
     let output = child.wait_with_output().map_err(|e| format!("wait: {e}"))?;
 

--- a/src/core/store/mutation_runner.rs
+++ b/src/core/store/mutation_runner.rs
@@ -137,6 +137,24 @@ fn is_safe_for_local(operator: MutationOperator) -> bool {
     )
 }
 
+/// Build a process-unique sandbox directory name for a local mutation run.
+///
+/// Combines PID, a process-wide atomic sequence (issue #141/#154 — defeats
+/// coarse-clock collisions between concurrent scoped threads), and a
+/// nanosecond timestamp (avoids stale-dir reuse across process restarts).
+pub(super) fn mutation_sandbox_name() -> String {
+    static SANDBOX_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = SANDBOX_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    format!(
+        "forjar-mut-{}-{seq}-{:x}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+    )
+}
+
 /// Run a single mutation test in a local tempdir sandbox.
 ///
 /// Only file-scoped operators run locally. System operators (StopService,
@@ -164,15 +182,18 @@ pub fn run_mutation_test(
         };
     }
 
-    // Create isolated sandbox directory
-    let sandbox_dir = std::env::temp_dir().join(format!(
-        "forjar-mut-{}-{:x}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_nanos()
-    ));
+    // Create isolated sandbox directory.
+    //
+    // Uniqueness MUST NOT depend on wall-clock time alone (issue #141/#154):
+    // run_mutation_parallel spawns scoped threads that share the PID, and two
+    // threads can read identical `SystemTime` values on coarse-granularity
+    // clocks (e.g. 100ns Hyper-V ticks on virtualized CI runners). Colliding
+    // runs then share a sandbox and race each other's cleanup —
+    // `remove_dir_all` yanks the directory out from under the sibling's bash
+    // subprocess (spawn fails with ENOENT). A process-wide atomic counter
+    // guarantees in-process uniqueness; the PID separates processes; the
+    // timestamp avoids stale-dir reuse. Mirrors convergence_runner.rs.
+    let sandbox_dir = std::env::temp_dir().join(mutation_sandbox_name());
     let _ = std::fs::create_dir_all(&sandbox_dir);
 
     let result = run_mutation_in_sandbox(target, operator, config, &sandbox_dir, start);

--- a/src/core/store/tests_mutation_runner.rs
+++ b/src/core/store/tests_mutation_runner.rs
@@ -404,3 +404,27 @@ fn mutations_per_resource_limit() {
     let report = run_mutation_suite(&targets, &config);
     assert_eq!(report.score.total, 2);
 }
+
+#[test]
+fn sandbox_name_is_unique_per_call() {
+    // Issue #154: two in-process generations must differ even when the
+    // wall clock has coarse granularity (the SANDBOX_SEQ atomic guarantees it).
+    let a = mutation_sandbox_name();
+    let b = mutation_sandbox_name();
+    assert_ne!(a, b, "consecutive sandbox names must be unique");
+    assert!(a.starts_with("forjar-mut-"));
+    assert!(b.starts_with("forjar-mut-"));
+}
+
+#[test]
+fn sandbox_names_unique_under_burst() {
+    // Generate many names back-to-back (same PID, near-identical clock reads)
+    // and confirm zero collisions — the failure mode of the #141/#154 race.
+    let names: std::collections::HashSet<String> =
+        (0..256).map(|_| mutation_sandbox_name()).collect();
+    assert_eq!(
+        names.len(),
+        256,
+        "all burst-generated names must be distinct"
+    );
+}

--- a/src/transport/container.rs
+++ b/src/transport/container.rs
@@ -5,11 +5,14 @@
 
 use super::ExecOutput;
 use crate::core::types::Machine;
-use std::io::Write;
 use std::process::{Command, Stdio};
 
 /// Execute a shell script inside a running container.
-pub fn exec_container(machine: &Machine, script: &str) -> Result<ExecOutput, String> {
+pub fn exec_container(
+    machine: &Machine,
+    script: &str,
+    pid_slot: Option<&super::ChildPidSlot>,
+) -> Result<ExecOutput, String> {
     let config = machine
         .container
         .as_ref()
@@ -24,12 +27,11 @@ pub fn exec_container(machine: &Machine, script: &str) -> Result<ExecOutput, Str
         .stderr(Stdio::piped())
         .spawn()
         .map_err(|e| format!("failed to exec in container '{container_name}': {e}"))?;
+    // FJ-#154: publish PID so a timeout can kill this child.
+    super::record_child_pid(pid_slot, &child);
 
-    if let Some(ref mut stdin) = child.stdin {
-        stdin
-            .write_all(script.as_bytes())
-            .map_err(|e| format!("stdin write error: {e}"))?;
-    }
+    // FJ-#154: reap the child if stdin write fails (no zombie on early return).
+    super::write_stdin_or_reap(&mut child, script)?;
 
     let output = child
         .wait_with_output()

--- a/src/transport/local.rs
+++ b/src/transport/local.rs
@@ -1,24 +1,25 @@
 //! FJ-010: Local execution transport.
 
 use super::ExecOutput;
-use std::io::Write;
 use std::process::{Command, Stdio};
 
 /// Execute a shell script locally via `bash`.
 /// Uses bash (not sh/dash) because generated scripts use `set -o pipefail`.
-pub fn exec_local(script: &str) -> Result<ExecOutput, String> {
+pub fn exec_local(
+    script: &str,
+    pid_slot: Option<&super::ChildPidSlot>,
+) -> Result<ExecOutput, String> {
     let mut child = Command::new("bash")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
         .map_err(|e| format!("failed to spawn bash: {e}"))?;
+    // FJ-#154: publish PID so a timeout can kill this child.
+    super::record_child_pid(pid_slot, &child);
 
-    if let Some(ref mut stdin) = child.stdin {
-        stdin
-            .write_all(script.as_bytes())
-            .map_err(|e| format!("stdin write error: {e}"))?;
-    }
+    // FJ-#154: reap the child if stdin write fails (no zombie on early return).
+    super::write_stdin_or_reap(&mut child, script)?;
 
     let output = child
         .wait_with_output()
@@ -37,21 +38,21 @@ mod tests {
 
     #[test]
     fn test_fj010_local_echo() {
-        let out = exec_local("echo hello").unwrap();
+        let out = exec_local("echo hello", None).unwrap();
         assert!(out.success());
         assert_eq!(out.stdout.trim(), "hello");
     }
 
     #[test]
     fn test_fj010_local_failure() {
-        let out = exec_local("exit 42").unwrap();
+        let out = exec_local("exit 42", None).unwrap();
         assert!(!out.success());
         assert_eq!(out.exit_code, 42);
     }
 
     #[test]
     fn test_fj010_local_multiline() {
-        let out = exec_local("echo line1\necho line2").unwrap();
+        let out = exec_local("echo line1\necho line2", None).unwrap();
         assert!(out.success());
         let lines: Vec<_> = out.stdout.lines().collect();
         assert_eq!(lines, vec!["line1", "line2"]);
@@ -59,7 +60,7 @@ mod tests {
 
     #[test]
     fn test_fj010_local_stderr() {
-        let out = exec_local("echo err >&2").unwrap();
+        let out = exec_local("echo err >&2", None).unwrap();
         assert!(out.success());
         assert!(out.stderr.contains("err"));
     }
@@ -67,33 +68,33 @@ mod tests {
     #[test]
     fn test_fj010_local_signal_killed() {
         // Process killed by signal has no exit code; unwrap_or(-1) returns -1
-        let out = exec_local("kill -9 $$").unwrap();
+        let out = exec_local("kill -9 $$", None).unwrap();
         assert_eq!(out.exit_code, -1);
     }
 
     #[test]
     fn test_fj010_local_pipefail() {
-        let out = exec_local("set -euo pipefail\nfalse | true").unwrap();
+        let out = exec_local("set -euo pipefail\nfalse | true", None).unwrap();
         assert!(!out.success(), "pipefail should catch false in pipeline");
     }
 
     #[test]
     fn test_fj010_local_empty_script() {
-        let out = exec_local("").unwrap();
+        let out = exec_local("", None).unwrap();
         assert!(out.success());
         assert!(out.stdout.is_empty());
     }
 
     #[test]
     fn test_fj010_local_environment_variables() {
-        let out = exec_local("FORJAR_TEST=yes; echo $FORJAR_TEST").unwrap();
+        let out = exec_local("FORJAR_TEST=yes; echo $FORJAR_TEST", None).unwrap();
         assert!(out.success());
         assert_eq!(out.stdout.trim(), "yes");
     }
 
     #[test]
     fn test_fj010_local_heredoc() {
-        let out = exec_local("cat <<'EOF'\nhello heredoc\nEOF").unwrap();
+        let out = exec_local("cat <<'EOF'\nhello heredoc\nEOF", None).unwrap();
         assert!(out.success());
         assert_eq!(out.stdout.trim(), "hello heredoc");
     }
@@ -101,7 +102,7 @@ mod tests {
     #[test]
     fn test_fj010_local_exit_code_range() {
         for code in [0, 1, 2, 126, 127, 255] {
-            let out = exec_local(&format!("exit {code}")).unwrap();
+            let out = exec_local(&format!("exit {code}"), None).unwrap();
             assert_eq!(out.exit_code, code);
         }
     }
@@ -109,7 +110,7 @@ mod tests {
     #[test]
     fn test_fj010_local_large_output() {
         // Generate 1000 lines
-        let out = exec_local("seq 1 1000").unwrap();
+        let out = exec_local("seq 1 1000", None).unwrap();
         assert!(out.success());
         assert_eq!(out.stdout.lines().count(), 1000);
     }
@@ -117,7 +118,7 @@ mod tests {
     #[test]
     fn test_fj153_local_binary_output() {
         // Test that binary-ish output is handled via lossy UTF-8
-        let out = exec_local("printf '\\x00\\x01\\x02'").unwrap();
+        let out = exec_local("printf '\\x00\\x01\\x02'", None).unwrap();
         assert!(out.success());
         // Should not panic on non-UTF-8 bytes
         assert!(!out.stdout.is_empty());
@@ -125,7 +126,7 @@ mod tests {
 
     #[test]
     fn test_fj153_local_stdout_and_stderr() {
-        let out = exec_local("echo out; echo err >&2").unwrap();
+        let out = exec_local("echo out; echo err >&2", None).unwrap();
         assert!(out.success());
         assert!(out.stdout.contains("out"));
         assert!(out.stderr.contains("err"));
@@ -134,7 +135,7 @@ mod tests {
     #[test]
     fn test_fj153_local_long_running_script() {
         // Script with multiple sequential commands
-        let out = exec_local("for i in $(seq 1 100); do echo \"line_$i\"; done").unwrap();
+        let out = exec_local("for i in $(seq 1 100); do echo \"line_$i\"; done", None).unwrap();
         assert!(out.success());
         assert_eq!(out.stdout.lines().count(), 100);
     }
@@ -142,7 +143,7 @@ mod tests {
     #[test]
     fn test_fj010_local_set_euo() {
         // set -euo pipefail is standard forjar preamble
-        let out = exec_local("set -euo pipefail\necho ok").unwrap();
+        let out = exec_local("set -euo pipefail\necho ok", None).unwrap();
         assert!(out.success());
         assert_eq!(out.stdout.trim(), "ok");
     }

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -22,6 +22,69 @@ mod tests_ssh;
 
 use crate::core::types::Machine;
 
+/// FJ-#154: Shared slot for publishing a spawned child's PID to the timeout
+/// path. `exec_script_timeout` populates this from a worker thread so it can
+/// kill the underlying ssh/bash/docker/nsenter process when the timeout fires,
+/// instead of leaking a detached thread blocked in `wait_with_output` on a
+/// still-alive child.
+pub(crate) type ChildPidSlot = std::sync::Arc<std::sync::Mutex<Option<u32>>>;
+
+/// Record a freshly-spawned child's PID into the (optional) tracking slot.
+pub(crate) fn record_child_pid(slot: Option<&ChildPidSlot>, child: &std::process::Child) {
+    if let Some(slot) = slot {
+        if let Ok(mut guard) = slot.lock() {
+            *guard = Some(child.id());
+        }
+    }
+}
+
+/// Best-effort kill of a process by PID via the `kill` binary.
+///
+/// Used only on the timeout path. The worker thread that spawned the child is
+/// still blocked in `wait_with_output`; killing the process unblocks it so it
+/// reaps the child itself — no zombie and no leaked thread survive.
+fn kill_pid(pid: u32) {
+    let _ = std::process::Command::new("kill")
+        .args(["-9", &pid.to_string()])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+}
+
+/// FJ-#154: Write a script to a child's stdin, reaping the child on failure.
+///
+/// If the child dies before consuming stdin (ssh auth fails instantly, remote
+/// bash unavailable, broken pipe / EPIPE), `write_all` returns Err. The old
+/// code `?`-returned here, dropping the `Child` WITHOUT `wait()`, which on Unix
+/// leaves a zombie. This helper kills + reaps the child before returning the
+/// error so no zombie survives. Passing the script through a function that owns
+/// the `&mut Child` keeps the reap guaranteed on every early return.
+pub(crate) fn write_stdin_or_reap(
+    child: &mut std::process::Child,
+    script: &str,
+) -> Result<(), String> {
+    use std::io::Write;
+    if let Some(mut stdin) = child.stdin.take() {
+        if let Err(e) = stdin.write_all(script.as_bytes()) {
+            // Drop our stdin handle first (close the pipe), then kill + reap so
+            // the child cannot become a zombie on this early return.
+            drop(stdin);
+            kill_and_reap(child);
+            return Err(format!("stdin write error: {e}"));
+        }
+        // Explicitly close stdin so the child sees EOF before we wait.
+        drop(stdin);
+    }
+    Ok(())
+}
+
+/// Kill a child and wait for it, so no zombie survives. Best-effort: both the
+/// kill and the wait are allowed to fail (e.g. the child already exited).
+pub(crate) fn kill_and_reap(child: &mut std::process::Child) {
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
 /// Output from executing a script on a target.
 #[derive(Debug, Clone)]
 pub struct ExecOutput {
@@ -113,51 +176,80 @@ fn strip_data_payloads(script: &str) -> String {
 ///
 /// I8 invariant: script is validated via bashrs before any execution.
 pub fn exec_script(machine: &Machine, script: &str) -> Result<ExecOutput, String> {
+    exec_script_tracked(machine, script, None)
+}
+
+/// Dispatch core for [`exec_script`] with an optional child-PID tracking slot.
+///
+/// `pid_slot`, when present, receives the spawned transport child's PID so the
+/// timeout path can kill it (FJ-#154). Public `exec_script` passes `None`.
+fn exec_script_tracked(
+    machine: &Machine,
+    script: &str,
+    pid_slot: Option<&ChildPidSlot>,
+) -> Result<ExecOutput, String> {
     validate_before_exec(script)?;
 
     // Pepita (kernel namespace) transport takes highest priority
     if machine.is_pepita_transport() {
-        return pepita::exec_pepita(machine, script);
+        return pepita::exec_pepita(machine, script, pid_slot);
     }
 
     // Container transport takes priority over local/SSH
     if machine.is_container_transport() {
-        return container::exec_container(machine, script);
+        return container::exec_container(machine, script, pid_slot);
     }
 
     let is_local =
         machine.addr == "127.0.0.1" || machine.addr == "localhost" || is_local_addr(&machine.addr);
 
     if is_local {
-        local::exec_local(script)
+        local::exec_local(script, pid_slot)
     } else {
-        ssh::exec_ssh(machine, script)
+        ssh::exec_ssh(machine, script, pid_slot)
     }
 }
 
 /// Execute a script with an optional timeout (in seconds).
 /// Returns an error if the script exceeds the timeout.
+///
+/// FJ-#154: On timeout the underlying transport child is killed via its PID
+/// (published into a shared slot by the worker). Killing the process unblocks
+/// the worker's `wait_with_output`, so neither the child process nor the
+/// worker thread is leaked.
 pub fn exec_script_timeout(
     machine: &Machine,
     script: &str,
     timeout_secs: Option<u64>,
 ) -> Result<ExecOutput, String> {
-    match timeout_secs {
-        Some(secs) => {
-            let hostname = machine.hostname.clone();
-            let machine = machine.clone();
-            let script = script.to_string();
-            let (tx, rx) = std::sync::mpsc::channel();
-            std::thread::spawn(move || {
-                let result = exec_script(&machine, &script);
-                let _ = tx.send(result);
-            });
-            rx.recv_timeout(std::time::Duration::from_secs(secs))
-                .map_err(|_| {
-                    format!("transport timeout: script on '{hostname}' exceeded {secs}s limit")
-                })?
+    let Some(secs) = timeout_secs else {
+        return exec_script(machine, script);
+    };
+
+    let hostname = machine.hostname.clone();
+    let machine = machine.clone();
+    let script = script.to_string();
+    let pid_slot: ChildPidSlot = std::sync::Arc::new(std::sync::Mutex::new(None));
+    let worker_slot = pid_slot.clone();
+    let (tx, rx) = std::sync::mpsc::channel();
+
+    std::thread::spawn(move || {
+        let result = exec_script_tracked(&machine, &script, Some(&worker_slot));
+        let _ = tx.send(result);
+    });
+
+    match rx.recv_timeout(std::time::Duration::from_secs(secs)) {
+        Ok(result) => result,
+        Err(_) => {
+            // Timed out: kill the orphaned child so the worker reaps it and
+            // exits, then return the timeout error.
+            if let Some(pid) = pid_slot.lock().ok().and_then(|g| *g) {
+                kill_pid(pid);
+            }
+            Err(format!(
+                "transport timeout: script on '{hostname}' exceeded {secs}s limit"
+            ))
         }
-        None => exec_script(machine, script),
     }
 }
 

--- a/src/transport/pepita.rs
+++ b/src/transport/pepita.rs
@@ -9,14 +9,17 @@
 
 use super::ExecOutput;
 use crate::core::types::Machine;
-use std::io::Write;
 use std::process::{Command, Stdio};
 
 /// Execute a shell script inside a pepita kernel namespace.
 ///
 /// Uses `nsenter` to enter the namespace identified by the PID file,
 /// then pipes the script to `bash` stdin.
-pub fn exec_pepita(machine: &Machine, script: &str) -> Result<ExecOutput, String> {
+pub fn exec_pepita(
+    machine: &Machine,
+    script: &str,
+    pid_slot: Option<&super::ChildPidSlot>,
+) -> Result<ExecOutput, String> {
     let config = machine
         .pepita
         .as_ref()
@@ -52,12 +55,11 @@ pub fn exec_pepita(machine: &Machine, script: &str) -> Result<ExecOutput, String
         .stderr(Stdio::piped())
         .spawn()
         .map_err(|e| format!("failed to nsenter namespace '{ns_name}': {e}"))?;
+    // FJ-#154: publish PID so a timeout can kill this child.
+    super::record_child_pid(pid_slot, &child);
 
-    if let Some(ref mut stdin) = child.stdin {
-        stdin
-            .write_all(script.as_bytes())
-            .map_err(|e| format!("stdin write error: {e}"))?;
-    }
+    // FJ-#154: reap the child if stdin write fails (no zombie on early return).
+    super::write_stdin_or_reap(&mut child, script)?;
 
     let output = child
         .wait_with_output()
@@ -233,7 +235,7 @@ mod tests {
             cost: 0,
             allowed_operators: vec![],
         };
-        let result = exec_pepita(&machine, "echo hi");
+        let result = exec_pepita(&machine, "echo hi", None);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("no pepita config"));
     }
@@ -333,7 +335,7 @@ rootfs: "debootstrap:jammy"
     #[test]
     fn test_fj230_exec_missing_pidfile() {
         let m = pepita_machine();
-        let result = exec_pepita(&m, "echo hi");
+        let result = exec_pepita(&m, "echo hi", None);
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(

--- a/src/transport/ssh.rs
+++ b/src/transport/ssh.rs
@@ -9,7 +9,6 @@
 
 use super::ExecOutput;
 use crate::core::types::Machine;
-use std::io::Write;
 use std::process::{Command, Stdio};
 
 /// Socket directory for SSH ControlMaster sockets.
@@ -137,7 +136,11 @@ pub fn stop_all_control_masters() {
 }
 
 /// Execute a shell script on a remote machine via SSH.
-pub fn exec_ssh(machine: &Machine, script: &str) -> Result<ExecOutput, String> {
+pub fn exec_ssh(
+    machine: &Machine,
+    script: &str,
+    pid_slot: Option<&super::ChildPidSlot>,
+) -> Result<ExecOutput, String> {
     let args = build_ssh_args(machine);
     let mut cmd = Command::new("ssh");
     for arg in &args {
@@ -150,12 +153,11 @@ pub fn exec_ssh(machine: &Machine, script: &str) -> Result<ExecOutput, String> {
     let mut child = cmd
         .spawn()
         .map_err(|e| format!("failed to spawn ssh to {}: {}", machine.addr, e))?;
+    // FJ-#154: publish PID so a timeout can kill this child.
+    super::record_child_pid(pid_slot, &child);
 
-    if let Some(ref mut stdin) = child.stdin {
-        stdin
-            .write_all(script.as_bytes())
-            .map_err(|e| format!("stdin write error: {e}"))?;
-    }
+    // FJ-#154: reap the child if stdin write fails (no zombie on early return).
+    super::write_stdin_or_reap(&mut child, script)?;
 
     let output = child
         .wait_with_output()

--- a/src/transport/tests_container.rs
+++ b/src/transport/tests_container.rs
@@ -44,7 +44,7 @@ fn test_fj021_exec_no_container_config() {
         cost: 0,
         allowed_operators: vec![],
     };
-    let result = exec_container(&machine, "echo hi");
+    let result = exec_container(&machine, "echo hi", None);
     assert!(result.is_err());
     assert!(result.unwrap_err().contains("no container config"));
 }
@@ -131,7 +131,7 @@ fn test_fj021_ensure_no_image() {
 fn test_fj021_exec_error_includes_container_name() {
     // When exec fails, error message should include the container name
     let m = container_machine();
-    let result = exec_container(&m, "echo hi");
+    let result = exec_container(&m, "echo hi", None);
     // Docker likely not available in test env, but error should reference the name
     if let Err(e) = result {
         assert!(
@@ -169,7 +169,7 @@ fn test_fj021_exec_with_fake_runtime() {
         cost: 0,
         allowed_operators: vec![],
     };
-    let result = exec_container(&machine, "echo test");
+    let result = exec_container(&machine, "echo test", None);
     // /bin/false doesn't accept args, so spawn will succeed but
     // the command will return non-zero — still produces ExecOutput
     match result {
@@ -283,7 +283,7 @@ fn test_fj021_podman_runtime() {
         allowed_operators: vec![],
     };
     // exec_container will try to run podman, which probably isn't available
-    let result = exec_container(&machine, "echo test");
+    let result = exec_container(&machine, "echo test", None);
     if let Err(e) = result {
         // Error should mention the container name
         assert!(

--- a/src/transport/tests_container_b.rs
+++ b/src/transport/tests_container_b.rs
@@ -49,7 +49,7 @@ fn test_fj021_exec_container_error_msg_no_config() {
         cost: 0,
         allowed_operators: vec![],
     };
-    let err = exec_container(&machine, "echo").unwrap_err();
+    let err = exec_container(&machine, "echo", None).unwrap_err();
     assert_eq!(err, "machine 'precise-host' has no container config");
 }
 

--- a/src/transport/tests_container_c.rs
+++ b/src/transport/tests_container_c.rs
@@ -49,7 +49,7 @@ fn test_fj021_exec_container_error_msg_no_config() {
         cost: 0,
         allowed_operators: vec![],
     };
-    let err = exec_container(&machine, "echo").unwrap_err();
+    let err = exec_container(&machine, "echo", None).unwrap_err();
     assert_eq!(err, "machine 'precise-host' has no container config");
 }
 

--- a/src/transport/tests_dispatch.rs
+++ b/src/transport/tests_dispatch.rs
@@ -405,3 +405,89 @@ fn test_fj132_exec_script_special_chars_in_output() {
     assert!(out.success());
     assert!(out.stdout.contains("tab"));
 }
+
+// --- FJ-#154: child reaping / PID tracking helpers ---
+
+/// #7: stdin write to a live consumer succeeds and the slot is populated.
+#[test]
+fn test_154_write_stdin_or_reap_success() {
+    use std::process::{Command, Stdio};
+    // `cat` consumes stdin and exits on EOF.
+    let mut child = Command::new("cat")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn cat");
+    let slot: ChildPidSlot = std::sync::Arc::new(std::sync::Mutex::new(None));
+    record_child_pid(Some(&slot), &child);
+    assert_eq!(*slot.lock().unwrap(), Some(child.id()));
+
+    // Write succeeds; helper closes stdin so cat sees EOF.
+    write_stdin_or_reap(&mut child, "hello").expect("write ok");
+    let out = child.wait_with_output().expect("wait");
+    assert!(out.status.success());
+    assert_eq!(String::from_utf8_lossy(&out.stdout), "hello");
+}
+
+/// #6/#7: kill_and_reap terminates a live child and waits for it, so the
+/// reaping step the timeout/error paths rely on leaves no zombie. Deterministic
+/// — no EPIPE timing, no ssh/docker, just a local long-running `sleep`.
+#[test]
+fn test_154_kill_and_reap_terminates_live_child() {
+    use std::process::{Command, Stdio};
+    let mut child = Command::new("sleep")
+        .arg("60")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn sleep");
+    // Child is alive (no exit status yet).
+    assert!(child.try_wait().expect("try_wait").is_none());
+    // Kill + reap; the helper must not block and must leave no zombie.
+    kill_and_reap(&mut child);
+    // A second try_wait after reaping is harmless (already reaped).
+    let _ = child.try_wait();
+}
+
+/// #7: write_stdin_or_reap consumes the child's stdin handle (so the caller's
+/// later wait sees EOF) on the success path.
+#[test]
+fn test_154_write_stdin_or_reap_consumes_stdin() {
+    use std::process::{Command, Stdio};
+    let mut child = Command::new("cat")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn cat");
+    write_stdin_or_reap(&mut child, "payload").expect("write ok");
+    // Helper took stdin, so it is no longer reachable from the Child.
+    assert!(child.stdin.is_none());
+    let out = child.wait_with_output().expect("wait");
+    assert_eq!(String::from_utf8_lossy(&out.stdout), "payload");
+}
+
+/// #6/#7: record_child_pid is a no-op when no slot is supplied.
+#[test]
+fn test_154_record_child_pid_no_slot() {
+    use std::process::{Command, Stdio};
+    let mut child = Command::new("cat")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn cat");
+    // Must not panic with None.
+    record_child_pid(None, &child);
+    let _ = write_stdin_or_reap(&mut child, "");
+    let _ = child.wait();
+}
+
+/// #6: kill_pid of a non-existent PID is a harmless no-op (best-effort).
+#[test]
+fn test_154_kill_pid_nonexistent_is_noop() {
+    // PID 0 / a very high PID: kill(1) just fails silently; must not panic.
+    kill_pid(2_000_000_000);
+}


### PR DESCRIPTION
Closes the CONCURRENCY & RESOURCE-LEAK defects from the v1.5.1 bug-hunt (#154): items #1, #2, #6, #7, #8.

## Defects fixed

### #1 — Mutation sandbox dir collides across threads (the #141 race, unpatched)
`src/core/store/mutation_runner.rs`: `run_mutation_parallel` spawns scoped threads that share the PID; on coarse clocks two threads read identical `SystemTime` nanos → identical sandbox path → one thread's `remove_dir_all` yanks the dir out from under the sibling's bash. Fixed by adding a process-wide `static SANDBOX_SEQ: AtomicU64` and embedding `fetch_add(1, Relaxed)` in the dir name (verbatim mirror of `convergence_runner.rs`).

### #2 — `acquire_process_lock` TOCTOU: two `forjar apply` both win
`src/core/state/mod.rs`: the old `exists → read → is_pid_running → remove → write` sequence is non-atomic. Replaced with an atomic `OpenOptions::new().write(true).create_new(true).open()` (single O_EXCL syscall); on `AlreadyExists` we read + evaluate stale-PID / `--force-unlock` semantics, then retry the `create_new`. Existing stale-PID and force-unlock behavior preserved.

### #6 — `exec_script_timeout` leaks a thread + orphan child on timeout
`src/transport/mod.rs`: the worker thread now publishes the spawned child's PID into a shared `Arc<Mutex<Option<u32>>>`. On timeout the parent kills that PID, which unblocks the worker's `wait_with_output` so it reaps the child — no leaked thread, no orphan ssh/bash/docker/nsenter process.

### #7 — stdin `write_all` error drops `Child` without `wait()` → zombie
All transports + store container helpers route stdin writes through a shared `write_stdin_or_reap` helper that, on write error, drops stdin then kills + waits the child before returning. Sites: `transport/ssh.rs`, `transport/local.rs`, `transport/container.rs`, `transport/pepita.rs`, `store/container_build.rs`, `store/mutation_container.rs`, `store/convergence_container.rs`.

### #8 — Container build leaks running container + temp extract dir
`src/core/store/container_build.rs`: a `ContainerGuard` (RAII) tears down the container on **every** early return — including the `create_dir_all` failure that previously left it running its full `sleep 300`. A `TempDirGuard` removes the extract dir even when `scan_overlay_upper` fails.

## Tests (deterministic & hermetic — no real network/ssh/docker)
- #1: `mutation_sandbox_name` uniqueness per call + 256-name burst with zero collisions.
- #2: atomic acquire → second acquire blocked while held → release → re-acquire; stale dead-PID reaped; unparseable lock reaped; missing-lock reap is `Ok`.
- #6/#7: `kill_and_reap` terminates a live `sleep` child; `write_stdin_or_reap` consumes stdin on success; `record_child_pid` no-op without a slot; `kill_pid` of a non-existent PID is a no-op.
- #8: `TempDirGuard` removes dir on drop (incl. missing-dir); `ContainerGuard` cleanup runs on drop (uses `true` as the runtime — no Docker); `build_unique_id` non-empty/PID-suffixed.

## Verification
- `cargo test --lib`: **12269 passed, 0 failed, 7 ignored**.
- `cargo clippy --all-targets -- -D warnings`: clean.
- `cargo fmt --all -- --check`: clean.
- All modified functions TDG grade A (complexity ≤ 10); all files < 500 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)