### PR TITLE
chore(release): prep v1.6.0 — L3-L5 coverage + 28-defect deep-audit remediation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,62 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - 2026-06-13
+
+### Added
+
+- **L3–L5 test-coverage persistence** (#155, FALSIFICATION-REPORT E9):
+  `forjar test coverage` now reports beyond L2. Convergence/mutation/
+  preservation runs append hash-stamped results to a `test-coverage.jsonl`
+  log in the state dir; `cmd_test_coverage` reads them back and promotes
+  each resource to the highest passing level whose `config_hash` still
+  matches the resource's current desired-state hash — a changed resource
+  falls back to its static L0–L2 level (no stale high-water marks). New
+  `core::store::coverage_persist` + `cli::coverage_promote`.
+
+### Security / Fixed — 28-defect deep audit (#154)
+
+An adversarial bug-hunt (8 fault-dimension finders, every finding
+double-refuted) surfaced 28 confirmed production defects; all are fixed:
+
+- **apply no longer reports success on real failures** (#157): a failed
+  `pre_apply:` hook now fails the resource (was reported `Skipped`, apply
+  exited 0, dependents ran, rollback was skipped) on the sequential path;
+  OCI registry push now checks HTTP status via `curl --fail-with-body`
+  (401/404/413/5xx were reported as successful pushes); the coverage
+  promotion gate distinguishes "llvm-cov absent" (advisory pass) from
+  "llvm-cov ran and failed" (gate failure).
+- **Shell-injection hardening** (#161): new `core::shell_escape::sh_squote`
+  + identifier validators route every resource-handler data field through
+  proper single-quote escaping. Fixes unescaped/unquoted interpolation in
+  `build` (arbitrary command over ssh), `github_release` (repo/tag command
+  substitution), `task`, `network` (ufw), the binary-cache rsync path, and
+  the file/mount/package/cron/docker/model handlers.
+- **Concurrency & resource leaks** (#159): mutation-runner sandbox dir now
+  uses a process-wide atomic sequence (the #141 race, unpatched in the
+  sibling); `acquire_process_lock` is now atomic via `O_EXCL` create_new
+  (was a TOCTOU letting two `apply` runs both win); transport timeout now
+  kills+reaps the child (was leaking a thread + orphan process); stdin-write
+  failure reaps the child across all 7 transports (was leaking zombies);
+  container build cleans up via RAII guards on every error path.
+- **Storage integrity** (#158): OCI base-image blob paths validate the
+  `sha256:<64-hex>` digest (a `..`-bearing digest allowed arbitrary
+  read/write); state encryption writes atomically (temp+rename, was an
+  in-place truncate that corrupted state on a mid-write crash); `lock
+  defrag` refreshes the BLAKE3 `.b3` sidecar (was bricking the next apply's
+  integrity check).
+- **Planner/executor correctness** (#160): planner and `refresh-only` now
+  resolve secrets with the same provider config the executor uses, ending
+  a perpetual spurious-Update idempotency violation; the rolling-deploy
+  `max_fail_percentage` gate uses integer math (was `as u8`-truncated at
+  the boundary); `moved:` blocks reject collisions/chains at validate time
+  (were silently overwriting lock state).
+- **FAR archive + parser hardening** (#156): FAR decode bounds the
+  manifest-length and chunk-count allocations from attacker-controlled
+  headers (was unbounded → OOM/abort); the RFC-3339 and duration parsers
+  validate ranges and use checked arithmetic (out-of-range month/day and
+  multibyte/overflow inputs previously panicked).
+
 ## [1.5.0] - 2026-06-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1092,7 +1092,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "forjar"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "age",
  "aprender-contracts",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forjar"
-version = "1.5.0"
+version = "1.6.0"
 edition.workspace = true
 rust-version = "1.89.0"
 authors = ["Pragmatic AI Labs"]

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -1527,7 +1527,7 @@ roadmap:
   priority: medium
   assigned_to: null
   created: 2026-06-12T12:00:00Z
-  updated: 2026-06-13T00:30:00Z
+  updated: 2026-06-13T02:00:00Z
   spec: null
   acceptance_criteria:
   - Lib tests added per tests_cov_* pattern for cmd_dist (0%), apply_mode_exits (23%), cmd_canary/cmd_rolling (24%), dispatch_infra_cmd (6%)
@@ -1574,3 +1574,22 @@ roadmap:
   estimated_effort: 0.5d
   labels: [sprint-2026-06, day-2, bug]
   notes: 'Discovered mid-sprint: pre-push suite runs corrupted the host repo (stray commits, staged state/ deletions, core.bare flip). Fixed in #137.'
+- id: PMAT-091
+  github_issue: 154
+  item_type: task
+  title: 'v1.5.1/v1.6.0: remediate 28 confirmed deep-audit defects + L3-L5 coverage'
+  status: completed
+  priority: high
+  assigned_to: null
+  created: 2026-06-13T01:30:00Z
+  updated: 2026-06-13T02:00:00Z
+  spec: null
+  acceptance_criteria:
+  - All 28 double-refuted bug-hunt defects fixed (PRs #156-#161), grouped file-disjoint by theme
+  - L3-L5 test-coverage persistence shipped (#155)
+  - Bundled into v1.6.0 (minor — feature + fixes); GitHub release + Friday crates.io publish
+  phases: []
+  subtasks: []
+  estimated_effort: 1d
+  labels: [sprint-2026-06, day-10, bug, feature]
+  notes: 'Found by an 8-dimension adversarial bug-hunt (84 agents). Closes #154.'


### PR DESCRIPTION
Release prep for **v1.6.0** (PMAT-091). Minor bump bundling:

- **Feature:** L3–L5 test-coverage persistence (#155) — the v1.6.0 anchor.
- **28-defect deep-audit remediation** (#154, PRs #156–#161): shell-injection hardening, apply success-masking, concurrency/leaks, storage integrity, planner correctness, FAR/parser bounds. All found by an 8-dimension adversarial bug-hunt (84 agents, every finding double-refuted) and fixed file-disjoint by theme.

`Cargo.toml` + `Cargo.lock` bumped together (lockfile-preflight passes). CHANGELOG details every fix.

After merge: tag `v1.6.0` → hosted-runner release with the full asset set + SHA256SUMS. **crates.io publish fires Friday 2026-06-19** via the standing cron (newest tag = v1.6.0). Closes #154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)