### PR TITLE
docs(book): document v1.6.0 behavior changes (apply failure, moved validation, L3-L5)

### DIFF
--- a/docs/book/src/01-getting-started.md
+++ b/docs/book/src/01-getting-started.md
@@ -229,8 +229,10 @@ resources:
     depends_on: [nginx-pkg]
 ```
 
-- **`pre_apply`**: Runs before the resource is applied. If it exits non-zero, the resource is skipped entirely (the main apply script does not run). Use this to back up files, check preconditions, or acquire locks.
+- **`pre_apply`**: Runs before the resource is applied. If it exits non-zero, the resource **fails** (the main apply script does not run). Use this to back up files, check preconditions, or acquire locks.
 - **`post_apply`**: Runs after a successful apply. If it exits non-zero, the resource is marked as failed. Use this to restart services, send notifications, or run smoke tests.
+
+> **Failure semantics (changed in v1.6.0).** A failing `pre_apply` hook is treated exactly like a failed apply: the resource is recorded as `Failed`, a `ResourceFailed` event is logged, and the run's failure count is non-zero so `forjar apply` exits non-zero. Under the default `failure: stop_on_first` policy this stops the run, **cascade-skips the resource's dependents**, and **triggers generation rollback**. Earlier versions silently reported a failing `pre_apply` as `Skipped`, exited `0`, ran the dependents anyway, and skipped rollback — so if you relied on a `pre_apply` precondition as a soft gate, it is now a hard gate. See the [troubleshooting chapter](./11-troubleshooting.md#pre_apply-hook-failed-resource-fails-dependents-skipped) for diagnosis.
 
 ## Visualize Dependencies
 

--- a/docs/book/src/02-configuration.md
+++ b/docs/book/src/02-configuration.md
@@ -663,7 +663,7 @@ policy:
 ```
 
 - **serial**: Number of machines per batch. After each batch converges, the next batch begins. Without `serial`, all machines are applied at once (or sequentially if `parallel_machines: false`).
-- **max_fail_percentage**: Cumulative failure threshold (0–100). After each batch, forjar checks the overall failure rate across all machines processed so far. If it exceeds the threshold, the rollout is aborted with an error. Machines not yet started are left untouched.
+- **max_fail_percentage**: Cumulative failure threshold (0–100). After each batch, forjar checks the overall failure rate across all machines processed so far. If it **strictly exceeds** the threshold, the rollout is aborted with an error; a rate exactly equal to the threshold does **not** abort. Machines not yet started are left untouched. As of v1.6.0 the comparison is computed in integer arithmetic (`failed × 100 > max_fail_percentage × total`), so boundary cases are exact — earlier versions truncated the percentage to a `u8` and could mis-gate right at the boundary.
 - When `serial` is combined with `parallel_machines: true`, `serial` controls the batch size and `parallel_machines` controls whether machines within each batch run concurrently.
 
 ## Cross-Machine References

--- a/docs/book/src/04-recipes.md
+++ b/docs/book/src/04-recipes.md
@@ -911,6 +911,15 @@ values are injected into shell script templates before execution. If an input co
 shell metacharacters, whitespace, or unexpected values, the resulting script could
 break or behave unsafely. bashrs catches these problems statically.
 
+> **Shell-value escaping (v1.6.0).** Resource handlers now route config-derived
+> string values through proper POSIX single-quote escaping when generating scripts.
+> A value containing quotes, `$`, backticks, `;`, spaces, or other metacharacters is
+> emitted as one inert literal word, so it can no longer break out of its context or
+> trigger command substitution. This is purely a safety hardening — benign values are
+> unaffected and produce the same scripts as before. You should still run `forjar lint`
+> to catch quoting issues in your own recipe *templates* (bashrs checks the surrounding
+> script structure, not just the interpolated values).
+
 ### Validating Recipe Scripts with `forjar lint`
 
 The `forjar lint` command generates scripts for all resources -- including expanded

--- a/docs/book/src/08-state-management.md
+++ b/docs/book/src/08-state-management.md
@@ -945,6 +945,41 @@ schema: '1.0'
 
 Forjar validates the schema version on load. Future versions may introduce `schema: '2.0'` with migration support.
 
+## Renaming Resources (`moved:` blocks)
+
+When you rename a resource in your config, forjar would normally see the old key disappear and the new key appear — destroying the old resource and recreating the new one. A top-level `moved:` block declares the rename so the lock state is carried over and no destroy/recreate happens:
+
+```yaml
+version: "1.0"
+name: web
+
+moved:
+  - from: nginx          # old resource name (still in state)
+    to: nginx-server     # new resource name (now in config)
+
+resources:
+  nginx-server:
+    type: package
+    machine: web1
+    packages: [nginx]
+```
+
+`moved:` entries are processed during planning, before the diff: the lock key `nginx` is renamed to `nginx-server`, so the plan is a no-op instead of a destroy + create. After the first successful apply has rewritten the lock with the new name, the `moved:` entry can be removed.
+
+### Validation rules (v1.6.0)
+
+`forjar validate` (and any plan/apply) now **rejects** `moved:` blocks that would silently corrupt lock state. Earlier versions accepted these and overwrote lock entries. A clear error is raised at validate time for each of:
+
+| Rejected | Why |
+|----------|-----|
+| `from: x` / `to: x` (no-op) | `from == to` does nothing — remove the entry. |
+| Duplicate `from` | Each resource may be moved at most once. |
+| Colliding `to` (two moves target the same id) | Two sources cannot rename onto the same destination. |
+| `to:` collides with a managed resource | Renaming onto a resource that already exists in `resources:` would overwrite its converged state. |
+| Chained move (`a→b` and `b→c`) | Chains are order-dependent; declare the final rename directly (`a→c`). |
+
+Each surviving rename is taken from the original lock exactly once, so a valid `moved:` set can never clobber another resource's state.
+
 ## Migration Guide
 
 When a new version of forjar changes the lock file format, the `schema` field drives forward compatibility. This section describes what happens during version transitions and how to handle them.

--- a/docs/book/src/10-testing-and-ci.md
+++ b/docs/book/src/10-testing-and-ci.md
@@ -1498,7 +1498,7 @@ forjar test all -f forjar.yaml --parallel
 | `forjar test --group behavior` | Behavior-driven specs (`.spec.yaml`) — executes verify commands |
 | `forjar test --group convergence` | Apply-twice idempotency in sandbox |
 | `forjar test --group mutation` | Infrastructure mutation detection |
-| `forjar test --group coverage` | Per-resource coverage level report (L0-L5) |
+| `forjar test --group coverage` | Per-resource coverage level report (L0-L5); promotes resources to L3-L5 from passing, hash-matching sandbox runs persisted in `test-coverage.jsonl` (see [Testing Strategy](./41-testing-strategy.md#l3l5-promotion-from-persisted-runs-v160)) |
 | `forjar test` | All resources (check script table) |
 | `forjar contracts --coverage` | Per-resource contract level analysis (L0-L2) |
 

--- a/docs/book/src/11-troubleshooting.md
+++ b/docs/book/src/11-troubleshooting.md
@@ -261,6 +261,25 @@ Ensure the target user has passwordless sudo for mount commands, or run as root.
 
 Another user management command is running, or `/etc/passwd` is locked. Retry after the lock clears.
 
+### pre_apply hook failed: resource fails, dependents skipped
+
+As of v1.6.0 a `pre_apply` hook that exits non-zero **fails the resource** — it is no longer silently skipped. The resource is recorded as `Failed`, a `ResourceFailed` event is appended to the event log, and `forjar apply` exits non-zero. Under the default `failure: stop_on_first` policy the run stops, the resource's dependents are cascade-skipped, and generation rollback is triggered.
+
+```
+JIDOKA: web1/site-config failed — dependents will be skipped: pre_apply hook failed (exit 1): permission denied
+```
+
+If a previously "passing" config started failing after upgrading, a `pre_apply` precondition that used to be silently ignored is now enforced. Diagnose by running the hook command manually on the target machine:
+
+```bash
+# Inspect the failing hook and its exit code
+forjar show -f forjar.yaml --json | jq '.resources["site-config"].pre_apply'
+# Run it on the target to see why it exits non-zero
+ssh web1 'cp /etc/nginx/sites-enabled/mysite /tmp/mysite.bak'; echo "exit=$?"
+```
+
+Fix the precondition (or the hook command) so it exits `0`. If the check was genuinely advisory, move it out of `pre_apply` — `pre_apply` is now a hard gate, not a warning.
+
 ### Cron: schedule field count
 
 Cron schedules must have exactly 5 fields: `minute hour day-of-month month day-of-week`.

--- a/docs/book/src/12-store.md
+++ b/docs/book/src/12-store.md
@@ -421,6 +421,16 @@ The push protocol follows OCI Distribution Spec v1.1:
 `--check-existing` (enabled by default) skips blobs that already exist
 in the registry, making incremental pushes fast.
 
+Every HTTP request in the push (blob upload, chunked PATCH/PUT, manifest
+PUT) is now gated on its response status (`curl --fail-with-body`). As of
+v1.6.0 a non-success status — `401`/`403` (auth), `404` (no such
+repository), `413` (blob too large), or any `5xx` — **fails the push with a
+non-zero exit and the registry's error body**. Earlier versions ignored the
+status code and reported these failed pushes as successful, so an image that
+never reached the registry could look as if it had been published. If a push
+that used to "succeed" now errors, check your registry credentials,
+repository name, and the printed HTTP detail.
+
 ## Container-Based Builds (Phase 9)
 
 When `--sandbox` is passed to `forjar build`, the entire image build runs

--- a/docs/book/src/41-testing-strategy.md
+++ b/docs/book/src/41-testing-strategy.md
@@ -27,6 +27,31 @@ println!("Min: {}, Avg: {:.1}", report.min_level, report.avg_level);
 assert!(report.meets_threshold(CoverageLevel::L3));
 ```
 
+### L3–L5 Promotion from Persisted Runs (v1.6.0)
+
+Before v1.6.0, `forjar test coverage` only reported the static L0–L2 level it could infer from the config (unit-testable, has a `.spec.yaml`, etc.). It now also **promotes** resources to L3 (convergence), L4 (mutation), and L5 (preservation).
+
+When a convergence/mutation/preservation test runs in the sandbox, its result is appended — stamped with the resource's desired-state config hash — to a `test-coverage.jsonl` log in the state directory. `forjar test coverage` reads that log back and promotes each resource to the **highest passing level whose recorded config hash still matches the resource's current desired-state hash**:
+
+- A passing recorded level raises the reported level to `max(static_level, proven_level)`.
+- A resource never regresses below its static L0–L2 assessment.
+- If the resource's config changed since the test ran (hash mismatch), the stale high-water mark is **ignored** and the resource falls back to its static level — so you cannot carry a green L4 across an edit that was never re-tested.
+
+The report now prints per-level counts and L3+/L4+ rollups:
+
+```
+Resource Coverage Report
+========================
+  nginx-pkg: L4 (package)
+  site-config: L3 (file)
+  app-svc: L1 (service)
+
+Min: L1, Avg: 2.7, L0: 0, L1: 1, L2: 0, L3: 1, L4: 1, L5: 0
+Coverage: 2/3 at L3+, 1/3 at L4+
+```
+
+Run the sandbox tests (`forjar test --group convergence`, `--group mutation`) to populate the log, then `forjar test --group coverage` to see the promoted levels.
+
 ## Behavior Specs (FJ-2602)
 
 YAML-based assertions for expected system state:


### PR DESCRIPTION
Documents the user-visible behavior changes shipped in forjar v1.5.x–v1.6.0 (CHANGELOG `[1.4.3]`–`[1.6.0]`) so users aren't surprised by the new semantics. Each claim was verified against current `src/` code before writing. **Markdown/docs only — no `src/` behavior changed.**

## Changes documented → chapter

| Change | Issue | Chapter(s) edited |
|--------|-------|-------------------|
| **apply failure semantics** — a failing `pre_apply:` hook now **fails the resource** (non-zero exit, dependents cascade-skip, generation rollback), instead of being silently `Skipped` with exit 0 | #157 | `01-getting-started.md` (Lifecycle Hooks — fixed the contradicting sentence "skipped entirely" + added a v1.6.0 failure-semantics note); `11-troubleshooting.md` (new "pre_apply hook failed" entry with diagnosis) |
| **`moved:` block validation** — colliding/chained moves, duplicate `from`, `to` colliding with a managed resource, and `from==to` no-ops are rejected at validate time | #160 | `08-state-management.md` (new "Renaming Resources (`moved:` blocks)" section + validation-rules table) |
| **L3–L5 test-coverage promotion** — `forjar test coverage` promotes resources to L3 (convergence) / L4 (mutation) / L5 (preservation) from hash-gated persisted sandbox runs; new output buckets | #155 | `41-testing-strategy.md` (new "L3–L5 Promotion from Persisted Runs" subsection w/ sample output); `10-testing-and-ci.md` (runner table entry + cross-link) |
| **OCI push verifies HTTP status** — push now fails loudly on `401/403/404/413/5xx` (was reported as success) | #157 | `12-store.md` (Registry Push section) |
| **Shell-value escaping** — config string values are POSIX single-quote escaped in generated scripts; quotes/`$`/metacharacters are inert (no change for benign values) | #161 | `04-recipes.md` (bashrs validation section) |
| **rolling-deploy gate** — `max_fail_percentage` uses exact integer strict-greater comparison (no `u8` boundary truncation); rate exactly equal to the threshold does not abort | #160 | `02-configuration.md` (Rolling Deploys) |

## Contradictions corrected

- `01-getting-started.md` previously stated a failing `pre_apply` causes the resource to be "**skipped entirely**" — this was the old (now-fixed, #157) behavior. Corrected to "the resource **fails**" and annotated with the v1.6.0 failure semantics.
- Other "silently skipped" mentions in the book (architecture filtering, missing metrics, build cache) were reviewed and are unrelated/correct — left untouched.

## Quality / CI

- `cargo test --test doc_cli_parity` — **passes** (4/4, incl. `every_cli_subcommand_is_documented_in_the_book`); no new CLI subcommands added, so parity holds.
- `mdbook build docs/book` — **builds successfully**. All three new heading anchors verified to match their cross-links. (One pre-existing `<stderr output>` HTML-tag warning at the bottom of `11-troubleshooting.md` is present on `main`, unrelated to these edits, left as-is per minimal-edit scope.)
- No new chapters/files, so `SUMMARY.md` is unchanged and still resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)