### PR TITLE
fix(planner,executor): post-expansion moved checks + non-retryable pre_apply hook failures (#165)

### DIFF
--- a/src/core/executor/helpers.rs
+++ b/src/core/executor/helpers.rs
@@ -15,12 +15,19 @@ pub(crate) fn apply_and_record_outcome(
 ) -> Result<ResourceOutcome, String> {
     let resource_start = Instant::now();
 
-    // FJ-283: Retry with exponential backoff
+    // FJ-283: Retry with exponential backoff.
+    // #165: only retry genuine apply failures (retryable: true). A pre_apply
+    // gate failure is non-retryable so its hook side effects don't re-run.
     let mut outcome = apply_single_resource(cfg, change, machine, ctx, converged_resources)?;
     if cfg.retry > 0 {
         let mut attempt = 0u32;
-        while matches!(outcome, ResourceOutcome::Failed { should_stop: false })
-            && attempt < cfg.retry
+        while matches!(
+            outcome,
+            ResourceOutcome::Failed {
+                should_stop: false,
+                retryable: true
+            }
+        ) && attempt < cfg.retry
         {
             attempt += 1;
             let backoff = std::time::Duration::from_secs(1u64 << (attempt - 1).min(4));

--- a/src/core/executor/mod.rs
+++ b/src/core/executor/mod.rs
@@ -44,6 +44,8 @@ mod tests_filters_b;
 #[cfg(test)]
 mod tests_hooks;
 #[cfg(test)]
+mod tests_hooks_b;
+#[cfg(test)]
 mod tests_localhost;
 #[cfg(test)]
 mod tests_localhost2;

--- a/src/core/executor/resource_ops.rs
+++ b/src/core/executor/resource_ops.rs
@@ -10,8 +10,11 @@ pub(crate) enum ResourceOutcome {
     Unchanged,
     /// Resource was skipped (filtered out or not found).
     Skipped,
-    /// Resource failed; includes whether to stop (jidoka).
-    Failed { should_stop: bool },
+    /// Resource failed; includes whether to stop (jidoka) and whether the
+    /// failure is safe to retry. `retryable` is `false` for pre_apply gate
+    /// failures (#165) — re-running that hook under `--retry` would re-execute
+    /// its non-idempotent side effects; genuine apply failures stay retryable.
+    Failed { should_stop: bool, retryable: bool },
 }
 
 /// Shared context for recording resource outcomes.
@@ -216,7 +219,13 @@ fn execute_resource(
                 duration,
                 &error,
             );
-            return Ok(ResourceOutcome::Failed { should_stop });
+            // #165: pre_apply gate failures are non-retryable so --retry does
+            // not re-run the hook's side effects. The resource still fails,
+            // cascades to dependents, and triggers rollback — it just doesn't loop.
+            return Ok(ResourceOutcome::Failed {
+                should_stop,
+                retryable: false,
+            });
         }
     }
 
@@ -352,7 +361,10 @@ fn handle_resource_output(
                         duration,
                         &error,
                     );
-                    return Ok(ResourceOutcome::Failed { should_stop });
+                    return Ok(ResourceOutcome::Failed {
+                        should_stop,
+                        retryable: true,
+                    });
                 }
             }
             record_success(
@@ -394,7 +406,10 @@ fn handle_resource_output(
                     failed: true,
                 },
             );
-            Ok(ResourceOutcome::Failed { should_stop })
+            Ok(ResourceOutcome::Failed {
+                should_stop,
+                retryable: true,
+            })
         }
         Err(e) => {
             let error = format!("transport error: {e}");
@@ -405,7 +420,10 @@ fn handle_resource_output(
                 duration,
                 &error,
             );
-            Ok(ResourceOutcome::Failed { should_stop })
+            Ok(ResourceOutcome::Failed {
+                should_stop,
+                retryable: true,
+            })
         }
     }
 }

--- a/src/core/executor/tests_hooks_b.rs
+++ b/src/core/executor/tests_hooks_b.rs
@@ -1,0 +1,97 @@
+//! #165: pre_apply hook retry-safety tests (companion to tests_hooks.rs).
+
+use super::*;
+
+// #165: a failing pre_apply hook must NOT be retried under --retry +
+// ContinueIndependent. #157 made a failing pre_apply return Failed{should_stop}
+// instead of Skipped; the FJ-283 retry loop only retries
+// Failed{should_stop:false}, so with continue_independent the pre_apply gate
+// hook started re-running up to N times, re-executing its (non-idempotent)
+// side effects. After the fix the gate failure is non-retryable: the hook runs
+// exactly ONCE, the resource still fails, and dependents still cascade-skip.
+#[test]
+fn test_gh165_pre_apply_hook_not_retried() {
+    let tmp = std::env::temp_dir().join(format!("gh165-pre-retry-{}", std::process::id()));
+    let state_dir = tmp.join("state");
+    let _ = std::fs::create_dir_all(&state_dir);
+    // Sentinel: each pre_apply invocation appends one line. Count == invocations.
+    let sentinel = tmp.join("pre_invocations.log");
+    let base = tmp.join("base.txt");
+    let child = tmp.join("child.txt");
+    let yaml = format!(
+        r#"
+version: "1.0"
+name: test
+policy:
+  parallel_resources: false
+  failure: continue_independent
+machines:
+  local:
+    hostname: localhost
+    addr: 127.0.0.1
+resources:
+  base:
+    type: file
+    machine: local
+    path: {base}
+    content: "base"
+    pre_apply: "echo x >> {sentinel}; exit 1"
+  child:
+    type: file
+    machine: local
+    path: {child}
+    content: "child"
+    depends_on: [base]
+"#,
+        base = base.display(),
+        child = child.display(),
+        sentinel = sentinel.display(),
+    );
+    let config: ForjarConfig = serde_yaml_ng::from_str(&yaml).unwrap();
+    let cfg = ApplyConfig {
+        config: &config,
+        state_dir: &state_dir,
+        force: false,
+        dry_run: false,
+        machine_filter: None,
+        resource_filter: None,
+        tag_filter: None,
+        group_filter: None,
+        timeout_secs: None,
+        force_unlock: false,
+        progress: false,
+        // retry > 0 is the trigger: the pre-fix bug looped the gate hook.
+        retry: 2,
+        // Force sequential so should_stop=false flows into the retry loop.
+        parallel: Some(false),
+        resource_timeout: None,
+        rollback_on_failure: false,
+        max_parallel: None,
+        trace: false,
+        run_id: None,
+        refresh: false,
+        force_tag: None,
+    };
+    let results = apply(&cfg).unwrap();
+
+    // Hook ran EXACTLY ONCE — not retried (would be 1 + retry = 3 before fix).
+    let invocations = std::fs::read_to_string(&sentinel)
+        .map(|s| s.lines().count())
+        .unwrap_or(0);
+    assert_eq!(
+        invocations, 1,
+        "pre_apply gate hook must run exactly once, not be retried (got {invocations})"
+    );
+    // Resource still fails (#157 correctness preserved) and dependent cascades.
+    assert_eq!(
+        results[0].resources_failed, 2,
+        "base + cascade-skipped child both count as failed"
+    );
+    assert_eq!(results[0].resources_converged, 0);
+    assert!(!base.exists(), "base main script must not run");
+    assert!(
+        !child.exists(),
+        "dependent must NOT run after prerequisite's pre_apply failed"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}

--- a/src/core/executor/tests_localhost2.rs
+++ b/src/core/executor/tests_localhost2.rs
@@ -263,19 +263,31 @@ fn test_fj131_resource_outcome_variants() {
     let converged = ResourceOutcome::Converged;
     let unchanged = ResourceOutcome::Unchanged;
     let skipped = ResourceOutcome::Skipped;
-    let failed_stop = ResourceOutcome::Failed { should_stop: true };
-    let failed_continue = ResourceOutcome::Failed { should_stop: false };
+    let failed_stop = ResourceOutcome::Failed {
+        should_stop: true,
+        retryable: true,
+    };
+    let failed_continue = ResourceOutcome::Failed {
+        should_stop: false,
+        retryable: true,
+    };
 
     assert!(matches!(converged, ResourceOutcome::Converged));
     assert!(matches!(unchanged, ResourceOutcome::Unchanged));
     assert!(matches!(skipped, ResourceOutcome::Skipped));
     assert!(matches!(
         failed_stop,
-        ResourceOutcome::Failed { should_stop: true }
+        ResourceOutcome::Failed {
+            should_stop: true,
+            ..
+        }
     ));
     assert!(matches!(
         failed_continue,
-        ResourceOutcome::Failed { should_stop: false }
+        ResourceOutcome::Failed {
+            should_stop: false,
+            ..
+        }
     ));
 }
 

--- a/src/core/parser/mod.rs
+++ b/src/core/parser/mod.rs
@@ -274,5 +274,22 @@ pub fn parse_and_validate_opts(path: &Path, deny_unknown: bool) -> Result<Forjar
     }
     expand_recipes(&mut config, path.parent())?;
     expand_resources(&mut config);
+
+    // #165: re-check moved.to collisions against the POST-expansion resource
+    // set. validate_config ran before expansion, so a `to` that lands on a
+    // recipe-expanded key (e.g. `recipe_id/foo`) would otherwise pass and then
+    // silently clobber that expanded resource's converged lock.
+    let post_errors = crate::core::planner::moved::validate_moved_targets(&config);
+    if !post_errors.is_empty() {
+        return Err(format!(
+            "validation errors:\n{}",
+            post_errors
+                .iter()
+                .map(|e| format!("  - {e}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        ));
+    }
+
     Ok(config)
 }

--- a/src/core/planner/moved.rs
+++ b/src/core/planner/moved.rs
@@ -70,6 +70,12 @@ fn rename_lock(moved: &[MovedEntry], lock: &StateLock, machine: &str) -> StateLo
 /// collides with an existing (managed) resource id, and chains where a `to`
 /// is also used as a `from` (transitive moves). `from == to` no-ops are
 /// rejected as redundant.
+///
+/// Note (#165): the managed-resource collision check here runs against the
+/// *pre-expansion* `config.resources`, so it catches collisions with literal
+/// resources only. Collisions with recipe-expanded keys (e.g. `to:
+/// myrecipe/foo`) are caught by [`validate_moved_targets`], which the parser
+/// runs *after* `expand_recipes` / `expand_resources`.
 pub(crate) fn validate_moved_blocks(config: &ForjarConfig, errors: &mut Vec<ValidationError>) {
     let moved = &config.moved;
     if moved.is_empty() {
@@ -102,11 +108,8 @@ pub(crate) fn validate_moved_blocks(config: &ForjarConfig, errors: &mut Vec<Vali
         // Collision with a managed resource whose own state we'd clobber. A
         // `to` that is itself being moved away (`to` ∈ froms) is a chain, not
         // a destructive collision, and is reported separately below.
-        if config.resources.contains_key(to) && !froms.contains(to) {
-            errors.push(err(format!(
-                "moved 'to: {to}' collides with existing resource '{to}' — \
-                 renaming onto a managed resource would overwrite its converged state"
-            )));
+        if managed_collision(to, &config.resources, &froms) {
+            errors.push(managed_collision_err(to));
         }
         // Chained move: this entry's `to` is some other entry's `from`.
         if to != from && froms.contains(to) {
@@ -117,6 +120,55 @@ pub(crate) fn validate_moved_blocks(config: &ForjarConfig, errors: &mut Vec<Vali
             )));
         }
     }
+}
+
+/// #165: Re-check `moved.to` collisions against the POST-expansion resource
+/// set so a `to` that lands on a recipe-expanded key is rejected too.
+///
+/// [`validate_moved_blocks`] runs at validate time, before `expand_recipes` /
+/// `expand_resources` insert namespaced keys (`recipe_id/foo`). A `moved.to`
+/// equal to such a key would pass validation and then clobber the expanded
+/// resource's converged lock. This runs against the fully expanded
+/// `config.resources` and reports any collision (deduped per `to`).
+pub(crate) fn validate_moved_targets(config: &ForjarConfig) -> Vec<ValidationError> {
+    let moved = &config.moved;
+    if moved.is_empty() {
+        return Vec::new();
+    }
+
+    let froms: std::collections::HashSet<&str> = moved.iter().map(|m| m.from.as_str()).collect();
+    let mut errors = Vec::new();
+    let mut reported: std::collections::HashSet<&str> = std::collections::HashSet::new();
+
+    for entry in moved {
+        let to = entry.to.as_str();
+        if reported.contains(to) {
+            continue;
+        }
+        if managed_collision(to, &config.resources, &froms) {
+            reported.insert(to);
+            errors.push(managed_collision_err(to));
+        }
+    }
+    errors
+}
+
+/// True when `to` would rename onto a managed resource and overwrite its
+/// converged state. A `to` that is itself being moved away (`to` ∈ `froms`)
+/// is a chain, not a destructive collision.
+fn managed_collision(
+    to: &str,
+    resources: &indexmap::IndexMap<String, Resource>,
+    froms: &std::collections::HashSet<&str>,
+) -> bool {
+    resources.contains_key(to) && !froms.contains(to)
+}
+
+fn managed_collision_err(to: &str) -> ValidationError {
+    err(format!(
+        "moved 'to: {to}' collides with existing resource '{to}' — \
+         renaming onto a managed resource would overwrite its converged state"
+    ))
 }
 
 fn err(message: String) -> ValidationError {
@@ -321,5 +373,60 @@ mod tests {
             !errs.iter().any(|m| m.contains("moved")),
             "clean renames must not error, got {errs:?}"
         );
+    }
+
+    // -- #165: moved.to vs POST-expansion (recipe) resource keys ------------
+
+    /// Write a `setup` recipe (expanding to `setup/config-file`) plus the
+    /// given `moved:` block to a config in a tempdir, then run the full
+    /// parse+validate+expand pipeline (`parse_and_validate`). Returns the
+    /// pipeline result so tests can assert acceptance or the collision error.
+    fn parse_and_validate_with_recipe(moved_block: &str) -> Result<ForjarConfig, String> {
+        use crate::core::parser::parse_and_validate;
+        let dir = tempfile::tempdir().unwrap();
+        let recipes_dir = dir.path().join("recipes");
+        std::fs::create_dir_all(&recipes_dir).unwrap();
+        std::fs::write(
+            recipes_dir.join("test-recipe.yaml"),
+            "recipe:\n  name: test-recipe\nresources:\n  config-file:\n    \
+             type: file\n    path: /etc/test.conf\n    content: hello\n",
+        )
+        .unwrap();
+
+        let cfg = dir.path().join("forjar.yaml");
+        std::fs::write(
+            &cfg,
+            format!(
+                "version: \"1.0\"\nname: recipe-test\nmachines:\n  m1:\n    \
+                 hostname: box\n    addr: 1.2.3.4\nresources:\n  setup:\n    \
+                 type: recipe\n    machine: m1\n    recipe: test-recipe\n{moved_block}"
+            ),
+        )
+        .unwrap();
+
+        parse_and_validate(&cfg)
+    }
+
+    #[test]
+    fn validate_rejects_to_colliding_with_recipe_expanded_key() {
+        // `to: setup/config-file` only EXISTS after recipe expansion. Before
+        // #165 the pre-expansion collision check missed it; now the parser
+        // re-checks against the post-expansion resource set and rejects it.
+        let result =
+            parse_and_validate_with_recipe("moved:\n  - from: old\n    to: setup/config-file\n");
+        let err = result.expect_err("collision with expanded recipe key must be rejected");
+        assert!(
+            err.contains("collides with existing resource 'setup/config-file'"),
+            "expected post-expansion managed-collision error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_accepts_non_colliding_rename_alongside_recipe() {
+        // A legitimate rename whose `to` does NOT collide with any expanded
+        // key must still pass the full pipeline.
+        let result = parse_and_validate_with_recipe("moved:\n  - from: old\n    to: brand-new\n");
+        let config = result.expect("non-colliding rename must pass");
+        assert!(config.resources.contains_key("setup/config-file"));
     }
 }


### PR DESCRIPTION
Fixes two new-code audit follow-ups for v1.6.1 (Refs #165).

## #6 — moved-block collision check missed recipe-expanded keys
`validate_moved_blocks`' `to`-vs-managed-resource collision check ran inside `validate_config`, which the parser invokes **before** `expand_recipes` / `expand_resources`. A `moved.to` colliding with a key that only exists after recipe expansion (e.g. `recipe_id/foo`) therefore passed validation and then silently clobbered the expanded resource's converged lock.

**Fix:** Added `validate_moved_targets`, run by `parse_and_validate_opts` **after** expansion, which re-checks every `moved.to` against the fully expanded resource set. The structural checks (duplicate `from`, duplicate `to`, no-op, chains) keep their original pre-expansion timing and error messages; the managed-collision message is unchanged and shared via a helper so pre- and post-expansion reports are identical.

- Test: a recipe expanding to `setup/config-file` with `moved: [{from: old, to: setup/config-file}]` is now **rejected**; a non-colliding rename (`to: brand-new`) still **passes** the full pipeline.

## #9 — pre_apply hook re-run under `--retry`
#157 changed a failing `pre_apply` hook from `Skipped` to `Failed { should_stop }`. Under `failure: continue_independent` (`should_stop: false`) with `--retry N`, the FJ-283 retry loop then re-ran `apply_single_resource` → `run_pre_apply_hook` up to N times, re-executing non-idempotent gate side effects.

**Fix:** Added a `retryable: bool` field to `ResourceOutcome::Failed`. Pre_apply gate failures are `retryable: false`; genuine apply, transport, and post_apply failures stay `retryable: true`. The retry loop only retries `retryable: true`, so the gate hook runs exactly once. #157's correctness is preserved — the resource still fails, cascades to dependents, and triggers rollback.

- Outcome-type change: yes. `ResourceOutcome::Failed` gained `retryable: bool`. Ripple updated all construction sites in `resource_ops.rs` (pre_apply gate, post_apply, exit-code, transport error) and the variant test in `tests_localhost2.rs`; the `{ .. }` match sites in `machine.rs`/`helpers.rs` were unaffected.
- Test: a failing `pre_apply` hook under `retry: 2` runs **exactly once** (verified via a sentinel file the hook appends to), the resource fails, and the dependent cascade-skips. Both fixes' tests were confirmed to fail against the un-fixed code.

## Verification
- `cargo test --lib`: 12440 passed, 0 failed
- `cargo clippy --all-targets -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean
- All touched/new files under 500 lines (the #9 test lives in a new `tests_hooks_b.rs` to keep `tests_hooks.rs` under the limit); new functions TDG grade A, complexity <= 5.

Hermetic: tests use the local `bash` transport with `addr: 127.0.0.1` (direct bash, no real ssh/containers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)