### PR TITLE
fix(coverage,dist): recency-aware coverage demotion + Tier-2 honors custom checksum filename (Refs #165)

### DIFF
--- a/src/cli/coverage_promote_tests.rs
+++ b/src/cli/coverage_promote_tests.rs
@@ -152,13 +152,19 @@ fn persist_convergence_writes_l5_when_pairwise() {
 }
 
 #[test]
-fn persist_convergence_writes_nothing_on_failure() {
+fn persist_convergence_writes_failing_record_on_failure() {
+    // #165: a failing convergence run now writes an explicit failing L3 record
+    // (passed=false) so a later failure supersedes an earlier pass under the
+    // recency-aware promotion — no more stale high-water mark.
     let dir = tempfile::tempdir().unwrap();
     let config = parse();
     let file = dir.path().join("forjar.yaml");
     let results = vec![conv_result("pkg", false, true, false)];
     persist_convergence_coverage(&file, &config, &results, false);
-    assert!(load_records(&coverage_state_dir(&file)).is_empty());
+    let records = load_records(&coverage_state_dir(&file));
+    assert_eq!(records.len(), 1, "a failure must record a demotion");
+    assert_eq!(records[0].level, CoverageLevel::L3);
+    assert!(!records[0].passed);
 }
 
 // ── persist_mutation_coverage writes L4 records ──
@@ -190,14 +196,19 @@ fn persist_mutation_writes_l4_when_all_detected() {
 }
 
 #[test]
-fn persist_mutation_writes_nothing_with_survivor() {
+fn persist_mutation_writes_failing_record_with_survivor() {
+    // #165: a surviving mutation now writes a failing L4 record so the latest
+    // result supersedes an earlier L4 pass.
     let dir = tempfile::tempdir().unwrap();
     let config = parse();
     let file = dir.path().join("forjar.yaml");
     let report =
         MutationReport::from_results(vec![mut_result("pkg", true), mut_result("pkg", false)]);
     persist_mutation_coverage(&file, &config, &report);
-    assert!(load_records(&coverage_state_dir(&file)).is_empty());
+    let records = load_records(&coverage_state_dir(&file));
+    assert_eq!(records.len(), 1, "a survivor must record a demotion");
+    assert_eq!(records[0].level, CoverageLevel::L4);
+    assert!(!records[0].passed);
 }
 
 // ── End-to-end: convergence then coverage read-back promotes ──
@@ -216,4 +227,38 @@ fn end_to_end_convergence_then_coverage_promotes() {
     let r = config.resources.get("pkg").unwrap();
     let level = coverage_entry("pkg", r, &config, &spec, &records).level;
     assert_eq!(level, CoverageLevel::L3);
+}
+
+#[test]
+fn end_to_end_regression_at_same_hash_demotes() {
+    // #165: a resource that passed convergence (L3) and then later FAILS at the
+    // SAME config_hash (e.g. an external dependency changed, or codegen
+    // regressed) must be demoted — the stale passing record no longer wins.
+    let dir = tempfile::tempdir().unwrap();
+    let config = parse();
+    let file = dir.path().join("forjar.yaml");
+
+    // First run: convergence passes → L3 record.
+    persist_convergence_coverage(
+        &file,
+        &config,
+        &[conv_result("pkg", true, true, true)],
+        false,
+    );
+    // Later run: convergence fails at the same (unchanged) config → demotion.
+    persist_convergence_coverage(
+        &file,
+        &config,
+        &[conv_result("pkg", false, true, false)],
+        false,
+    );
+
+    let records = load_records(&coverage_state_dir(&file));
+    let spec: HashSet<String> = HashSet::new();
+    let r = config.resources.get("pkg").unwrap();
+    let level = coverage_entry("pkg", r, &config, &spec, &records).level;
+    assert!(
+        level < CoverageLevel::L3,
+        "a regression at an unchanged config_hash must demote below L3, got {level:?}"
+    );
 }

--- a/src/cli/dist_verify_tier2.rs
+++ b/src/cli/dist_verify_tier2.rs
@@ -153,14 +153,23 @@ pub(crate) fn select_asset_for_target<'a>(
 /// `staged_archive` is the in-container path of the staged `.tar.gz`;
 /// `sums_line` is a real `<sha256>  <asset>` line so the installer's
 /// `verify_checksum` actually verifies (rather than warn-skipping);
-/// `tag` is the pinned version; `version_cmd` is the post-install check.
+/// `sums_file` is the CONFIGURED checksums basename (`dist.checksums`, e.g.
+/// `SHA256SUMS` or a custom `CHECKSUMS.txt`) that the installer builds its
+/// `SUMS_URL` from; `tag` is the pinned version; `version_cmd` is the
+/// post-install check.
 ///
-/// The `download` override is URL-aware: a SHA256SUMS / `.sha256` URL
-/// returns the staged sums line, anything else returns the tarball bytes.
+/// The `download` override is URL-aware: the configured-sums URL (or the
+/// `${{ASSET}}.sha256` per-asset fallback) returns the staged sums line, and
+/// anything else returns the tarball bytes. Matching the ACTUAL configured
+/// sums filename (#165) — not a hardcoded `*SHA256SUMS*` glob — is what makes
+/// `verify_checksum` actually run for ANY `dist.checksums` name; a hardcoded
+/// glob would let a custom filename fall through to the tarball arm and the
+/// installer would silently warn-skip verification.
 pub(crate) fn build_install_harness(
     installer_body: &str,
     staged_archive: &str,
     sums_line: &str,
+    sums_file: &str,
     tag: &str,
     version_cmd: &str,
 ) -> String {
@@ -168,6 +177,7 @@ pub(crate) fn build_install_harness(
     // network functions BEFORE main runs. The generator always ends the
     // script with a lone `main` line.
     let body = strip_trailing_main(installer_body);
+    let sums_glob = sums_url_glob(sums_file);
     format!(
         r#"set -eu
 {body}
@@ -177,9 +187,11 @@ pub(crate) fn build_install_harness(
 TAG="{tag}"
 resolve_version() {{ TAG="{tag}"; }}
 # Serve the staged tarball / checksums instead of fetching from github.com.
+# The sums case arm matches the CONFIGURED checksums filename ({sums_file})
+# plus the *.sha256 per-asset fallback, so verify_checksum actually verifies.
 download() {{
   case "$1" in
-    *SHA256SUMS*|*.sha256) printf '%s\n' '{sums_line}' ;;
+    {sums_glob}) printf '%s\n' '{sums_line}' ;;
     *) cat "{staged}" ;;
   esac
 }}
@@ -194,8 +206,24 @@ echo "TIER2_VERSION_OK"
         tag = tag,
         staged = staged_archive,
         sums_line = sums_line,
+        sums_file = sums_file,
+        sums_glob = sums_glob,
         version_cmd = version_cmd,
     )
+}
+
+/// Build the `case` pattern that matches the installer's SUMS download URLs.
+///
+/// The installer (`dist_generators::build_checksum_snippet`) fetches the
+/// configured `SUMS_URL` (ending in `dist.checksums`, default `SHA256SUMS`)
+/// and falls back to a per-asset `${{ASSET}}.sha256`. We match the configured
+/// basename anywhere in the URL plus the `.sha256` fallback. A blank/whitespace
+/// filename degrades to the historical `*SHA256SUMS*` default so we never emit
+/// an empty `**` glob that would swallow the tarball URL too.
+fn sums_url_glob(sums_file: &str) -> String {
+    let name = sums_file.trim();
+    let basename = if name.is_empty() { "SHA256SUMS" } else { name };
+    format!("*{basename}*|*.sha256")
 }
 
 /// Remove the final top-level `main` invocation the generator appends, so
@@ -368,12 +396,17 @@ fn run_inside(
         .version_cmd
         .clone()
         .unwrap_or_else(|| format!("{} --version", dist.binary));
+    // The configured checksums basename the installer's SUMS_URL is built
+    // from (default SHA256SUMS); the harness must match THIS so verify_checksum
+    // runs for any custom dist.checksums name (#165).
+    let sums_file = dist.checksums.as_deref().unwrap_or("SHA256SUMS");
     // The installer is POSIX sh; run it through sh inside the container so
     // alpine (no bash) works the same as ubuntu.
     let harness = build_install_harness(
         &installer,
         staged_in_container,
         sums_line,
+        sums_file,
         tag,
         &version_cmd,
     );

--- a/src/cli/tests_dist_verify_tier2.rs
+++ b/src/cli/tests_dist_verify_tier2.rs
@@ -103,6 +103,7 @@ fn harness_pins_tag_and_overrides_downloads() {
         &installer,
         "/tmp/x.tar.gz",
         "deadbeef  x.tar.gz",
+        "SHA256SUMS",
         "v1.2.3",
         "mytool --version",
     );
@@ -129,6 +130,7 @@ fn harness_strips_original_main_call() {
         &installer,
         "/tmp/x.tar.gz",
         "deadbeef  x.tar.gz",
+        "SHA256SUMS",
         "v1",
         "mytool --version",
     );
@@ -136,6 +138,93 @@ fn harness_strips_original_main_call() {
     // because the generator's trailing `main` was stripped.
     let main_calls = h.matches("\nmain\n").count();
     assert_eq!(main_calls, 1, "harness must call main exactly once");
+}
+
+// ── #165: download override matches the CONFIGURED checksums filename ──
+
+/// Extract the line of the harness `download()` override whose `case` arm
+/// serves the staged sums line, to assert on its glob pattern. The override
+/// arm is uniquely `<glob>) printf '%s\n' '<sums_line>' ;;`.
+fn sums_case_arm(harness: &str) -> &str {
+    harness
+        .lines()
+        .find(|l| l.contains(r") printf '%s\n' '") && l.trim_end().ends_with(";;"))
+        .expect("harness must have a sums-serving case arm")
+}
+
+/// Crude POSIX `case`-glob match for the patterns we emit (`*x*` / `*.sha256`),
+/// enough to prove the configured-sums URL would hit the sums arm.
+fn glob_matches(pattern: &str, url: &str) -> bool {
+    pattern.split('|').any(|alt| {
+        let alt = alt.trim();
+        match (alt.starts_with('*'), alt.ends_with('*')) {
+            (true, true) => url.contains(alt.trim_matches('*')),
+            (true, false) => url.ends_with(alt.trim_start_matches('*')),
+            (false, true) => url.starts_with(alt.trim_end_matches('*')),
+            (false, false) => url == alt,
+        }
+    })
+}
+
+#[test]
+fn harness_matches_custom_checksums_filename() {
+    // #165: a custom dist.checksums (e.g. CHECKSUMS.txt) must be matched by the
+    // download override so verify_checksum FETCHES + verifies rather than
+    // falling through to the tarball arm (which makes the installer warn-skip).
+    let mut dist = sample_dist();
+    dist.checksums = Some("CHECKSUMS.txt".into());
+    let installer = crate::cli::dist_generators::generate_installer(&dist);
+    let h = build_install_harness(
+        &installer,
+        "/tmp/x.tar.gz",
+        "deadbeef  x.tar.gz",
+        "CHECKSUMS.txt",
+        "v1.2.3",
+        "mytool --version",
+    );
+    // The case arm must reference the custom basename, not a hardcoded glob.
+    let arm = sums_case_arm(&h);
+    assert!(
+        arm.contains("CHECKSUMS.txt"),
+        "sums case arm must match the configured filename, got: {arm}"
+    );
+    assert!(!arm.contains("SHA256SUMS"), "must not hardcode SHA256SUMS: {arm}");
+
+    // The arm's glob must actually match the SUMS_URL the installer builds.
+    let sums_url = "https://github.com/acme/tool/releases/download/v1.2.3/CHECKSUMS.txt";
+    let pattern = arm.split(')').next().unwrap().trim();
+    assert!(
+        glob_matches(pattern, sums_url),
+        "glob {pattern:?} must match the installer's SUMS_URL {sums_url:?} (else verify_checksum skips)"
+    );
+    // The tarball URL must NOT hit the sums arm (else we'd serve sums for the binary).
+    let asset_url = "https://github.com/acme/tool/releases/download/v1.2.3/mytool-1.2.3-x86_64-unknown-linux-gnu.tar.gz";
+    assert!(
+        !glob_matches(pattern, asset_url),
+        "the tarball URL must fall through to the *) tarball arm"
+    );
+}
+
+#[test]
+fn harness_default_sha256sums_still_matches() {
+    // The default SHA256SUMS name must keep working (regression guard for #165).
+    let dist = sample_dist(); // checksums = Some("SHA256SUMS")
+    let installer = crate::cli::dist_generators::generate_installer(&dist);
+    let h = build_install_harness(
+        &installer,
+        "/tmp/x.tar.gz",
+        "deadbeef  x.tar.gz",
+        "SHA256SUMS",
+        "v1.2.3",
+        "mytool --version",
+    );
+    let arm = sums_case_arm(&h);
+    let pattern = arm.split(')').next().unwrap().trim();
+    let sums_url = "https://github.com/acme/tool/releases/download/v1.2.3/SHA256SUMS";
+    assert!(glob_matches(pattern, sums_url), "default SHA256SUMS must match");
+    // The per-asset .sha256 fallback must also match.
+    let fallback = "https://github.com/acme/tool/releases/download/v1.2.3/asset.tar.gz.sha256";
+    assert!(glob_matches(pattern, fallback), "the .sha256 fallback must match");
 }
 
 // ── result parsing ──

--- a/src/core/store/coverage_persist.rs
+++ b/src/core/store/coverage_persist.rs
@@ -106,21 +106,29 @@ pub fn load_records(state_dir: &Path) -> Vec<TestCoverageRecord> {
         .collect()
 }
 
-/// PMAT-088: Highest level a record set proves for one resource, hash-gated.
+/// PMAT-088 (#165): Level proven for one resource, hash-gated AND recency-aware.
 ///
-/// Returns `None` if no passing record matches `current_hash`. Only passing
-/// records whose `config_hash == current_hash` are considered; the maximum of
-/// their levels is returned (L5 implies L4/L3/... by `CoverageLevel` ordering).
+/// Returns `None` unless the resource's MOST RECENT record at `current_hash`
+/// passed. Only records whose `config_hash == current_hash` are considered (a
+/// record for a different hash is a stale config and ignored). Among those, the
+/// latest record by `timestamp` wins: a failing latest record is an explicit
+/// DEMOTION (returns `None`) so a regression at an unchanged config can no
+/// longer be masked by an earlier pass. A passing latest record promotes to its
+/// `level` (L5 implies L4/L3/... by `CoverageLevel` ordering).
+///
+/// This closes the "stale high-water mark survives forever" bug: promotion is
+/// no longer `max()` over ALL passing records — a later failure supersedes an
+/// earlier pass for the same (resource, config_hash).
 pub fn proven_level(
     records: &[TestCoverageRecord],
     resource_id: &str,
     current_hash: &str,
 ) -> Option<CoverageLevel> {
-    records
+    let latest = records
         .iter()
-        .filter(|r| r.resource_id == resource_id && r.passed && r.config_hash == current_hash)
-        .map(|r| r.level)
-        .max()
+        .filter(|r| r.resource_id == resource_id && r.config_hash == current_hash)
+        .max_by(|a, b| a.timestamp.cmp(&b.timestamp))?;
+    latest.passed.then_some(latest.level)
 }
 
 /// PMAT-088: Promote a static base level using the persisted, hash-gated log.
@@ -187,26 +195,45 @@ impl ConvergenceOutcome {
     }
 }
 
-/// PMAT-088: Build a convergence coverage record for one resource.
+/// PMAT-088 (#165): Build a convergence coverage record for one resource.
 ///
 /// Records L5 when pairwise preservation passed, else L3 when convergence +
-/// idempotency passed. Returns `None` when the resource did not even reach L3
-/// (no record is written for a non-result, keeping the log signal-only).
+/// idempotency passed (`passed=true`). When the resource did NOT reach L3, a
+/// **failing L3 record** (`passed=false`) is written instead so a later
+/// regression supersedes an earlier pass under recency-aware `proven_level`
+/// (a stale high-water mark must not survive a regression at an unchanged
+/// config_hash). Always returns `Some`.
 pub fn convergence_record(
     resource_id: &str,
     outcome: ConvergenceOutcome,
     config_hash: &str,
 ) -> Option<TestCoverageRecord> {
-    outcome
-        .proven_level()
-        .map(|level| TestCoverageRecord::new(resource_id, level, true, config_hash))
+    match outcome.proven_level() {
+        Some(level) => Some(TestCoverageRecord::new(
+            resource_id,
+            level,
+            true,
+            config_hash,
+        )),
+        // A failing convergence run records an explicit L3 demotion so the
+        // latest result wins over any earlier passing record.
+        None => Some(TestCoverageRecord::new(
+            resource_id,
+            CoverageLevel::L3,
+            false,
+            config_hash,
+        )),
+    }
 }
 
-/// PMAT-088: Build an L4 (mutation) coverage record for one resource.
+/// PMAT-088 (#165): Build an L4 (mutation) coverage record for one resource.
 ///
-/// A resource is L4 when at least one mutation was attempted and every
-/// applicable mutation was detected (zero survivors, zero errors). A resource
-/// with no mutations attempted, survivors, or errors earns no record.
+/// A resource is L4 (`passed=true`) when at least one mutation was attempted
+/// and every applicable mutation was detected (zero survivors, zero errors).
+/// When mutations were attempted but some survived/errored, a **failing L4
+/// record** (`passed=false`) is written so a regression supersedes an earlier
+/// L4 pass under recency-aware `proven_level`. When NOTHING was attempted
+/// (`attempted == 0`) there is no signal at all, so no record is written.
 pub fn mutation_record(
     resource_id: &str,
     attempted: usize,
@@ -214,16 +241,16 @@ pub fn mutation_record(
     errored: usize,
     config_hash: &str,
 ) -> Option<TestCoverageRecord> {
-    if attempted > 0 && errored == 0 && detected == attempted {
-        Some(TestCoverageRecord::new(
-            resource_id,
-            CoverageLevel::L4,
-            true,
-            config_hash,
-        ))
-    } else {
-        None
+    if attempted == 0 {
+        return None;
     }
+    let passed = errored == 0 && detected == attempted;
+    Some(TestCoverageRecord::new(
+        resource_id,
+        CoverageLevel::L4,
+        passed,
+        config_hash,
+    ))
 }
 
 /// PMAT-088: Index records by resource id for repeated promotion lookups.
@@ -241,216 +268,5 @@ pub fn latest_hash_by_resource(records: &[TestCoverageRecord]) -> HashMap<String
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn rec(id: &str, level: CoverageLevel, passed: bool, hash: &str) -> TestCoverageRecord {
-        TestCoverageRecord {
-            resource_id: id.into(),
-            level,
-            passed,
-            timestamp: "2026-06-13T00:00:00Z".into(),
-            config_hash: hash.into(),
-        }
-    }
-
-    #[test]
-    fn append_then_load_roundtrip() {
-        let dir = tempfile::tempdir().unwrap();
-        let r = rec("pkg", CoverageLevel::L3, true, "abc");
-        append_record(dir.path(), &r).unwrap();
-        let loaded = load_records(dir.path());
-        assert_eq!(loaded, vec![r]);
-    }
-
-    #[test]
-    fn load_missing_log_is_empty() {
-        let dir = tempfile::tempdir().unwrap();
-        assert!(load_records(dir.path()).is_empty());
-    }
-
-    #[test]
-    fn load_skips_malformed_lines() {
-        let dir = tempfile::tempdir().unwrap();
-        let r = rec("pkg", CoverageLevel::L4, true, "h1");
-        append_record(dir.path(), &r).unwrap();
-        // Simulate a torn final write by appending garbage.
-        let path = coverage_log_path(dir.path());
-        let mut f = std::fs::OpenOptions::new()
-            .append(true)
-            .open(&path)
-            .unwrap();
-        writeln!(f, "{{not valid json").unwrap();
-        let loaded = load_records(dir.path());
-        assert_eq!(loaded, vec![r]);
-    }
-
-    #[test]
-    fn append_records_batch() {
-        let dir = tempfile::tempdir().unwrap();
-        let recs = vec![
-            rec("a", CoverageLevel::L3, true, "h"),
-            rec("b", CoverageLevel::L4, true, "h"),
-        ];
-        append_records(dir.path(), &recs).unwrap();
-        assert_eq!(load_records(dir.path()).len(), 2);
-    }
-
-    #[test]
-    fn proven_level_picks_max_matching() {
-        let recs = vec![
-            rec("pkg", CoverageLevel::L3, true, "h1"),
-            rec("pkg", CoverageLevel::L4, true, "h1"),
-        ];
-        assert_eq!(
-            proven_level(&recs, "pkg", "h1"),
-            Some(CoverageLevel::L4),
-            "should pick the highest passing matching level"
-        );
-    }
-
-    #[test]
-    fn proven_level_ignores_hash_mismatch() {
-        let recs = vec![rec("pkg", CoverageLevel::L5, true, "old-hash")];
-        assert_eq!(proven_level(&recs, "pkg", "new-hash"), None);
-    }
-
-    #[test]
-    fn proven_level_ignores_failures() {
-        let recs = vec![rec("pkg", CoverageLevel::L4, false, "h1")];
-        assert_eq!(proven_level(&recs, "pkg", "h1"), None);
-    }
-
-    #[test]
-    fn proven_level_ignores_other_resources() {
-        let recs = vec![rec("other", CoverageLevel::L5, true, "h1")];
-        assert_eq!(proven_level(&recs, "pkg", "h1"), None);
-    }
-
-    // ── Falsification-style tests (PMAT-088 / E9) ──
-
-    #[test]
-    fn falsify_a_fresh_resource_stays_at_base() {
-        // (a) No records → a fresh L1 resource is NOT promoted.
-        let recs: Vec<TestCoverageRecord> = vec![];
-        assert_eq!(
-            promote_level(CoverageLevel::L1, &recs, "pkg", "h1"),
-            CoverageLevel::L1
-        );
-        assert_eq!(
-            promote_level(CoverageLevel::L0, &recs, "pkg", "h1"),
-            CoverageLevel::L0
-        );
-    }
-
-    #[test]
-    fn falsify_b_passing_l3_promotes() {
-        // (b) A passing L3 record (hash match) promotes L2 → L3.
-        let recs = vec![rec("pkg", CoverageLevel::L3, true, "h1")];
-        assert_eq!(
-            promote_level(CoverageLevel::L2, &recs, "pkg", "h1"),
-            CoverageLevel::L3
-        );
-    }
-
-    #[test]
-    fn falsify_c_config_change_demotes() {
-        // (c) Config change (hash mismatch) demotes back to static base.
-        let recs = vec![rec("pkg", CoverageLevel::L3, true, "old-hash")];
-        assert_eq!(
-            promote_level(CoverageLevel::L2, &recs, "pkg", "new-hash"),
-            CoverageLevel::L2,
-            "stale high-water mark must not survive a config change"
-        );
-    }
-
-    #[test]
-    fn falsify_d_l5_implies_l3_and_l4() {
-        // (d) An L5 record promotes a resource to L5 (which subsumes L3/L4).
-        let recs = vec![rec("pkg", CoverageLevel::L5, true, "h1")];
-        let level = promote_level(CoverageLevel::L1, &recs, "pkg", "h1");
-        assert_eq!(level, CoverageLevel::L5);
-        assert!(level >= CoverageLevel::L3, "L5 implies L3");
-        assert!(level >= CoverageLevel::L4, "L5 implies L4");
-    }
-
-    #[test]
-    fn promote_never_regresses_below_base() {
-        // A lower proven level than the static base does not regress the base.
-        let recs = vec![rec("pkg", CoverageLevel::L3, true, "h1")];
-        assert_eq!(
-            promote_level(CoverageLevel::L4, &recs, "pkg", "h1"),
-            CoverageLevel::L4,
-            "base L4 must not regress to a proven L3"
-        );
-    }
-
-    fn outcome(
-        converged: bool,
-        idempotent: bool,
-        preserved: bool,
-        errored: bool,
-        pairwise_enabled: bool,
-    ) -> ConvergenceOutcome {
-        ConvergenceOutcome {
-            converged,
-            idempotent,
-            preserved,
-            errored,
-            pairwise_enabled,
-        }
-    }
-
-    #[test]
-    fn convergence_record_l3_on_pass() {
-        let r = convergence_record("pkg", outcome(true, true, true, false, false), "h");
-        assert_eq!(r.unwrap().level, CoverageLevel::L3);
-    }
-
-    #[test]
-    fn convergence_record_l5_when_pairwise_preserved() {
-        let r = convergence_record("pkg", outcome(true, true, true, false, true), "h");
-        assert_eq!(r.unwrap().level, CoverageLevel::L5);
-    }
-
-    #[test]
-    fn convergence_record_l3_when_pairwise_off_even_if_preserved() {
-        // preserved=true but pairwise not enabled → only L3, not L5.
-        let r = convergence_record("pkg", outcome(true, true, true, false, false), "h");
-        assert_eq!(r.unwrap().level, CoverageLevel::L3);
-    }
-
-    #[test]
-    fn convergence_record_none_on_failure() {
-        assert!(
-            convergence_record("pkg", outcome(false, true, false, false, false), "h").is_none()
-        );
-        assert!(
-            convergence_record("pkg", outcome(true, false, false, false, false), "h").is_none()
-        );
-        assert!(convergence_record("pkg", outcome(true, true, true, true, false), "h").is_none());
-    }
-
-    #[test]
-    fn mutation_record_l4_when_all_detected() {
-        let r = mutation_record("pkg", 5, 5, 0, "h");
-        assert_eq!(r.unwrap().level, CoverageLevel::L4);
-    }
-
-    #[test]
-    fn mutation_record_none_on_survivor_or_error_or_empty() {
-        assert!(mutation_record("pkg", 5, 4, 0, "h").is_none()); // survivor
-        assert!(mutation_record("pkg", 5, 5, 1, "h").is_none()); // errored
-        assert!(mutation_record("pkg", 0, 0, 0, "h").is_none()); // nothing attempted
-    }
-
-    #[test]
-    fn latest_hash_by_resource_tracks_last_seen() {
-        let recs = vec![
-            rec("pkg", CoverageLevel::L3, true, "h1"),
-            rec("pkg", CoverageLevel::L3, true, "h2"),
-        ];
-        let map = latest_hash_by_resource(&recs);
-        assert_eq!(map.get("pkg"), Some(&"h2".to_string()));
-    }
-}
+#[path = "coverage_persist_tests.rs"]
+mod tests;

--- a/src/core/store/coverage_persist_tests.rs
+++ b/src/core/store/coverage_persist_tests.rs
@@ -1,0 +1,318 @@
+//! Tests for `coverage_persist` (PMAT-088 / #165 recency-aware demotion).
+//!
+//! Extracted from `coverage_persist.rs` to keep that file under the
+//! 500-line limit; included via `#[path]` so the tests still live in the
+//! module's namespace (`use super::*`).
+
+use super::*;
+
+fn rec(id: &str, level: CoverageLevel, passed: bool, hash: &str) -> TestCoverageRecord {
+    TestCoverageRecord {
+        resource_id: id.into(),
+        level,
+        passed,
+        timestamp: "2026-06-13T00:00:00Z".into(),
+        config_hash: hash.into(),
+    }
+}
+
+/// Like `rec` but with an explicit timestamp, for recency-ordering tests.
+fn rec_at(
+    id: &str,
+    level: CoverageLevel,
+    passed: bool,
+    hash: &str,
+    ts: &str,
+) -> TestCoverageRecord {
+    TestCoverageRecord {
+        resource_id: id.into(),
+        level,
+        passed,
+        timestamp: ts.into(),
+        config_hash: hash.into(),
+    }
+}
+
+#[test]
+fn append_then_load_roundtrip() {
+    let dir = tempfile::tempdir().unwrap();
+    let r = rec("pkg", CoverageLevel::L3, true, "abc");
+    append_record(dir.path(), &r).unwrap();
+    let loaded = load_records(dir.path());
+    assert_eq!(loaded, vec![r]);
+}
+
+#[test]
+fn load_missing_log_is_empty() {
+    let dir = tempfile::tempdir().unwrap();
+    assert!(load_records(dir.path()).is_empty());
+}
+
+#[test]
+fn load_skips_malformed_lines() {
+    let dir = tempfile::tempdir().unwrap();
+    let r = rec("pkg", CoverageLevel::L4, true, "h1");
+    append_record(dir.path(), &r).unwrap();
+    // Simulate a torn final write by appending garbage.
+    let path = coverage_log_path(dir.path());
+    let mut f = std::fs::OpenOptions::new()
+        .append(true)
+        .open(&path)
+        .unwrap();
+    writeln!(f, "{{not valid json").unwrap();
+    let loaded = load_records(dir.path());
+    assert_eq!(loaded, vec![r]);
+}
+
+#[test]
+fn append_records_batch() {
+    let dir = tempfile::tempdir().unwrap();
+    let recs = vec![
+        rec("a", CoverageLevel::L3, true, "h"),
+        rec("b", CoverageLevel::L4, true, "h"),
+    ];
+    append_records(dir.path(), &recs).unwrap();
+    assert_eq!(load_records(dir.path()).len(), 2);
+}
+
+#[test]
+fn proven_level_uses_latest_matching() {
+    // The latest passing record at the current hash wins (recency-aware).
+    let recs = vec![
+        rec_at("pkg", CoverageLevel::L3, true, "h1", "2026-06-13T00:00:00Z"),
+        rec_at("pkg", CoverageLevel::L4, true, "h1", "2026-06-13T00:00:01Z"),
+    ];
+    assert_eq!(
+        proven_level(&recs, "pkg", "h1"),
+        Some(CoverageLevel::L4),
+        "should use the most recent passing matching record"
+    );
+}
+
+#[test]
+fn proven_level_ignores_hash_mismatch() {
+    let recs = vec![rec("pkg", CoverageLevel::L5, true, "old-hash")];
+    assert_eq!(proven_level(&recs, "pkg", "new-hash"), None);
+}
+
+#[test]
+fn proven_level_ignores_failures() {
+    let recs = vec![rec("pkg", CoverageLevel::L4, false, "h1")];
+    assert_eq!(proven_level(&recs, "pkg", "h1"), None);
+}
+
+// ── #165: recency-aware demotion (regression at an unchanged hash) ──
+
+#[test]
+fn proven_level_demotes_when_latest_record_fails() {
+    // A passing L3 record then a LATER failing record at the SAME hash:
+    // recency wins, so the resource is demoted (no longer L3). This is the
+    // exact "stale high-water mark survives forever" bug from #165.
+    let recs = vec![
+        rec_at("pkg", CoverageLevel::L3, true, "h1", "2026-06-13T00:00:00Z"),
+        rec_at(
+            "pkg",
+            CoverageLevel::L3,
+            false,
+            "h1",
+            "2026-06-13T00:00:05Z",
+        ),
+    ];
+    assert_eq!(
+        proven_level(&recs, "pkg", "h1"),
+        None,
+        "a later failing record at the same hash must demote the resource"
+    );
+    assert_eq!(
+        promote_level(CoverageLevel::L2, &recs, "pkg", "h1"),
+        CoverageLevel::L2,
+        "promotion must fall back to the static base after a regression"
+    );
+}
+
+#[test]
+fn proven_level_repromotes_when_latest_record_passes() {
+    // Fail then a LATER pass at the same hash re-promotes (recency wins).
+    let recs = vec![
+        rec_at(
+            "pkg",
+            CoverageLevel::L3,
+            false,
+            "h1",
+            "2026-06-13T00:00:00Z",
+        ),
+        rec_at("pkg", CoverageLevel::L3, true, "h1", "2026-06-13T00:00:09Z"),
+    ];
+    assert_eq!(proven_level(&recs, "pkg", "h1"), Some(CoverageLevel::L3));
+}
+
+#[test]
+fn proven_level_recency_is_hash_scoped() {
+    // A LATER failing record at a STALE hash must not demote the current
+    // hash's passing record (the hash gate isolates per-config history).
+    let recs = vec![
+        rec_at("pkg", CoverageLevel::L3, true, "h1", "2026-06-13T00:00:00Z"),
+        rec_at(
+            "pkg",
+            CoverageLevel::L3,
+            false,
+            "stale",
+            "2026-06-13T00:00:09Z",
+        ),
+    ];
+    assert_eq!(
+        proven_level(&recs, "pkg", "h1"),
+        Some(CoverageLevel::L3),
+        "a failing record at a different hash must be ignored"
+    );
+}
+
+#[test]
+fn proven_level_ignores_other_resources() {
+    let recs = vec![rec("other", CoverageLevel::L5, true, "h1")];
+    assert_eq!(proven_level(&recs, "pkg", "h1"), None);
+}
+
+// ── Falsification-style tests (PMAT-088 / E9) ──
+
+#[test]
+fn falsify_a_fresh_resource_stays_at_base() {
+    // (a) No records → a fresh L1 resource is NOT promoted.
+    let recs: Vec<TestCoverageRecord> = vec![];
+    assert_eq!(
+        promote_level(CoverageLevel::L1, &recs, "pkg", "h1"),
+        CoverageLevel::L1
+    );
+    assert_eq!(
+        promote_level(CoverageLevel::L0, &recs, "pkg", "h1"),
+        CoverageLevel::L0
+    );
+}
+
+#[test]
+fn falsify_b_passing_l3_promotes() {
+    // (b) A passing L3 record (hash match) promotes L2 → L3.
+    let recs = vec![rec("pkg", CoverageLevel::L3, true, "h1")];
+    assert_eq!(
+        promote_level(CoverageLevel::L2, &recs, "pkg", "h1"),
+        CoverageLevel::L3
+    );
+}
+
+#[test]
+fn falsify_c_config_change_demotes() {
+    // (c) Config change (hash mismatch) demotes back to static base.
+    let recs = vec![rec("pkg", CoverageLevel::L3, true, "old-hash")];
+    assert_eq!(
+        promote_level(CoverageLevel::L2, &recs, "pkg", "new-hash"),
+        CoverageLevel::L2,
+        "stale high-water mark must not survive a config change"
+    );
+}
+
+#[test]
+fn falsify_d_l5_implies_l3_and_l4() {
+    // (d) An L5 record promotes a resource to L5 (which subsumes L3/L4).
+    let recs = vec![rec("pkg", CoverageLevel::L5, true, "h1")];
+    let level = promote_level(CoverageLevel::L1, &recs, "pkg", "h1");
+    assert_eq!(level, CoverageLevel::L5);
+    assert!(level >= CoverageLevel::L3, "L5 implies L3");
+    assert!(level >= CoverageLevel::L4, "L5 implies L4");
+}
+
+#[test]
+fn promote_never_regresses_below_base() {
+    // A lower proven level than the static base does not regress the base.
+    let recs = vec![rec("pkg", CoverageLevel::L3, true, "h1")];
+    assert_eq!(
+        promote_level(CoverageLevel::L4, &recs, "pkg", "h1"),
+        CoverageLevel::L4,
+        "base L4 must not regress to a proven L3"
+    );
+}
+
+fn outcome(
+    converged: bool,
+    idempotent: bool,
+    preserved: bool,
+    errored: bool,
+    pairwise_enabled: bool,
+) -> ConvergenceOutcome {
+    ConvergenceOutcome {
+        converged,
+        idempotent,
+        preserved,
+        errored,
+        pairwise_enabled,
+    }
+}
+
+#[test]
+fn convergence_record_l3_on_pass() {
+    let r = convergence_record("pkg", outcome(true, true, true, false, false), "h");
+    assert_eq!(r.unwrap().level, CoverageLevel::L3);
+}
+
+#[test]
+fn convergence_record_l5_when_pairwise_preserved() {
+    let r = convergence_record("pkg", outcome(true, true, true, false, true), "h");
+    assert_eq!(r.unwrap().level, CoverageLevel::L5);
+}
+
+#[test]
+fn convergence_record_l3_when_pairwise_off_even_if_preserved() {
+    // preserved=true but pairwise not enabled → only L3, not L5.
+    let r = convergence_record("pkg", outcome(true, true, true, false, false), "h");
+    assert_eq!(r.unwrap().level, CoverageLevel::L3);
+}
+
+#[test]
+fn convergence_record_writes_failing_l3_on_failure() {
+    // #165: a failing convergence run now writes an explicit failing L3
+    // record (passed=false) so a later failure supersedes an earlier pass.
+    for o in [
+        outcome(false, true, false, false, false),
+        outcome(true, false, false, false, false),
+        outcome(true, true, true, true, false),
+    ] {
+        let r = convergence_record("pkg", o, "h").expect("failure must record a demotion");
+        assert_eq!(r.level, CoverageLevel::L3);
+        assert!(
+            !r.passed,
+            "a failing convergence run must record passed=false"
+        );
+    }
+}
+
+#[test]
+fn mutation_record_l4_when_all_detected() {
+    let r = mutation_record("pkg", 5, 5, 0, "h");
+    let r = r.unwrap();
+    assert_eq!(r.level, CoverageLevel::L4);
+    assert!(r.passed);
+}
+
+#[test]
+fn mutation_record_writes_failing_l4_on_survivor_or_error() {
+    // #165: survivors/errors now write a failing L4 record so the latest
+    // result supersedes an earlier L4 pass; nothing-attempted writes none.
+    let survivor = mutation_record("pkg", 5, 4, 0, "h").expect("survivor must record");
+    assert_eq!(survivor.level, CoverageLevel::L4);
+    assert!(!survivor.passed);
+    let errored = mutation_record("pkg", 5, 5, 1, "h").expect("error must record");
+    assert!(!errored.passed);
+    assert!(
+        mutation_record("pkg", 0, 0, 0, "h").is_none(),
+        "no mutations attempted means no signal — write nothing"
+    );
+}
+
+#[test]
+fn latest_hash_by_resource_tracks_last_seen() {
+    let recs = vec![
+        rec("pkg", CoverageLevel::L3, true, "h1"),
+        rec("pkg", CoverageLevel::L3, true, "h2"),
+    ];
+    let map = latest_hash_by_resource(&recs);
+    assert_eq!(map.get("pkg"), Some(&"h2".to_string()));
+}


### PR DESCRIPTION
Fixes two new-code audit defects (#7, #8) for v1.6.1. Refs #165.

## #7 — coverage-persist: regression at an unchanged config_hash never demoted

`proven_level` took `max()` over **all** passing records for a
`(resource_id, config_hash)`, so a resource that passed once stayed L3/L4/L5
forever — even if it later regressed for any reason that left the resource
config unchanged (a forjar codegen change, a script-template change, a real
convergence regression, an external dependency change). The module docstring
promised "a stale high-water mark is a correctness bug, not a feature", but the
hash gate only caught config-field changes, not regressions at an unchanged
config.

**Fix (recency-aware promotion):**
- `proven_level` now considers, per `(resource_id, config_hash)`, only the
  **most recent** record by timestamp. A failing latest record is an explicit
  **demotion** (returns `None`). The hash gate is retained (a record at a
  different hash is ignored), as is the `L5 ⇒ L4 ⇒ L3` implication for a
  passing record. On equal-second timestamps the later-appended record wins
  (append-only-log order is the recency tiebreaker).
- `convergence_record` / `mutation_record` now **persist failures too**
  (`passed=false`) so a later failure supersedes an earlier pass. A
  zero-mutations-attempted run still writes nothing (no signal).

**Tests** (`coverage_persist_tests.rs`, `coverage_promote_tests.rs`): a passing
L3 record then a later failing record at the **same** hash demotes (no longer
L3); a later pass re-promotes; a failing record at a **stale** hash is ignored
(hash-scoped recency); end-to-end persist-pass-then-persist-fail demotes below
L3.

## #8 — dist Tier-2: custom `dist.checksums` filename silently skipped verification

The offline shim's `download()` override hardcoded `*SHA256SUMS*|*.sha256`. The
generated installer builds `SUMS_URL` from the free-form `dist.checksums`
(`dist_generators.rs`), so for any custom filename (e.g. `CHECKSUMS.txt`) the
URL matched neither arm and fell through to the tarball case, returning gzip
bytes. The installer then found no checksum line and hit the
`warn "no checksum found ... skipping verification"; return` branch — so the
container "verify" passed **without verifying anything**.

**Fix:** thread the resolved `dist.checksums` basename into
`build_install_harness` and match the **actual** configured SUMS filename
(`*<basename>*|*.sha256`) in the download override, so `verify_checksum`
fetches and verifies for any configured filename. A blank/whitespace filename
degrades to the historical `SHA256SUMS` default.

**Tests** (`tests_dist_verify_tier2.rs`): a custom `CHECKSUMS.txt` is matched by
the download override (glob-matches the installer's `SUMS_URL`, does **not**
match the tarball URL, and does not hardcode `SHA256SUMS`); default
`SHA256SUMS` and the `.sha256` per-asset fallback still match.

## Notes
- `generate_installer` was **not** touched, so `install.sh` parity is preserved
  (`install_sh_parity` and `falsification_dist*` stay green).
- All tests hermetic/deterministic; the Tier-2 container test stays `#[ignore]`d.
- Full `cargo test --lib` green (12443 passed, 0 failed, 8 ignored); clippy
  `--all-targets -D warnings` clean; fmt clean; touched files under 500 lines
  (tests extracted to `coverage_persist_tests.rs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)