### PR TITLE
chore(release): prep v1.6.1 — new-code audit remediation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.1] - 2026-06-13
+
+### Fixed — new-code audit of the v1.6.0 changes (#165)
+
+A focused audit of the ~10.6k lines merged for v1.6.0 (the fix/feature
+implementations themselves, which the original bug-hunt predated) found 9
+regressions/gaps, each double-refuted; all fixed:
+
+- **Lock-acquire livelock (regression, #169):** the v1.6.0 `O_EXCL`
+  rewrite of `acquire_process_lock` could spin at 100% CPU when a
+  stale-but-undeletable lock persisted (read-only mount / cross-UID
+  sticky-bit dir). The loop is now bounded (5 attempts, 50ms backoff) and
+  propagates a clear error instead of looping; the stale-lock reap re-reads
+  and byte-matches the dead-PID content before unlinking, so it can't
+  delete a concurrently-acquired fresh lock (TOCTOU); and the transport
+  timeout now spawns children in their own process group and kills the
+  group gated on a worker-done flag, eliminating a PID-reuse kill of an
+  unrelated process.
+- **Shell-escape gaps (#166):** the v1.6.0 escaping sweep missed
+  `mount.rs` mounted/unmounted echo labels and `file.rs` source-read /
+  unsupported-state error messages — config-derived values are now
+  escaped there too.
+- **Planner/executor (#167):** `moved:` collision checks now also run
+  *after* recipe/resource expansion (a `to` colliding with an expanded
+  recipe key was previously missed); a failing `pre_apply` hook is no
+  longer re-executed under `--retry` (the v1.6.0 Skipped→Failed change had
+  made it retryable) via a `retryable` flag on the failed outcome.
+- **Coverage demotion (#168):** L3–L5 promotion is now recency-aware —
+  a failing run at the same config hash demotes the resource (failures are
+  now persisted), instead of an old passing record surviving forever.
+- **Tier-2 verify (#168):** `--verify-containers` now honors a custom
+  `dist.checksums` filename (the offline shim previously hardcoded
+  `SHA256SUMS`, silently skipping verification for any other name).
+
 ## [1.6.0] - 2026-06-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1092,7 +1092,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "forjar"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "age",
  "aprender-contracts",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forjar"
-version = "1.6.0"
+version = "1.6.1"
 edition.workspace = true
 rust-version = "1.89.0"
 authors = ["Pragmatic AI Labs"]

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -1594,3 +1594,22 @@ roadmap:
   estimated_effort: 1d
   labels: [sprint-2026-06, day-10, bug, feature]
   notes: 'Found by an 8-dimension adversarial bug-hunt (84 agents). Closes #154.'
+- id: PMAT-092
+  github_issue: 165
+  item_type: task
+  title: 'v1.6.1: fix 9 regressions/gaps in v1.6.0 code (new-code audit)'
+  status: completed
+  priority: high
+  assigned_to: null
+  created: 2026-06-13T02:30:00Z
+  updated: 2026-06-13T03:00:00Z
+  spec: null
+  acceptance_criteria:
+  - 'Audit of v1.6.0 fix/feature code (the implementations the original hunt predated) found 9 double-refuted defects'
+  - 'All fixed file-disjoint (PRs #166-#169): lock livelock/TOCTOU/PID-kill, shell-escape gaps, moved post-expansion, pre_apply retry, coverage demotion, Tier-2 checksum'
+  - Shipped as v1.6.1
+  phases: []
+  subtasks: []
+  estimated_effort: 0.5d
+  labels: [sprint-2026-06, day-10, bug]
+  notes: 'Standout: the #159 O_EXCL lock rewrite introduced a 100%-CPU livelock regression; caught before users hit it. Closes #165.'


### PR DESCRIPTION
Release prep for **v1.6.1** (PMAT-092, closes #165). Patch bundling the 9 fixes from the focused audit of the v1.6.0 fix/feature code (the implementations the original bug-hunt predated):

- **#169** lock-acquire **livelock regression** (100% CPU on undeletable stale lock) + reap TOCTOU + timeout PID-reuse kill
- **#166** two shell-escape sites the v1.6.0 sweep missed (mount/file labels)
- **#167** `moved:` post-expansion collision checks + non-retryable `pre_apply` hook failures
- **#168** recency-aware L3–L5 coverage demotion + Tier-2 custom-checksum-filename support

`Cargo.toml` + `Cargo.lock` bumped together (lockfile-preflight passes). CHANGELOG details each fix.

After merge: tag `v1.6.1` → hosted-runner release with full assets. crates.io publish fires Friday 2026-06-19 via the cron (newest tag = v1.6.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)