### PR TITLE
docs(readme): refresh for v1.6.1 — crates.io install, current feature set

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ cargo fmt --check
 
 All contributions must pass:
 
-- **Tests**: `cargo test` (8000+ tests, 95%+ line coverage)
+- **Tests**: `cargo test` (12000+ tests, 95%+ line coverage)
 - **Clippy**: `cargo clippy -- -D warnings` (zero warnings)
 - **Format**: `cargo fmt --check`
 - **Deny**: `cargo deny check` (supply chain security)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@
 
 ---
 
+**Latest: v1.6.1 — on [crates.io](https://crates.io/crates/forjar).** Install via `cargo install forjar`, a prebuilt binary, or from source.
+
 Forjar is a single-binary IaC tool written in Rust. It manages bare-metal machines over SSH using YAML configs, BLAKE3 content-addressed state, and deterministic DAG execution. No cloud APIs, no runtime dependencies, no remote state backends.
 
 ```
@@ -43,9 +45,14 @@ forjar.yaml  →  parse  →  resolve DAG  →  plan  →  codegen  →  execute
 ## Features
 
 - Declarative YAML-based infrastructure provisioning
-- Content-addressed artifact store with blake3 hashing
+- Content-addressed artifact store (BLAKE3 hashing) with a 4-level purity model (Pure / Pinned / Constrained / Impure)
 - SSH-based remote execution with automatic retry
 - Drift detection and convergence verification
+- Provable convergence contracts — `idempotent-apply`, `plan-apply-equivalence`, and `destroy-undo-roundtrip` (see `forjar contracts` / `forjar prove`)
+- L0–L5 test coverage levels — `forjar test` reports per-resource coverage through L3 convergence, L4 mutation, and L5 preservation
+- Distribution-artifact generation — `forjar dist` emits a shell installer, Homebrew formula, Nix flake, cargo-binstall metadata, deb, and rpm with real checksum resolution, plus `--verify` (static installer checks) and `--verify-containers` (gnu/musl container runs)
+- age-encrypted state at rest — `forjar state-encrypt` / `state-decrypt` / `state-rekey`
+- WASM resource plugins (opt-in `--features wasm-runtime`) via `forjar plugin`
 - Pure Rust with zero C dependencies
 
 ## Why Forjar
@@ -62,8 +69,13 @@ forjar.yaml  →  parse  →  resolve DAG  →  plan  →  codegen  →  execute
 ## Quick Start
 
 ```bash
-# Install from source
-cargo install --path .
+# Install from crates.io
+cargo install forjar
+
+# ...or grab a prebuilt binary (picks the right target, verifies sha256)
+curl -fsSL https://raw.githubusercontent.com/paiml/forjar/main/install.sh | sh
+
+# ...or build from source: git clone … && cargo install --path .
 
 # Initialize a project
 forjar init my-infra && cd my-infra
@@ -327,7 +339,8 @@ Fewer than 20 direct crate dependencies (currently 17 runtime + 1 build). Single
 Verify: `cargo metadata --no-deps --format-version 1 | jq '[.packages[0].dependencies[] | select(.kind == null)] | length'`
 
 ### C10: Jidoka failure isolation
-First failure stops execution. Previously converged state is preserved.
+First failure stops execution. Previously converged state is preserved. A failing `pre_apply`
+gate hook fails apply (v1.6.0) and is not retried — it never silently passes.
 Tests: `test_fj012_apply_local_file`
 
 </details>
@@ -335,7 +348,7 @@ Tests: `test_fj012_apply_local_file`
 ## Testing
 
 ```bash
-cargo test                    # 6295+ unit tests
+cargo test                    # 12000+ unit tests
 cargo test -- --nocapture     # with output
 cargo test planner            # specific module
 cargo bench                   # Criterion benchmarks
@@ -352,7 +365,7 @@ cargo clippy -- -D warnings   # lint
 curl -fsSL https://raw.githubusercontent.com/paiml/forjar/main/install.sh | sh
 
 # Or manually: download, verify, extract
-VERSION=1.4.3 TARGET=x86_64-unknown-linux-gnu
+VERSION=1.6.1 TARGET=x86_64-unknown-linux-gnu
 curl -fsSLO "https://github.com/paiml/forjar/releases/download/v${VERSION}/forjar-${VERSION}-${TARGET}.tar.gz"
 curl -fsSLO "https://github.com/paiml/forjar/releases/download/v${VERSION}/forjar-${VERSION}-${TARGET}.tar.gz.sha256"
 sha256sum -c "forjar-${VERSION}-${TARGET}.tar.gz.sha256"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 1.1.x   | :white_check_mark: |
-| < 1.0   | :x:                |
+| 1.6.x   | :white_check_mark: |
+| < 1.6   | :x:                |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
Refreshes README.md and the root docs to match shipped reality: **v1.6.1, published on crates.io**, install works via cargo / prebuilt binary / source. Docs-only — no `src/` changes.

## README.md
- **Stale version literal:** manual-install block bumped `VERSION=1.4.3` → `1.6.1`. Swept the whole README; no other `1.4.x`/`1.5.x` literals remained.
- **Quick Start** now leads with `cargo install forjar`, then the `curl | sh` one-liner, then source build — consistent with the Installation section (no duplicate-contradiction; both list cargo/binary/source).
- **Status line** added near the top: "Latest: v1.6.1 — on crates.io".
- **Features** expanded to the current, verified capability set:
  - Content-addressed store + 4-level purity model (Pure/Pinned/Constrained/Impure)
  - Provable convergence contracts: `idempotent-apply`, `plan-apply-equivalence`, `destroy-undo-roundtrip` (`forjar contracts` / `forjar prove`)
  - L0–L5 test coverage levels reported by `forjar test` (L3 convergence / L4 mutation / L5 preservation)
  - `forjar dist` distribution artifacts (installer / Homebrew / Nix / cargo-binstall / deb / rpm) with real checksum resolution + `--verify` (static) and `--verify-containers` (gnu/musl) tiers
  - age-encrypted state at rest (`state-encrypt` / `state-decrypt` / `state-rekey`)
  - WASM resource plugins (opt-in `--features wasm-runtime`, `forjar plugin`)
- **C10 (Falsifiable Claims):** noted that a failing `pre_apply` gate hook now fails apply (v1.6.0) and is not retried.

Every feature/command was verified against `src/cli/commands/mod.rs` and the implementing modules before claiming it. WASM is correctly marked opt-in (feature-gated behind `wasmi`).

## Root docs checked
- **CONTRIBUTING.md** — dev setup, quality gates (clippy/fmt/deny, 500-line cap, TDG grade A), and PR process all accurate; only the stale test count (`8000+`) was bumped to `12000+` to match the README.
- **SECURITY.md** — supported-versions table was stale (`1.1.x`); updated to `1.6.x` supported / `< 1.6` unsupported. Verified the security-measures claims still hold: `unsafe_code = "forbid"` is in `Cargo.toml`, and CI actions are largely SHA-pinned. No reporting-policy or contact changes needed.

README test count (`6295+`) also bumped to `12000+` (actual `#[test]` count ≈ 12,582).

🤖 Generated with [Claude Code](https://claude.com/claude-code)