### PR TITLE
docs(book): freshness pass for v1.6.1

### DIFF
--- a/docs/book/src/01-getting-started.md
+++ b/docs/book/src/01-getting-started.md
@@ -2,7 +2,26 @@
 
 ## Installation
 
-Build from source (requires Rust 1.89.0+):
+Forjar ships as a single static binary. Pick whichever method suits you.
+
+**From crates.io** (requires Rust 1.89.0+):
+
+```bash
+cargo install forjar
+```
+
+**Prebuilt binaries** (Linux x86_64/aarch64, gnu + static musl — see the
+[Releases](https://github.com/paiml/forjar/releases) page):
+
+```bash
+# One-liner installer (picks the right target, verifies sha256)
+curl -fsSL https://raw.githubusercontent.com/paiml/forjar/main/install.sh | sh
+
+# Or via cargo-binstall (downloads the same release artifacts, no compile)
+cargo binstall forjar
+```
+
+**From source** (requires Rust 1.89.0+):
 
 ```bash
 git clone https://github.com/paiml/forjar.git

--- a/docs/book/src/06b-cli-reference-appendix.md
+++ b/docs/book/src/06b-cli-reference-appendix.md
@@ -203,5 +203,30 @@ Generate distribution artifacts (installer script, Homebrew formula,
 cargo-binstall metadata, Nix flake, GitHub Action, deb/rpm specs).
 
 ```bash
-forjar dist [--installer|--homebrew|--binstall|--nix|--github-action|--deb|--rpm|--all] [-o <OUT>]
+forjar dist [--installer|--homebrew|--binstall|--nix|--github-action|--deb|--rpm|--all] [-o <OUT>] [--json]
+```
+
+**Checksum resolution.** Artifacts that embed real SHA-256 checksums
+(`--homebrew`, `--nix`) need a release to pin against:
+
+```bash
+# Pin a release tag — checksums are fetched from the GitHub release
+forjar dist --homebrew --version v1.6.1
+
+# Or resolve checksums offline from a local SHA256SUMS-format file
+forjar dist --nix --version v1.6.1 --checksums-file dist/SHA256SUMS
+```
+
+**Verification (FJ-3607).** Validate the generated installer before you ship it:
+
+```bash
+# Tier 1 (static): generate to a temp dir and check the installer with
+# `sh -n`, bashrs lint, required-snippet presence, and download-URL structure
+forjar dist --installer --verify
+
+# Tier 2 (runtime): actually RUN the installer inside ubuntu (gnu) and
+# alpine (musl) containers against a locally-staged tarball, asserting the
+# binary lands in install_dir and version_cmd succeeds. Requires
+# Docker/Podman and implies --verify; cleanly skips when no runtime is found.
+forjar dist --installer --verify-containers
 ```

--- a/docs/book/src/10-testing-and-ci.md
+++ b/docs/book/src/10-testing-and-ci.md
@@ -1609,6 +1609,9 @@ CI enforcement with color-coded badges:
 | < 60% | red |
 
 ```bash
-# CI gate: fail if line coverage drops below 95%
-forjar test coverage --min-line 95 --enforce
+# Per-resource coverage levels (L0-L5), JSON for CI gating
+forjar test --group coverage --json
+
+# Rust source-coverage gate: fail the build below 95% line coverage
+cargo llvm-cov --summary-only --fail-under-lines 95
 ```

--- a/docs/book/src/13-formal-verification.md
+++ b/docs/book/src/13-formal-verification.md
@@ -131,6 +131,22 @@ model proves "if handler invariant holds, then idempotency holds." The
 `debug_assert!` on `determine_present_action` catches violations of
 that invariant in every test run.
 
+## Provable Convergence Contracts
+
+The end-to-end convergence guarantees are pinned by three contract specs
+in the `contracts/` directory, each backed by a Kani harness and/or runtime
+`debug_assert!` plus regression tests (paiml/forjar#97):
+
+| Contract spec | ID | What It Guarantees |
+|---------------|----|--------------------|
+| `idempotent-apply-v1.yaml` | `F-IDEM-001` | Re-planning a fully converged lock set is a no-op (`apply(apply(s)) == apply(s)`). Bounded by Kani `proof_planner_idempotency_bounded`. |
+| `plan-apply-equivalence-v1.yaml` | `F-PAE-001` | The actions executed by `apply` are exactly the actions reported by `plan` — no hidden work, no skipped work. |
+| `destroy-undo-roundtrip-v1.yaml` | `F-UNDO-001` | `destroy` followed by `undo` restores the pre-destroy generation snapshot bit-for-bit. |
+
+Each spec carries `verification_level: L3` and points at the Kani harness and
+test functions that discharge it, so the guarantee is checked in CI rather than
+asserted in prose.
+
 ## Verification Tier Model (FJ-2203)
 
 Forjar tracks verification maturity across six tiers per critical-path function:

--- a/docs/book/src/41-testing-strategy.md
+++ b/docs/book/src/41-testing-strategy.md
@@ -29,9 +29,9 @@ assert!(report.meets_threshold(CoverageLevel::L3));
 
 ### L3–L5 Promotion from Persisted Runs (v1.6.0)
 
-Before v1.6.0, `forjar test coverage` only reported the static L0–L2 level it could infer from the config (unit-testable, has a `.spec.yaml`, etc.). It now also **promotes** resources to L3 (convergence), L4 (mutation), and L5 (preservation).
+Before v1.6.0, `forjar test --group coverage` only reported the static L0–L2 level it could infer from the config (unit-testable, has a `.spec.yaml`, etc.). It now also **promotes** resources to L3 (convergence), L4 (mutation), and L5 (preservation).
 
-When a convergence/mutation/preservation test runs in the sandbox, its result is appended — stamped with the resource's desired-state config hash — to a `test-coverage.jsonl` log in the state directory. `forjar test coverage` reads that log back and promotes each resource to the **highest passing level whose recorded config hash still matches the resource's current desired-state hash**:
+When a convergence/mutation/preservation test runs in the sandbox, its result is appended — stamped with the resource's desired-state config hash — to a `test-coverage.jsonl` log in the state directory. `forjar test --group coverage` reads that log back and promotes each resource to the **highest passing level whose recorded config hash still matches the resource's current desired-state hash**:
 
 - A passing recorded level raises the reported level to `max(static_level, proven_level)`.
 - A resource never regresses below its static L0–L2 assessment.


### PR DESCRIPTION
Targeted freshness pass over the mdBook (`docs/book/`) for release **v1.6.1** (MSRV 1.89.0). Docs-only; no source, README, or roadmap changes.

## Stale references fixed
- **Incorrect CLI invocation:** corrected `forjar test coverage` → `forjar test --group coverage` in `41-testing-strategy.md` (the L3–L5 promotion section) and `10-testing-and-ci.md`. There is no positional `coverage` subcommand; coverage mode is dispatched via `-g/--group coverage` (verified against `src/cli/commands/misc_ops_args.rs` / `src/cli/check_test.rs`).
- **Nonexistent flags:** replaced the fictional `forjar test coverage --min-line 95 --enforce` example with the real gates — `forjar test --group coverage --json` for per-resource L0–L5 levels, and `cargo llvm-cov --summary-only --fail-under-lines 95` for source coverage (matches the Makefile/`coverage.yml` CI gate).
- Version/MSRV sweep (`1.4.x`/`1.5.x`/`Rust 1.8x`) found no stale forjar version literals in the book — chapter 34's `1.x` hits are CIS benchmark IDs and pack version IDs, not forjar versions. The behavioral "changed in v1.6.0" notes are correct historical markers and were left intact.

## Feature-coverage additions (verified against `src/cli`)
- **`forjar dist`** (`06b-cli-reference-appendix.md`): documented `--verify` (Tier-1 static: `sh -n`, bashrs lint, snippet/URL checks), `--verify-containers` (Tier-2: runs the generated installer in ubuntu/alpine containers; implies `--verify`), and real checksum resolution via `--version <TAG>` / `--checksums-file <PATH>`. Flag spellings/help confirmed in `src/cli/commands/dist_args.rs`.
- **Install / getting-started** (`01-getting-started.md`): now leads with `cargo install forjar` (crates.io) and the binary one-liner + `cargo binstall`, consistent with the README, instead of source-build only.
- **L3–L5 coverage persistence** (`41-testing-strategy.md`): verified present and accurate (levels L3 convergence / L4 mutation / L5 preservation, `test-coverage.jsonl`, hash-gated promotion).
- **Provable convergence contracts** (`13-formal-verification.md`): added a concise table noting `F-IDEM-001` (idempotent-apply), `F-PAE-001` (plan/apply-equivalence), `F-UNDO-001` (destroy-undo-roundtrip) in `contracts/`, each `verification_level: L3` and backed by the `proof_planner_idempotency_bounded` Kani harness / `debug_assert!` + regression tests. IDs and levels verified directly against the YAML specs.

## Verification
- `cargo test --test doc_cli_parity` → **4 passed, 0 failed** (incl. `every_cli_subcommand_is_documented_in_the_book`).
- `mdbook build docs/book` (mdbook v0.5.2) → success, no broken SUMMARY links. The lone `<stderr>` HTML-tag warning is pre-existing in `11-troubleshooting.md` (untouched).
- No new chapters added, so `SUMMARY.md` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)