### PR TITLE
docs(readme): correct C9 dependency claim (30, not <20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,9 +334,13 @@ Tests: `test_fj019_validate_inputs_type_mismatch`, `test_fj019_validate_inputs_e
 Single-quoted heredoc prevents shell expansion in file content.
 Tests: `test_fj007_heredoc_safe`
 
-### C9: Minimal dependencies
-Fewer than 20 direct crate dependencies (currently 17 runtime + 1 build). Single binary output.
-Verify: `cargo metadata --no-deps --format-version 1 | jq '[.packages[0].dependencies[] | select(.kind == null)] | length'`
+### C9: Lean dependency set
+30 direct runtime dependencies — 27 always-on plus 3 optional, feature-gated
+(`age` for encryption, `wasmi` for WASM plugins, `dhat` for heap profiling) —
+and 3 build dependencies. Single static binary output.
+Verify (counts all runtime deps, including the optional ones):
+`cargo metadata --no-deps --format-version 1 | jq '[.packages[0].dependencies[] | select(.kind == null)] | length'` → `30`
+(build deps: `select(.kind == "build")` → `3`).
 
 ### C10: Jidoka failure isolation
 First failure stops execution. Previously converged state is preserved. A failing `pre_apply`


### PR DESCRIPTION
Fixes the falsified C9 claim the dogfood skill found (#177): README said "<20 deps (17 runtime + 1 build)" but its own verify command reports **30 runtime** (27 always-on + 3 optional: `age`/`wasmi`/`dhat`) + 3 build deps. Restated so the claim and its verify command agree.

Closes #177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)