### PR TITLE
fix(examples): make 4 stale example configs validate + add examples-validate guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,11 +41,24 @@ jobs:
       - name: Verify Cargo.lock is committed and current
         run: cargo package --locked --no-verify
 
+  # Regression guard (#179): every shipped standalone example config must pass
+  # `forjar validate`. The sovereign-ci `test` job only runs `cargo test --lib`,
+  # so this integration test (tests/examples_validate.rs) needs an explicit step.
+  # Deterministic and offline — validate never opens a network/SSH connection.
+  examples-validate:
+    name: examples-validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - name: Validate all standalone example configs
+        run: cargo test --locked --test examples_validate
+
   # Top-level gate: satisfies org ruleset which requires check named "gate".
   # The reusable workflow produces "ci / gate" but rulesets need exact match on "gate".
   gate:
     runs-on: ubuntu-latest
-    needs: [ci, lockfile]
+    needs: [ci, lockfile, examples-validate]
     if: always()
     steps:
       - name: Check required jobs
@@ -56,6 +69,10 @@ jobs:
           fi
           if [ "${{ needs.lockfile.result }}" != "success" ]; then
             echo "lockfile preflight failed: ${{ needs.lockfile.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.examples-validate.result }}" != "success" ]; then
+            echo "examples-validate failed: ${{ needs.examples-validate.result }}"
             exit 1
           fi
           echo "All required jobs passed"

--- a/examples/agent-deployment.yaml
+++ b/examples/agent-deployment.yaml
@@ -33,8 +33,7 @@ resources:
     type: model
     machine: gpu-box
     name: "{{params.model_name}}"
-    model_source: local
-    model_path: "{{params.model_path}}"
+    source: "{{params.model_path}}" # local path or URI to the model weights
     depends_on: [gpu-driver]
     tags: [agent, model, ml]
 
@@ -43,6 +42,7 @@ resources:
     type: file
     machine: gpu-box
     path: "/etc/pforge/{{params.agent_name}}.yaml"
+    sudo: true # /etc is a privileged path; the 'deploy' user needs sudo to write it
     content: |
       name: {{params.agent_name}}
       model: {{params.model_name}}
@@ -78,6 +78,8 @@ policies:
   - type: require
     message: "all resources must be tagged"
     field: tags
+  # deny rules match on a concrete field/value pair (equality check), not regex.
   - type: deny
-    message: "no curl|bash patterns"
-    pattern: "curl.*\\|.*bash"
+    message: "files must not be owned by root (run as the deploy user)"
+    condition_field: owner
+    condition_value: root

--- a/examples/dogfood-gpu-training.yaml
+++ b/examples/dogfood-gpu-training.yaml
@@ -48,21 +48,22 @@ resources:
     mode: "0755"
 
   # ── Verify GPU availability ─────────────────────────────────────
+  # Verify AMD GPUs available via Vulkan on intel
   gpu-check-intel:
     type: task
     machine: intel
     command: |
       vulkaninfo --summary 2>/dev/null | grep -c "GPU" || echo "0"
-    description: "Verify AMD GPUs available via Vulkan on intel"
 
+  # Verify NVIDIA GPU available on lambda
   gpu-check-lambda:
     type: task
     machine: lambda
     command: |
       nvidia-smi --query-gpu=name,memory.total --format=csv,noheader 2>/dev/null || echo "no-gpu"
-    description: "Verify NVIDIA GPU available on lambda"
 
   # ── Model weights sync ──────────────────────────────────────────
+  # Sync model weights from intel to lambda
   model-sync-lambda:
     type: task
     machine: lambda
@@ -71,9 +72,9 @@ resources:
         rsync -avz --progress noah@192.168.50.100:{{params.model_dir}}/ {{params.model_dir}}/
       fi
     depends_on: [training-output-lambda]
-    description: "Sync model weights from intel to lambda"
 
   # ── Training data sync ──────────────────────────────────────────
+  # Sync training data from intel to lambda
   data-sync-lambda:
     type: task
     machine: lambda
@@ -82,26 +83,26 @@ resources:
         rsync -avz noah@192.168.50.100:{{params.data_dir}}/ {{params.data_dir}}/
       fi
     depends_on: [training-output-lambda]
-    description: "Sync training data from intel to lambda"
 
   # ── Build aprender on both machines ─────────────────────────────
+  # Build apr CLI with wgpu support on intel
   build-apr-intel:
     type: task
     machine: intel
     command: |
       cd /home/noah/src/aprender && cargo build -p apr-cli --features entrenar/gpu --release
     depends_on: [gpu-check-intel]
-    description: "Build apr CLI with wgpu support on intel"
 
+  # Build apr CLI with CUDA support on lambda
   build-apr-lambda:
     type: task
     machine: lambda
     command: |
       cd /home/noah/src/aprender && cargo build -p apr-cli --features entrenar/cuda --release
     depends_on: [gpu-check-lambda, model-sync-lambda, data-sync-lambda]
-    description: "Build apr CLI with CUDA support on lambda"
 
   # ── Launch coordinator (intel) ──────────────────────────────────
+  # Launch training coordinator on intel (2x Radeon Pro W5700X)
   training-coordinator:
     type: task
     machine: intel
@@ -115,9 +116,9 @@ resources:
         {{params.model_dir}} --data {{params.data_dir}}/train.jsonl \
         -o {{params.output_dir}}
     depends_on: [build-apr-intel]
-    description: "Launch training coordinator on intel (2x Radeon Pro W5700X)"
 
   # ── Launch worker (lambda) ─────────────────────────────────────
+  # Launch training worker on lambda (RTX 4090)
   training-worker:
     type: task
     machine: lambda
@@ -127,7 +128,6 @@ resources:
         --gpus 0 --gpu-backend cuda \
         {{params.model_dir}} --data {{params.data_dir}}/train.jsonl
     depends_on: [build-apr-lambda, training-coordinator]
-    description: "Launch training worker on lambda (RTX 4090)"
 
 policy:
   failure: stop_on_first

--- a/examples/dogfood-outputs.yaml
+++ b/examples/dogfood-outputs.yaml
@@ -21,6 +21,7 @@ resources:
     type: file
     machine: web
     path: /etc/app/config.yaml
+    sudo: true # /etc is a privileged path; the 'deploy' user needs sudo to write it
     content: |
       data_dir: {{params.data_dir}}
       port: {{params.app_port}}

--- a/examples/multi-agent-fleet.yaml
+++ b/examples/multi-agent-fleet.yaml
@@ -48,6 +48,7 @@ resources:
     type: file
     machine: [gpu-1, gpu-2, gpu-3]
     path: /etc/pforge/agent.yaml
+    sudo: true # /etc is a privileged path; the 'deploy' user needs sudo to write it
     content: |
       name: fleet-agent
       model: llama-3.2-3b
@@ -71,6 +72,7 @@ resources:
     type: file
     machine: gpu-1
     path: /etc/nginx/conf.d/agent-lb.conf
+    sudo: true # /etc is a privileged path; the 'deploy' user needs sudo to write it
     content: |
       upstream agent_pool {
         server 192.168.1.101:{{params.mcp_port}};
@@ -102,6 +104,7 @@ resources:
     type: file
     machine: [gpu-1, gpu-2, gpu-3]
     path: /etc/pforge/tool-policy.yaml
+    sudo: true # /etc is a privileged path; the 'deploy' user needs sudo to write it
     content: |
       allow:
         - file-read
@@ -118,6 +121,8 @@ policies:
   - type: require
     message: "all resources must be tagged"
     field: tags
+  # deny rules match on a concrete field/value pair (equality check), not regex.
   - type: deny
-    message: "no curl|bash patterns"
-    pattern: "curl.*\\|.*bash"
+    message: "files must not be owned by root (run as the deploy user)"
+    condition_field: owner
+    condition_value: root

--- a/tests/examples_validate.rs
+++ b/tests/examples_validate.rs
@@ -1,0 +1,93 @@
+//! Regression guard (Refs #179): every shipped standalone example config must
+//! pass `forjar validate`.
+//!
+//! Background: 4 `examples/*.yaml` configs went stale against the current schema
+//! (unknown fields like `model_source`/`description`, privileged paths missing
+//! `sudo: true`, a non-existent `pattern` policy field) and silently failed
+//! `forjar validate`. This test sweeps the example set so a stale example can
+//! never regress unnoticed again.
+//!
+//! Strategy: call the library validate path directly
+//! (`parse_and_validate_opts(path, /*deny_unknown=*/ true)`) rather than shelling
+//! out to the binary. This mirrors exactly what `forjar validate` does — unknown
+//! fields are hard errors, then `validate_config` runs the semantic checks — while
+//! staying deterministic and fully offline (validate never opens an SSH/network
+//! connection). It also avoids depending on a built binary being present in CI.
+//!
+//! Scope: only top-level `examples/*.yaml` files that declare a `machines:` block
+//! are treated as standalone, validatable configs. Files without `machines:` are
+//! illustrative fragments (e.g. an `includes:`-only snippet) and are skipped, as
+//! are recipe/cookbook fragments under subdirectories.
+//!
+//! Usage: cargo test --test examples_validate
+
+use forjar::core::parser::parse_and_validate_opts;
+use std::path::{Path, PathBuf};
+
+/// Absolute path to the `examples/` directory in the crate root.
+fn examples_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("examples")
+}
+
+/// True if the YAML declares a top-level `machines:` block — i.e. it is a
+/// standalone config rather than an illustrative fragment.
+fn declares_machines(contents: &str) -> bool {
+    contents.lines().any(|line| line.trim_end() == "machines:")
+}
+
+/// Collect every top-level `examples/*.yaml` that declares a `machines:` block.
+fn standalone_example_configs() -> Vec<PathBuf> {
+    let dir = examples_dir();
+    let mut configs: Vec<PathBuf> = std::fs::read_dir(&dir)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", dir.display()))
+        .filter_map(|entry| entry.ok().map(|e| e.path()))
+        .filter(|path| path.extension().is_some_and(|ext| ext == "yaml"))
+        .filter(|path| {
+            std::fs::read_to_string(path)
+                .ok()
+                .as_deref()
+                .is_some_and(declares_machines)
+        })
+        .collect();
+    configs.sort();
+    configs
+}
+
+#[test]
+fn examples_dir_has_standalone_configs() {
+    // Guard against the sweep silently passing because it found nothing
+    // (e.g. the directory moved or the glob broke).
+    let configs = standalone_example_configs();
+    assert!(
+        configs.len() >= 40,
+        "expected the standalone example sweep to find many configs, found {} — \
+         did examples/ move or did `machines:` detection break?",
+        configs.len()
+    );
+}
+
+#[test]
+fn every_standalone_example_validates() {
+    let mut failures: Vec<String> = Vec::new();
+
+    for path in standalone_example_configs() {
+        // deny_unknown = true mirrors `forjar validate` exactly: unknown fields
+        // are hard errors, then validate_config runs the semantic checks
+        // (sudo inference, dependency cycles, type-specific rules, …).
+        if let Err(e) = parse_and_validate_opts(&path, true) {
+            let name = path
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_else(|| path.display().to_string());
+            failures.push(format!("  {name}: {e}"));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "the following standalone example configs failed `forjar validate` \
+         (fix the example or mark it as an intentionally-partial fragment by \
+         removing its top-level `machines:` block):\n{}",
+        failures.join("\n")
+    );
+}


### PR DESCRIPTION
Closes #179

The dogfood QA skill (Gate 2) found that 4 of 45 standalone `examples/*.yaml` configs failed `forjar validate` against the current schema. forjar's validation is **correct** — the examples were stale. Each fix preserves the example's teaching intent.

## Per-example fixes

### `examples/agent-deployment.yaml`
- Removed unknown model fields `model_source: local` + `model_path:` — the `model` resource uses `source:` for the weights location (matching the canonical `examples/recipes/apr-inference-server.yaml` and `multi-agent-fleet.yaml`). Collapsed to `source: "{{params.model_path}}"`.
- Added `sudo: true` to the `agent-config` file resource (writes to `/etc/pforge/...` as the non-root `deploy` user).
- Replaced the non-existent `pattern:` policy field on the `deny` rule with a valid `condition_field: owner` / `condition_value: root` rule (deny rules do field/value equality, not regex), keeping a real security-policy illustration.

### `examples/dogfood-gpu-training.yaml`
- Converted 8 unknown `description:` fields on `task` resources into YAML comments on the line above (`description` is not a resource field; the human-readable annotations are preserved verbatim).

### `examples/dogfood-outputs.yaml`
- Added `sudo: true` to the `app-config` file resource (writes to `/etc/app/config.yaml` as `deploy`).

### `examples/multi-agent-fleet.yaml`
- Replaced the `pattern:` policy field with a valid `condition_field`/`condition_value` deny rule (same as agent-deployment).
- Added `sudo: true` to the three `/etc/...` file resources (`agent-config`, `lb-config`, `tool-policy`), surfaced once the unknown-field error stopped masking the semantic checks.

No invented fields — every replacement field exists in `src/core/parser/known_fields.rs`.

## Regression guard

New integration test `tests/examples_validate.rs`:
- Sweeps every top-level `examples/*.yaml` that declares a `machines:` block (illustrative fragments without `machines:` are skipped).
- Calls the library validate path directly — `forjar::core::parser::parse_and_validate_opts(path, /*deny_unknown=*/ true)` — which is exactly what `forjar validate` runs (unknown fields are hard errors, then `validate_config` semantic checks). No binary dependency, deterministic, fully offline (validate never opens a network/SSH connection).
- A second test guards against the sweep silently finding nothing.

Wired into CI as an explicit `examples-validate` gate job in `.github/workflows/ci.yml`, because the sovereign-ci `test` job only runs `cargo test --lib` (which does not run `tests/`).

## Verification

- All 4 originally-failing examples now `forjar validate` → exit 0.
- Full standalone sweep `for f in examples/*.yaml; do grep -q '^machines:' $f && forjar validate -f $f; done` → **45/45 pass** (was 41/45).
- `cargo test --test examples_validate` → green (2 tests).
- `cargo clippy --all-targets -- -D warnings` → clean. `cargo fmt --all --check` → clean. `cargo test --lib` → 12460 passed (3 pre-existing Docker/container-backend timeouts in the sandbox, unrelated to this docs/examples change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)