### PR TITLE
ci(nextest): enable use_nextest pilot (PMAT-155 Phase 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,11 @@ jobs:
     uses: paiml/.github/.github/workflows/sovereign-ci.yml@main
     with:
       repo: ${{ github.event.repository.name }}
+      # PMAT-155 Phase 2 nextest pilot (build-performance.md §4.3 + §7 Phase 2).
+      # forjar = medium workload, healthy --lib suite. cargo-nextest is baked into
+      # sovereign-ci:stable (infra Dockerfile). Pilot only — keep until F11 test-job
+      # p95 ≤ 300s is verified over 7 days, then promote fleet-wide.
+      use_nextest: true
     secrets: inherit
 
   # Release preflight: a stale Cargo.lock must fail PR CI, not the tag.


### PR DESCRIPTION
## PMAT-155 Phase 2 — nextest migration pilot

Enables `use_nextest: true` on the shared `sovereign-ci` reusable workflow call for **forjar** (one of 3 pilot repos).

### Why forjar
- Medium-workload Rust repo with a healthy `--lib` test suite (paiml-owned, CI green on main).
- `cargo-nextest` is already baked into `sovereign-ci:stable` (infra `machines/intel/sovereign-ci/Dockerfile`, `cargo install cargo-nextest --locked`, verified at image build via `cargo nextest --version`).
- The reusable workflow falls back to `cargo test` if nextest fails, so this is low-risk.

### What this does
The `test` job runs `cargo nextest run` instead of `cargo test` (build-performance.md §4.3). Expected 30-40% test-job speedup on larger suites.

### Pilot scope
This is a **pilot only**. Keep `use_nextest: true` here until **F11 test-job p95 ≤ 300s is verified over a 7-day observation window** (build-performance.md §7 Phase 2), then promote fleet-wide. The 7-day observation is a separate WAIT step that cannot be completed at PR-open time.

Refs PMAT-155

🤖 Generated with [Claude Code](https://claude.com/claude-code)