### PR TITLE
v1.11.1 — fix two defects in 1.11.0 found by dogfooding it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.1] - 2026-07-27
+
+### Fixed — two defects in 1.11.0, found by dogfooding it
+
+**Directory `output_artifacts` created an idempotency pump.** Hashing a
+directory's *contents* meant the canonical translation of make's `| build`
+order-only prerequisite — `output_artifacts: ["build"]` — went stale the moment
+the next rule wrote into it. Observed: apply #1 converged, apply #2 reported
+`stale — output artifact modified` and **re-ran the entire graph**, and only
+apply #3 settled. That violates `f(f(x)) = f(x)`, forjar's core idempotency
+contract.
+
+A directory artifact is now identified by **existence**, never by contents. Its
+contents are the products of *other* rules; they are not the identity of the
+rule that created it. Files declared alongside a directory are still hashed.
+
+**The read paths were blind to the staleness `apply` acts on.** `planner::plan`
+forwarded an EMPTY probe map, so after `rm build/demo`:
+
+```
+forjar plan  -> Plan: 0 to add, 0 to change, 0 to destroy, 3 unchanged
+forjar check -> Check: 3 pass, 0 fail, 0 skip
+forjar drift -> No drift detected
+forjar apply -> stale — output artifact missing ... rebuilt
+```
+
+A planner that cannot predict its own apply is worse than one that is merely
+conservative. `plan` now probes, so `plan`/`drift`/`observe` and `apply` give
+one answer. `plan_with_probes` remains pure for unit tests.
+
+### Known limitation
+
+`forjar check` still over-reports. Its generated scripts echo a marker
+(`task=completed` / `task=pending`) but exit 0 either way, and the CLI grades on
+process success — so `check` currently means "a shell ran", not "the resource is
+converged". Fixing it touches all 14 resource generators and changes what
+`check` means for non-build resources, so it is deferred rather than rushed into
+a patch release.
+
+
 ## [1.11.0] - 2026-07-27
 
 ### Added — incremental builds: forjar now plans from the world, not just the config

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1117,7 +1117,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "forjar"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "age",
  "aprender-contracts",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forjar"
-version = "1.11.0"
+version = "1.11.1"
 edition.workspace = true
 rust-version = "1.89.0"
 authors = ["Pragmatic AI Labs"]

--- a/src/core/planner/mod.rs
+++ b/src/core/planner/mod.rs
@@ -11,12 +11,15 @@ pub fn plan(
     locks: &std::collections::HashMap<String, StateLock>,
     tag_filter: Option<&str>,
 ) -> ExecutionPlan {
+    // v1.11.0 forwarded an EMPTY map here, which made every READ path
+    // (plan/check/drift/observe) blind to the staleness that `apply` acts on.
+    // Probing here means one answer for both.
     plan_with_probes(
         config,
         execution_order,
         locks,
         tag_filter,
-        &std::collections::HashMap::new(),
+        &crate::core::task::probe_config(config),
     )
 }
 

--- a/src/core/task/mod.rs
+++ b/src/core/task/mod.rs
@@ -10,7 +10,7 @@ pub mod service;
 
 pub mod probe;
 pub use io_tracking::{hash_inputs, hash_outputs, hash_outputs_in, should_skip_cached};
-pub use probe::{probe_all, probe_resource, staleness_reason, IoDigest};
+pub use probe::{probe_all, probe_config, probe_resource, staleness_reason, IoDigest};
 pub use quality_gate::{evaluate_gate, gpu_env_vars, GateAction, GateResult};
 
 #[cfg(test)]

--- a/src/core/task/probe.rs
+++ b/src/core/task/probe.rs
@@ -104,12 +104,27 @@ pub fn probe_resource(resource: &Resource) -> Option<IoDigest> {
         }
     }
 
-    let output_hash = if resource.output_artifacts.is_empty() || outputs_missing {
+    // A DIRECTORY artifact is identified by its existence, never by its
+    // contents. Hashing contents created an idempotency pump: the canonical
+    // translation of make's `| build` order-only directory prerequisite
+    // declares `output_artifacts: ["build"]`, and the very next rule writes
+    // build/a.o INTO it — so apply #2 saw "output artifact modified" and
+    // re-ran the entire graph, with only apply #3 settling. That violates
+    // f(f(x)) = f(x), forjar's core idempotency contract.
+    //
+    // The contents of a directory are the products of OTHER rules; they are
+    // not the identity of the rule that created the directory.
+    let file_artifacts: Vec<String> = resource
+        .output_artifacts
+        .iter()
+        .filter(|a| !resolve_under(&base, a).is_dir())
+        .cloned()
+        .collect();
+
+    let output_hash = if file_artifacts.is_empty() || outputs_missing {
         None
     } else {
-        hash_outputs_in(&resource.output_artifacts, &base)
-            .ok()
-            .flatten()
+        hash_outputs_in(&file_artifacts, &base).ok().flatten()
     };
 
     Some(IoDigest {
@@ -233,4 +248,34 @@ pub fn record_io_hashes(
             );
         }
     }
+}
+
+/// Build the probe map for a whole config.
+///
+/// The single place that decides what "observed state" means, so the read
+/// paths (`plan`, `check`, `drift`, `observe`) and the write path (`apply`)
+/// can never disagree about it.
+///
+/// v1.11.0 shipped without this: `planner::plan` forwarded an EMPTY map, so
+/// after `rm build/demo` the tool reported `Plan: 0 to change, 3 unchanged`,
+/// `Check: 3 pass, 0 fail`, and `No drift detected` — and then `apply`
+/// rebuilt. A planner that cannot predict its own apply is worse than one
+/// that is merely conservative.
+///
+/// Resources MUST be resolved first: `working_dir` is routinely
+/// `{{params.proj}}`, and probing the raw form makes every artifact look
+/// missing.
+pub fn probe_config(config: &crate::core::types::ForjarConfig) -> HashMap<String, IoDigest> {
+    let resolved = crate::core::resolver::resolve_all(
+        &config.resources,
+        &config.params,
+        &config.machines,
+        &config.secrets,
+    );
+    probe_all(&resolved, |m| {
+        config
+            .machines
+            .get(m)
+            .is_some_and(crate::transport::machine_is_local)
+    })
 }

--- a/src/core/task/tests_probe.rs
+++ b/src/core/task/tests_probe.rs
@@ -175,3 +175,65 @@ fn real_filesystem_roundtrip_detects_content_change() {
 
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+#[test]
+fn directory_artifact_is_identified_by_existence_not_contents() {
+    // v1.11.0 REGRESSION: hashing a directory's CONTENTS created an
+    // idempotency pump. The canonical translation of make's `| build`
+    // order-only prerequisite declares `output_artifacts: ["build"]`, and the
+    // next rule writes build/a.o INTO it — so apply #2 saw "output artifact
+    // modified" and re-ran the whole graph, violating f(f(x)) = f(x).
+    let dir = std::env::temp_dir().join(format!("forjar-dirart-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(dir.join("build")).unwrap();
+
+    let r = task_with(&[], &["build"], dir.to_str());
+    let before = probe_resource(&r).expect("declares an output");
+    assert!(!before.outputs_missing, "the directory exists");
+
+    // A later rule drops a product into the directory.
+    std::fs::write(dir.join("build/a.o"), "OBJECT BYTES").unwrap();
+    let after = probe_resource(&r).unwrap();
+
+    assert_eq!(
+        after, before,
+        "a directory artifact must not change identity when other rules write into it"
+    );
+    assert_eq!(
+        staleness_reason(&after, None, before.output_hash.as_deref()),
+        None,
+        "writing into the directory must not make its creator stale"
+    );
+
+    // Deleting it still counts as missing — existence is the signal.
+    std::fs::remove_dir_all(dir.join("build")).unwrap();
+    assert!(probe_resource(&r).unwrap().outputs_missing);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn mixed_file_and_directory_artifacts_still_track_the_file() {
+    // Descoping directories must not silently descope files declared next to
+    // them — that would turn the fix into a hole.
+    let dir = std::env::temp_dir().join(format!("forjar-mixart-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(dir.join("build")).unwrap();
+    std::fs::write(dir.join("build/bin"), "V1").unwrap();
+
+    let r = task_with(&[], &["build", "build/bin"], dir.to_str());
+    let first = probe_resource(&r).unwrap();
+    assert!(
+        first.output_hash.is_some(),
+        "the file artifact is still hashed"
+    );
+
+    std::fs::write(dir.join("build/bin"), "V2").unwrap();
+    let second = probe_resource(&r).unwrap();
+    assert_ne!(
+        second.output_hash, first.output_hash,
+        "a modified FILE artifact must still be detected"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
Two defects in the release I shipped hours ago. Both were found by **installing 1.11.0 from crates.io and using it**, not by the 12494-test suite.

## 1. Directory `output_artifacts` created an idempotency pump

Hashing a directory's **contents** meant the canonical translation of make's `| build` order-only prerequisite — `output_artifacts: ["build"]` — went stale the moment the next rule wrote into it:

```
apply 1: 2 converged, 0 unchanged
apply 2: stale — output artifact modified   2 converged, 0 unchanged
apply 3: 0 converged, 2 unchanged
```

Only the **third** apply settled. That violates `f(f(x)) = f(x)` — forjar's core idempotency contract — and it fires on the most ordinary build shape there is.

A directory artifact is now identified by **existence**, never contents. Its contents are the products of *other* rules; they are not the identity of the rule that created it. Files declared alongside a directory are still hashed — there's a test that fails if descoping directories silently descopes files too.

## 2. The read paths were blind to the staleness `apply` acts on

`planner::plan` forwarded an **empty** probe map. After `rm build/demo`:

```
forjar plan  -> Plan: 0 to add, 0 to change, 0 to destroy, 3 unchanged
forjar check -> Check: 3 pass, 0 fail, 0 skip
forjar drift -> No drift detected
forjar apply -> stale — output artifact missing ... rebuilt
```

I wrote that empty map deliberately, for call-site compatibility. **It was the wrong call** — a planner that cannot predict its own apply is worse than one that is merely conservative. `plan()` now probes via a new `probe_config()`, so every read path and the write path give one answer. `plan_with_probes` stays pure, so planner unit tests still just construct the map.

After: `plan` reports `1 to change` and `apply` does `1 converged`.

## Known limitation — stated, not quietly shipped

`forjar check` still over-reports. Its generated scripts echo `task=completed`/`task=pending` but **exit 0 either way**, and the CLI grades on process success — so `check` currently means "a shell ran", not "the resource is converged". Fixing it touches all 14 resource generators and changes what `check` means for non-build resources. That does not belong in a patch release; it's queued for 1.12.

## Gates

12496 tests (+2 regression) · fmt · clippy `-D warnings` · clean-room to follow before publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)