### PR TITLE
fix: v1.12.1 — three interface defects found by driving every surface (Refs PMAT-199)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.12.1] - 2026-07-28
+
+Three interface defects found by installing 1.12.0 from crates.io and driving
+every CLI, MCP and LSP surface against a real project. None was visible from a
+schema, a `tools/list`, or a handler test that only asserted "returns Ok".
+
+### Fixed
+
+- **MCP `forjar_plan` reported every resource as a pending change.**
+  `ExecutionPlan::changes` carries EVERY resource with its action, NoOp
+  included; `cli::plan` filters those before counting and the MCP handler did
+  not. A fully converged project reported all 6 of its resources as pending
+  while the CLI reported `0 to change`. It also included phony resources, which
+  are goal-only.
+- **MCP `forjar_status` returned no machines, ever.** It scanned the state
+  directory for files with a `.json` extension; a machine's state is a
+  DIRECTORY, `state/<machine>/state.lock.yaml`. The CLI printed
+  `Machine: local (localhost)` for the same project.
+- **`forjar lsp` was an unrecognized subcommand.** The language server is
+  complete and has 80 passing tests, but no `Commands` variant dispatched it,
+  so no editor could start it. Now wired and documented.
+
+### Known
+
+`core::webhook_server` implements an HTTP endpoint with 16 tests including live
+socket accept/reject, but nothing starts it — there is no `forjar webhook`
+command. Exposing a listening socket needs bind-address and authentication
+decisions, so it is a design question rather than a wiring fix; tracked in
+PMAT-200 rather than added unilaterally in a patch release.
+
 ## [1.12.0] - 2026-07-28
 
 forjar can now **replace and ingest** a trivial Makefile. Getting there required

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1117,7 +1117,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "forjar"
-version = "1.12.0"
+version = "1.12.1"
 dependencies = [
  "age",
  "aprender-contracts",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forjar"
-version = "1.12.0"
+version = "1.12.1"
 edition.workspace = true
 rust-version = "1.89.0"
 authors = ["Pragmatic AI Labs"]

--- a/docs/book/src/06b-cli-reference-appendix.md
+++ b/docs/book/src/06b-cli-reference-appendix.md
@@ -57,6 +57,18 @@ are detected and reported, and nothing is written. Review the generated config
 before applying it: recipes are make's own expansion, and forjar injects
 `set -euo pipefail` where make sets no shell options.
 
+### forjar lsp
+
+Run the forjar.yaml language server on stdio, for editor integration.
+
+```bash
+forjar lsp
+```
+
+Speaks LSP over stdin/stdout with `Content-Length` framing: diagnostics from the
+same validator `forjar validate` uses, plus completion for resource types and
+fields. Point your editor's LSP client at this command for `forjar.yaml` files.
+
 ## Config Analysis & Composition
 
 ### forjar stack-diff

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -48,6 +48,8 @@ pub enum Commands {
     /// FJ-2726: Import a Makefile's build graph into forjar.yaml
     #[command(name = "import-makefile")]
     ImportMakefile(ImportMakefileArgs),
+    /// Run the forjar.yaml language server on stdio (editor integration)
+    Lsp,
     /// Detect unauthorized changes (tripwire)
     Drift(DriftArgs),
     /// Show current state from lock files

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -68,6 +68,10 @@ pub fn dispatch(cmd: Commands, verbose: u8, no_color: bool) -> Result<(), String
         cmd @ Commands::Apply(..) => dispatch_apply_cmd(cmd, verbose),
         Commands::Make(args) => super::make::cmd_make(&args, verbose),
         Commands::ImportMakefile(args) => super::makefile_cmd::cmd_import_makefile(&args),
+        // FJ-2730: the LSP server had 80 passing tests, a complete stdio
+        // implementation and NO entry point — `forjar lsp` was an unrecognized
+        // subcommand. Found by sweeping every interface.
+        Commands::Lsp => super::lsp::cmd_lsp(),
         Commands::Drift(DriftArgs {
             file,
             machine,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -281,3 +281,13 @@ pub use dispatch::dispatch;
 include!("mod_test_decl.rs");
 include!("mod_test_decl_b.rs");
 include!("mod_test_decl_c.rs");
+
+/// FJ-2729: the phony filter, for the MCP layer.
+///
+/// `mcp::handlers` must apply exactly the same goal-only phony rule as
+/// `cli::plan`, or the two disagree about whether a converged project has
+/// pending work. Re-exported through one named function so there is a single
+/// definition, not a second implementation.
+pub(crate) fn strip_unrequested_phony_for_mcp(config: &mut crate::core::types::ForjarConfig) {
+    apply_selection::strip_unrequested_phony(config, &[]);
+}

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -3,8 +3,8 @@
 use pforge_runtime::Handler;
 use std::path::PathBuf;
 
-use crate::core::{codegen, parser, planner, resolver, state, types};
-use crate::tripwire::{anomaly, drift, tracer};
+use crate::core::{codegen, parser, planner, resolver, state};
+use crate::tripwire::drift;
 
 use super::types::*;
 
@@ -66,7 +66,13 @@ impl Handler for PlanHandler {
         let path = PathBuf::from(&input.path);
         let state_dir = PathBuf::from(input.state_dir.as_deref().unwrap_or("state"));
 
-        let config = parser::parse_and_validate(&path).map_err(pforge_runtime::Error::Handler)?;
+        let mut config =
+            parser::parse_and_validate(&path).map_err(pforge_runtime::Error::Handler)?;
+
+        // FJ-2729: mirror `cli::plan`. Phony resources are goal-only, so a bulk
+        // plan must not report them — otherwise an agent reading this tool sees
+        // a converged project as permanently pending.
+        crate::cli::strip_unrequested_phony_for_mcp(&mut config);
 
         let order =
             resolver::build_execution_order(&config).map_err(pforge_runtime::Error::Handler)?;
@@ -81,9 +87,15 @@ impl Handler for PlanHandler {
 
         let exec_plan = planner::plan(&config, &order, &locks, input.tag.as_deref());
 
+        // FJ-2729: `exec_plan.changes` carries EVERY resource with its action,
+        // including NoOp — `cli::plan` filters those out before counting
+        // (plan.rs:262). The MCP handler did not, so it reported all 6
+        // resources of a fully converged project as pending changes while the
+        // CLI reported "0 to change". Verified on the published 1.12.0 binary.
         let mut changes: Vec<PlannedChangeOutput> = exec_plan
             .changes
             .iter()
+            .filter(|c| c.action != crate::core::types::PlanAction::NoOp)
             .map(|c| PlannedChangeOutput {
                 resource_id: c.resource_id.clone(),
                 machine: c.machine.clone(),
@@ -291,203 +303,6 @@ impl Handler for ShowHandler {
 
         Ok(ShowOutput {
             config: config_value,
-        })
-    }
-}
-
-#[async_trait::async_trait]
-impl Handler for StatusHandler {
-    type Input = StatusInput;
-    type Output = StatusOutput;
-    type Error = pforge_runtime::Error;
-
-    async fn handle(&self, input: Self::Input) -> pforge_runtime::Result<Self::Output> {
-        let state_dir = PathBuf::from(input.state_dir.as_deref().unwrap_or("state"));
-
-        let mut machines = Vec::new();
-
-        if state_dir.exists() {
-            let entries = std::fs::read_dir(&state_dir)
-                .map_err(|e| pforge_runtime::Error::Handler(e.to_string()))?;
-
-            for entry in entries.flatten() {
-                let path = entry.path();
-                if path.extension().and_then(|e| e.to_str()) == Some("json") {
-                    let name = path
-                        .file_stem()
-                        .and_then(|s| s.to_str())
-                        .unwrap_or("unknown")
-                        .to_string();
-
-                    if let Some(ref m) = input.machine {
-                        if &name != m {
-                            continue;
-                        }
-                    }
-
-                    let resource_count = state::load_lock(&state_dir, &name)
-                        .ok()
-                        .flatten()
-                        .map(|l| l.resources.len())
-                        .unwrap_or(0);
-
-                    machines.push(MachineStatusOutput {
-                        name,
-                        resource_count,
-                    });
-                }
-            }
-        }
-
-        Ok(StatusOutput { machines })
-    }
-}
-
-#[async_trait::async_trait]
-impl Handler for TraceHandler {
-    type Input = TraceInput;
-    type Output = TraceOutput;
-    type Error = pforge_runtime::Error;
-
-    async fn handle(&self, input: Self::Input) -> pforge_runtime::Result<Self::Output> {
-        let state_dir = PathBuf::from(input.state_dir.as_deref().unwrap_or("state"));
-
-        let mut all_spans = Vec::new();
-
-        if state_dir.exists() {
-            let entries = std::fs::read_dir(&state_dir)
-                .map_err(|e| pforge_runtime::Error::Handler(e.to_string()))?;
-
-            for entry in entries.flatten() {
-                let name = entry.file_name().to_string_lossy().to_string();
-                if let Some(ref filter) = input.machine {
-                    if &name != filter {
-                        continue;
-                    }
-                }
-                if !entry.path().is_dir() {
-                    continue;
-                }
-
-                if let Ok(spans) = tracer::read_trace(&state_dir, &name) {
-                    for span in spans {
-                        all_spans.push((name.clone(), span));
-                    }
-                }
-            }
-        }
-
-        all_spans.sort_by_key(|(_, span)| span.logical_clock);
-
-        let trace_count = {
-            let ids: std::collections::HashSet<&str> =
-                all_spans.iter().map(|(_, s)| s.trace_id.as_str()).collect();
-            ids.len()
-        };
-
-        let spans = all_spans
-            .into_iter()
-            .map(|(machine, span)| TraceSpanOutput {
-                machine,
-                trace_id: span.trace_id,
-                span_id: span.span_id,
-                parent_span_id: span.parent_span_id,
-                name: span.name,
-                start_time: span.start_time,
-                duration_us: span.duration_us,
-                exit_code: span.exit_code,
-                resource_type: span.resource_type,
-                action: span.action,
-                content_hash: span.content_hash,
-                logical_clock: span.logical_clock,
-            })
-            .collect();
-
-        Ok(TraceOutput { trace_count, spans })
-    }
-}
-
-#[async_trait::async_trait]
-impl Handler for AnomalyHandler {
-    type Input = AnomalyInput;
-    type Output = AnomalyOutput;
-    type Error = pforge_runtime::Error;
-
-    async fn handle(&self, input: Self::Input) -> pforge_runtime::Result<Self::Output> {
-        let state_dir = PathBuf::from(input.state_dir.as_deref().unwrap_or("state"));
-        let min_events = input.min_events.unwrap_or(3);
-
-        let mut metrics: std::collections::HashMap<String, (u32, u32, u32)> =
-            std::collections::HashMap::new();
-
-        if state_dir.exists() {
-            let entries = std::fs::read_dir(&state_dir)
-                .map_err(|e| pforge_runtime::Error::Handler(e.to_string()))?;
-
-            for entry in entries.flatten() {
-                let name = entry.file_name().to_string_lossy().to_string();
-                if let Some(ref filter) = input.machine {
-                    if &name != filter {
-                        continue;
-                    }
-                }
-                if !entry.path().is_dir() {
-                    continue;
-                }
-
-                let log_path = entry.path().join("events.jsonl");
-                if !log_path.exists() {
-                    continue;
-                }
-
-                let content = std::fs::read_to_string(&log_path)
-                    .map_err(|e| pforge_runtime::Error::Handler(e.to_string()))?;
-
-                for line in content.lines() {
-                    if line.trim().is_empty() {
-                        continue;
-                    }
-                    if let Ok(te) = serde_json::from_str::<types::TimestampedEvent>(line) {
-                        match te.event {
-                            types::ProvenanceEvent::ResourceConverged { ref resource, .. } => {
-                                let key = format!("{name}:{resource}");
-                                metrics.entry(key).or_insert((0, 0, 0)).0 += 1;
-                            }
-                            types::ProvenanceEvent::ResourceFailed { ref resource, .. } => {
-                                let key = format!("{name}:{resource}");
-                                metrics.entry(key).or_insert((0, 0, 0)).1 += 1;
-                            }
-                            types::ProvenanceEvent::DriftDetected { ref resource, .. } => {
-                                let key = format!("{name}:{resource}");
-                                metrics.entry(key).or_insert((0, 0, 0)).2 += 1;
-                            }
-                            _ => {}
-                        }
-                    }
-                }
-            }
-        }
-
-        let metrics_vec: Vec<(String, u32, u32, u32)> = metrics
-            .into_iter()
-            .map(|(k, (c, f, d))| (k, c, f, d))
-            .collect();
-
-        let findings = anomaly::detect_anomalies(&metrics_vec, min_events);
-
-        let output_findings = findings
-            .iter()
-            .map(|f| AnomalyFindingOutput {
-                resource: f.resource.clone(),
-                score: f.score,
-                status: format!("{:?}", f.status),
-                reasons: f.reasons.clone(),
-            })
-            .collect::<Vec<_>>();
-
-        Ok(AnomalyOutput {
-            anomaly_count: output_findings.len(),
-            findings: output_findings,
         })
     }
 }

--- a/src/mcp/handlers_state.rs
+++ b/src/mcp/handlers_state.rs
@@ -1,0 +1,216 @@
+//! MCP handlers that read STATE rather than config: status, trace, anomaly.
+//!
+//! Split out of `handlers.rs` to keep both files under the 500-line limit.
+
+use super::handlers::{AnomalyHandler, StatusHandler, TraceHandler};
+use super::types::*;
+use crate::core::state;
+use crate::core::types;
+use crate::tripwire::{anomaly, tracer};
+use pforge_runtime::Handler;
+use std::path::PathBuf;
+
+#[async_trait::async_trait]
+impl Handler for StatusHandler {
+    type Input = StatusInput;
+    type Output = StatusOutput;
+    type Error = pforge_runtime::Error;
+
+    async fn handle(&self, input: Self::Input) -> pforge_runtime::Result<Self::Output> {
+        let state_dir = PathBuf::from(input.state_dir.as_deref().unwrap_or("state"));
+
+        let mut machines = Vec::new();
+
+        // FJ-2729: a machine's state is a DIRECTORY —
+        // `state/<machine>/state.lock.yaml` (see `state::lock_file_path`). This
+        // scanned for files with a `.json` extension, which forjar has never
+        // written, so the handler returned an empty machine list on every
+        // project. Verified on the published 1.12.0 binary: the CLI printed
+        // `Machine: local (localhost)` while MCP returned `{"machines": []}`.
+        //
+        // Presence of the lock is the test, so a stray directory is not
+        // reported as a machine.
+        if state_dir.exists() {
+            let entries = std::fs::read_dir(&state_dir)
+                .map_err(|e| pforge_runtime::Error::Handler(e.to_string()))?;
+
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    let name = path
+                        .file_name()
+                        .and_then(|s| s.to_str())
+                        .unwrap_or("unknown")
+                        .to_string();
+
+                    if let Some(ref m) = input.machine {
+                        if &name != m {
+                            continue;
+                        }
+                    }
+
+                    let Some(lock) = state::load_lock(&state_dir, &name).ok().flatten() else {
+                        continue;
+                    };
+
+                    machines.push(MachineStatusOutput {
+                        name,
+                        resource_count: lock.resources.len(),
+                    });
+                }
+            }
+        }
+        machines.sort_by(|a, b| a.name.cmp(&b.name));
+
+        Ok(StatusOutput { machines })
+    }
+}
+
+#[async_trait::async_trait]
+impl Handler for TraceHandler {
+    type Input = TraceInput;
+    type Output = TraceOutput;
+    type Error = pforge_runtime::Error;
+
+    async fn handle(&self, input: Self::Input) -> pforge_runtime::Result<Self::Output> {
+        let state_dir = PathBuf::from(input.state_dir.as_deref().unwrap_or("state"));
+
+        let mut all_spans = Vec::new();
+
+        if state_dir.exists() {
+            let entries = std::fs::read_dir(&state_dir)
+                .map_err(|e| pforge_runtime::Error::Handler(e.to_string()))?;
+
+            for entry in entries.flatten() {
+                let name = entry.file_name().to_string_lossy().to_string();
+                if let Some(ref filter) = input.machine {
+                    if &name != filter {
+                        continue;
+                    }
+                }
+                if !entry.path().is_dir() {
+                    continue;
+                }
+
+                if let Ok(spans) = tracer::read_trace(&state_dir, &name) {
+                    for span in spans {
+                        all_spans.push((name.clone(), span));
+                    }
+                }
+            }
+        }
+
+        all_spans.sort_by_key(|(_, span)| span.logical_clock);
+
+        let trace_count = {
+            let ids: std::collections::HashSet<&str> =
+                all_spans.iter().map(|(_, s)| s.trace_id.as_str()).collect();
+            ids.len()
+        };
+
+        let spans = all_spans
+            .into_iter()
+            .map(|(machine, span)| TraceSpanOutput {
+                machine,
+                trace_id: span.trace_id,
+                span_id: span.span_id,
+                parent_span_id: span.parent_span_id,
+                name: span.name,
+                start_time: span.start_time,
+                duration_us: span.duration_us,
+                exit_code: span.exit_code,
+                resource_type: span.resource_type,
+                action: span.action,
+                content_hash: span.content_hash,
+                logical_clock: span.logical_clock,
+            })
+            .collect();
+
+        Ok(TraceOutput { trace_count, spans })
+    }
+}
+
+#[async_trait::async_trait]
+impl Handler for AnomalyHandler {
+    type Input = AnomalyInput;
+    type Output = AnomalyOutput;
+    type Error = pforge_runtime::Error;
+
+    async fn handle(&self, input: Self::Input) -> pforge_runtime::Result<Self::Output> {
+        let state_dir = PathBuf::from(input.state_dir.as_deref().unwrap_or("state"));
+        let min_events = input.min_events.unwrap_or(3);
+
+        let mut metrics: std::collections::HashMap<String, (u32, u32, u32)> =
+            std::collections::HashMap::new();
+
+        if state_dir.exists() {
+            let entries = std::fs::read_dir(&state_dir)
+                .map_err(|e| pforge_runtime::Error::Handler(e.to_string()))?;
+
+            for entry in entries.flatten() {
+                let name = entry.file_name().to_string_lossy().to_string();
+                if let Some(ref filter) = input.machine {
+                    if &name != filter {
+                        continue;
+                    }
+                }
+                if !entry.path().is_dir() {
+                    continue;
+                }
+
+                let log_path = entry.path().join("events.jsonl");
+                if !log_path.exists() {
+                    continue;
+                }
+
+                let content = std::fs::read_to_string(&log_path)
+                    .map_err(|e| pforge_runtime::Error::Handler(e.to_string()))?;
+
+                for line in content.lines() {
+                    if line.trim().is_empty() {
+                        continue;
+                    }
+                    if let Ok(te) = serde_json::from_str::<types::TimestampedEvent>(line) {
+                        match te.event {
+                            types::ProvenanceEvent::ResourceConverged { ref resource, .. } => {
+                                let key = format!("{name}:{resource}");
+                                metrics.entry(key).or_insert((0, 0, 0)).0 += 1;
+                            }
+                            types::ProvenanceEvent::ResourceFailed { ref resource, .. } => {
+                                let key = format!("{name}:{resource}");
+                                metrics.entry(key).or_insert((0, 0, 0)).1 += 1;
+                            }
+                            types::ProvenanceEvent::DriftDetected { ref resource, .. } => {
+                                let key = format!("{name}:{resource}");
+                                metrics.entry(key).or_insert((0, 0, 0)).2 += 1;
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            }
+        }
+
+        let metrics_vec: Vec<(String, u32, u32, u32)> = metrics
+            .into_iter()
+            .map(|(k, (c, f, d))| (k, c, f, d))
+            .collect();
+
+        let findings = anomaly::detect_anomalies(&metrics_vec, min_events);
+
+        let output_findings = findings
+            .iter()
+            .map(|f| AnomalyFindingOutput {
+                resource: f.resource.clone(),
+                score: f.score,
+                status: format!("{:?}", f.status),
+                reasons: f.reasons.clone(),
+            })
+            .collect::<Vec<_>>();
+
+        Ok(AnomalyOutput {
+            anomaly_count: output_findings.len(),
+            findings: output_findings,
+        })
+    }
+}

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -5,6 +5,7 @@
 //! O(1) dispatch and pforge McpServer for protocol handling.
 
 pub mod handlers;
+pub mod handlers_state;
 pub mod registry;
 pub mod types;
 
@@ -12,6 +13,8 @@ pub mod types;
 mod tests_handlers;
 #[cfg(test)]
 mod tests_handlers_more;
+#[cfg(test)]
+mod tests_parity;
 #[cfg(test)]
 mod tests_registry;
 

--- a/src/mcp/tests_handlers_more.rs
+++ b/src/mcp/tests_handlers_more.rs
@@ -159,24 +159,20 @@ async fn test_fj063_status_handler_nonexistent_dir() {
 async fn test_fj063_status_handler_with_state() {
     let dir = tempfile::tempdir().unwrap();
     let state_dir = dir.path().join("state");
-    std::fs::create_dir_all(&state_dir).unwrap();
 
-    // StatusHandler reads .json files from state_dir
-    let state_json = serde_json::json!({
-        "version": "1.0",
-        "machine": "local",
-        "resources": {
-            "test-pkg": {
-                "resource_type": "Package",
-                "status": "Converged",
-                "hash": "abc123",
-                "details": {}
-            }
-        }
-    });
+    // FJ-2729: a machine's state is a DIRECTORY —
+    // `state/<machine>/state.lock.yaml` (see `state::lock_file_path`). This
+    // test used to write `local.json` and comment "StatusHandler reads .json
+    // files from state_dir", codifying the defect: forjar has never written a
+    // `.json` lock, so the handler returned an empty machine list for every
+    // real project while the CLI printed `Machine: local (localhost)`.
+    let machine_dir = state_dir.join("local");
+    std::fs::create_dir_all(&machine_dir).unwrap();
     std::fs::write(
-        state_dir.join("local.json"),
-        serde_json::to_string_pretty(&state_json).unwrap(),
+        machine_dir.join("state.lock.yaml"),
+        "schema: \"1.0\"\nmachine: local\nhostname: localhost\ngenerated_at: now\n\
+         generator: test\nblake3_version: \"1\"\nresources:\n  test-pkg:\n    type: package\n\
+         \x20   status: converged\n    hash: abc123\n",
     )
     .unwrap();
 
@@ -188,6 +184,7 @@ async fn test_fj063_status_handler_with_state() {
     let output = handler.handle(input).await.unwrap();
     assert_eq!(output.machines.len(), 1);
     assert_eq!(output.machines[0].name, "local");
+    assert_eq!(output.machines[0].resource_count, 1);
 }
 
 #[tokio::test]

--- a/src/mcp/tests_parity.rs
+++ b/src/mcp/tests_parity.rs
@@ -1,0 +1,162 @@
+//! FJ-2729 (PMAT-199): the MCP tools must agree with the CLI they mirror.
+//!
+//! Both defects below were found by driving the PUBLISHED 1.12.0 binary over
+//! stdio and comparing each tool against its CLI counterpart on the same
+//! project. Neither was visible from the schema, from `tools/list`, or from a
+//! handler test that only asserted "returns Ok".
+
+use super::handlers::*;
+use super::types::*;
+use pforge_runtime::Handler;
+
+fn project(dir: &std::path::Path) -> std::path::PathBuf {
+    let cfg = dir.join("forjar.yaml");
+    std::fs::write(
+        &cfg,
+        format!(
+            r#"
+version: "1.0"
+name: parity
+machines:
+  local:
+    hostname: localhost
+    addr: localhost
+resources:
+  real:
+    type: file
+    machine: local
+    path: {}
+    content: hi
+  action:
+    type: task
+    machine: local
+    phony: true
+    command: "echo run"
+"#,
+            dir.join("f.txt").display()
+        ),
+    )
+    .unwrap();
+    cfg
+}
+
+/// Write a lock marking `real` converged, the way a successful apply would.
+fn converged_lock(dir: &std::path::Path, cfg: &std::path::Path) {
+    let config = crate::core::parser::parse_and_validate(cfg).unwrap();
+    let hash = crate::core::planner::hash_desired_state(&config.resources["real"]);
+    let md = dir.join("state").join("local");
+    std::fs::create_dir_all(&md).unwrap();
+    std::fs::write(
+        md.join("state.lock.yaml"),
+        format!(
+            "schema: \"1.0\"\nmachine: local\nhostname: localhost\ngenerated_at: now\n\
+             generator: test\nblake3_version: \"1\"\nresources:\n  real:\n    type: file\n\
+             \x20   status: converged\n    hash: \"{hash}\"\n"
+        ),
+    )
+    .unwrap();
+    std::fs::write(dir.join("f.txt"), "hi").unwrap();
+}
+
+#[tokio::test]
+async fn plan_reports_only_real_changes_not_every_resource() {
+    // `exec_plan.changes` carries EVERY resource with its action, NoOp
+    // included; `cli::plan` filters those out before counting. The MCP handler
+    // did not, so a fully converged project reported all of its resources as
+    // pending. Verified on the published binary: CLI said "0 to change", MCP
+    // said 6 changes.
+    let d = tempfile::tempdir().unwrap();
+    let cfg = project(d.path());
+    converged_lock(d.path(), &cfg);
+
+    let out = PlanHandler
+        .handle(PlanInput {
+            path: cfg.display().to_string(),
+            state_dir: Some(d.path().join("state").display().to_string()),
+            resource: None,
+            tag: None,
+        })
+        .await
+        .expect("plan runs");
+
+    assert!(
+        !out.changes.iter().any(|c| c.resource_id == "real"),
+        "a converged resource must not be reported as a change: {:?}",
+        out.changes
+    );
+    assert!(
+        !out.changes.iter().any(|c| c.resource_id == "action"),
+        "a phony resource is goal-only and must not appear in a bulk plan: {:?}",
+        out.changes
+    );
+}
+
+#[tokio::test]
+async fn plan_still_reports_a_genuine_change() {
+    // The guard against "fixed" meaning "always empty".
+    let d = tempfile::tempdir().unwrap();
+    let cfg = project(d.path());
+
+    let out = PlanHandler
+        .handle(PlanInput {
+            path: cfg.display().to_string(),
+            state_dir: Some(d.path().join("state").display().to_string()),
+            resource: None,
+            tag: None,
+        })
+        .await
+        .expect("plan runs");
+
+    assert!(
+        out.changes.iter().any(|c| c.resource_id == "real"),
+        "nothing has been applied, so `real` must be planned: {:?}",
+        out.changes
+    );
+}
+
+#[tokio::test]
+async fn status_finds_machines_whose_state_is_a_directory() {
+    // A machine's state is `state/<machine>/state.lock.yaml`. The handler
+    // scanned for files with a `.json` extension, which forjar has never
+    // written, so it returned an empty list for every project ever. Verified
+    // on the published binary: CLI printed `Machine: local (localhost)` while
+    // MCP returned `{"machines": []}`.
+    let d = tempfile::tempdir().unwrap();
+    let cfg = project(d.path());
+    converged_lock(d.path(), &cfg);
+
+    let out = StatusHandler
+        .handle(StatusInput {
+            state_dir: Some(d.path().join("state").display().to_string()),
+            machine: None,
+        })
+        .await
+        .expect("status runs");
+
+    assert_eq!(
+        out.machines.len(),
+        1,
+        "expected the `local` machine: {:?}",
+        out.machines
+    );
+    assert_eq!(out.machines[0].name, "local");
+    assert_eq!(out.machines[0].resource_count, 1);
+}
+
+#[tokio::test]
+async fn status_ignores_a_directory_with_no_lock() {
+    // Presence of the lock is the test, so a stray directory under the state
+    // dir is not reported as a machine.
+    let d = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(d.path().join("state").join("not-a-machine")).unwrap();
+
+    let out = StatusHandler
+        .handle(StatusInput {
+            state_dir: Some(d.path().join("state").display().to_string()),
+            machine: None,
+        })
+        .await
+        .expect("status runs");
+
+    assert!(out.machines.is_empty(), "{:?}", out.machines);
+}


### PR DESCRIPTION
Installed **1.12.0 from crates.io** and drove every CLI, MCP and LSP interface against a real project, comparing each tool to its CLI counterpart. None of these was visible from a schema, from `tools/list`, or from a handler test that only asserted "returns Ok".

## MCP `forjar_plan` reported every resource as pending

`ExecutionPlan::changes` carries **every** resource with its action, NoOp included; `cli::plan` filters those before counting and the MCP handler did not.

```
converged project — CLI: "Plan: 0 to change"      MCP: 6 changes
```

An agent driving forjar through MCP would see a converged system as needing a full re-apply. It also included phony resources, which are goal-only.

## MCP `forjar_status` returned no machines, ever

It scanned the state directory for files with a `.json` extension. A machine's state is a **directory** — `state/<machine>/state.lock.yaml`. forjar has never written a `.json` lock.

```
same project — CLI: "Machine: local (localhost)"   MCP: {"machines": []}
```

Its existing test wrote `local.json` with the comment *"StatusHandler reads .json files from state_dir"* — **the fifth test this release found asserting a bug as intended behaviour.**

## `forjar lsp` was an unrecognized subcommand

The language server is complete — stdio framing, diagnostics from the same validator `forjar validate` uses, completion, **80 passing tests** — but no `Commands` variant dispatched it, so no editor could ever start it. Now wired and documented (the doc-parity test required the book entry).

## After the fix, same project

| | CLI | MCP |
|---|---|---|
| converged | `0 to change` | `0 changes` |
| `rm build/app` | `1 to change` | `1 change (build-app UPDATE)` |
| status | `Machine: local` | `{"machines":[{"name":"local","resource_count":5}]}` |
| `forjar lsp` | — | `initialize` returns capabilities, completion responds |

The phony filter is shared through one named re-export rather than reimplemented, so the two cannot drift apart again.

## Sweep coverage

- **CLI** — 157 subcommands, all verified to exist and respond; every one taking no required argument driven against a real project.
- **MCP** — all 9 tools driven over stdio and compared to their CLI counterparts.
- **LSP** — driven over stdio with real `Content-Length` framing.
- **HTTP** — `core::webhook_server` works (16 tests, live socket accept/reject) but **nothing starts it**; there is no `forjar webhook` command. Exposing a listening socket needs bind-address and authentication decisions, so it is a design question rather than a wiring fix — tracked in PMAT-200 rather than added unilaterally in a patch.

12,570 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)