### PR TITLE
chore(release): forjar 1.12.2 — four design defects where forjar reported on the wrong artifact (Refs PMAT-200)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.12.2] - 2026-07-29
+
+Four design defects, each one a place where forjar reported on something other
+than the thing that would actually run. They were found by a design review of
+1.12.1 rather than by a failing test, because in every case the test suite and
+the CLI output agreed with each other and both were wrong.
+
+### Fixed
+
+- **`apply` treated a zero exit code as proof the work happened.** A task
+  declaring `output_artifacts` whose command exited 0 without producing them was
+  recorded as converged, and the state lock then asserted an artifact that was
+  not on disk. Apply now verifies declared outputs exist on local machines
+  before recording success, and names the missing ones when they don't.
+- **The script was readable as its own stdin.** The transport feeds the
+  generated script to `bash` on stdin, so a task command that itself reads stdin
+  (`cat > f`, `read`, `xargs`) consumed the remaining script lines. The task
+  half-executed and reported success, having silently eaten its own tail. Every
+  script is now wrapped `{ ... } < /dev/null` at the one point where scripts are
+  executed, so a command's stdin can never be the script.
+- **`forjar prove` proved the unresolved config.** It read `config.resources`
+  before template expansion, so a proof about conflict-freedom examined
+  `${var}/out` rather than the path two targets would really write. Two targets
+  that genuinely collide after expansion were reported as
+  `[PASS] I3 conflict-freedom: [CHECKED] 2 targets disjoint`. `prove` now
+  resolves first.
+- **`forjar lock` hashed the unresolved config.** The lockfile therefore
+  fingerprinted the template text rather than the values, so two configs that
+  expand to different infrastructure could share a hash. `lock` now resolves
+  before hashing.
+
 ## [1.12.1] - 2026-07-28
 
 Three interface defects found by installing 1.12.0 from crates.io and driving

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1117,7 +1117,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "forjar"
-version = "1.12.1"
+version = "1.12.2"
 dependencies = [
  "age",
  "aprender-contracts",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forjar"
-version = "1.12.1"
+version = "1.12.2"
 edition.workspace = true
 rust-version = "1.89.0"
 authors = ["Pragmatic AI Labs"]


### PR DESCRIPTION
Releases the four design fixes merged in #203.

Each is a case where forjar's output was about something other than what would
actually run — and in every case the test suite and the CLI agreed with each
other, which is why a design review found them and the suite did not.

| Fix | What was wrong |
|---|---|
| `apply` verifies declared outputs | Exit 0 was taken as proof the work happened; a task with `output_artifacts` that exited 0 without producing them was locked as converged |
| Transport isolates stdin | The script was fed to `bash` on stdin, so a command reading stdin (`cat > f`, `read`, `xargs`) ate the rest of the script and reported success half-executed |
| `prove` resolves first | Proved the template, not the expansion — two targets that genuinely collide after expansion reported `[PASS] I3 conflict-freedom: 2 targets disjoint` |
| `lock` resolves first | Fingerprinted the template text, so two configs expanding to different infrastructure could share a lock hash |

## Verification

- 12,591 lib tests pass; fmt, clippy (`--all-targets --all-features`), `cargo deny check advisories` clean
- `cargo publish --dry-run` clean
- Clean-room 10/10 on the #203 tree (mandatory hard gate)
- Post-publish: `cargo install forjar` and re-verify all four fixes on the crates.io binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)