### PR TITLE
chore(release): 1.12.5 — raise bashrs floor to 6.66.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.12.5] - 2026-08-12
+
+### Changed
+
+- **bashrs floor raised `6.64.0` → `6.66.3`** (lockfile moves 6.66.0 → 6.66.3).
+  forjar surfaces bashrs' linter directly to users — `bashrs::linter::lint_shell`
+  in the purifier, plus `forjar lint` and the MCP handlers — so bashrs' lint
+  fixes are forjar's user-visible behaviour.
+
+  This is a **floor** bump, not just a lockfile refresh, and deliberately so:
+  bashrs 6.66.3 retires MAKE016, whose autofix **corrupted Makefiles**. A caret
+  range still admitting 6.64.0 would let a consumer resolve back into a
+  Makefile-corrupting autofix, which matters because v1.12's headline feature is
+  Makefile ingest.
+
+  What forjar users gain: no more spurious diagnostics inside quoted heredocs
+  (`<<'EOF'` bodies are literal text, not shell — provisioning scripts and
+  `command:` blocks are full of them), MAKE003 no longer trips over Make's `$$`
+  escape, and MAKE010 recognises `|| exit` / `|| return` / `|| die` tails as
+  error handling.
+
+  No API changes were required: the full suite passes unmodified against 6.66.3
+  (12776 passed, 0 failed).
+
 ## [1.12.4] - 2026-08-11
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,9 +300,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bashrs"
-version = "6.66.0"
+version = "6.66.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da1542ffb7192d409a83da0e7ba805f91666decdb78d23d847deeb3c3f95d4e"
+checksum = "5a6717d878d405cebef3b94c95e5e9d2e23605a5bbe6029da3c7f9e757ff6172"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1117,7 +1117,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "forjar"
-version = "1.12.4"
+version = "1.12.5"
 dependencies = [
  "age",
  "aprender-contracts",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forjar"
-version = "1.12.4"
+version = "1.12.5"
 edition.workspace = true
 rust-version = "1.89.0"
 authors = ["Pragmatic AI Labs"]
@@ -49,7 +49,7 @@ clap = { version = "4", features = ["derive"] }
 indexmap = { version = "2.7", features = ["serde"] }
 aprender-contracts-macros = "0.31"
 base64 = "0.22.1"
-bashrs = "6.64.0"
+bashrs = "6.66.3"
 pforge-runtime = "0.1.4"
 pforge-config = "0.1.4"
 tokio = { version = "1.35", features = ["rt-multi-thread", "macros"] }


### PR DESCRIPTION
Closes the gap that 1.12.4 shipped with: its lockfile pinned **bashrs 6.66.0**, three patch releases behind.

## Why this matters for forjar specifically

forjar surfaces bashrs' linter **directly to users**:

```rust
src/core/purifier.rs:  use bashrs::linter::{lint_shell, LintResult, Severity};
src/cli/lint.rs:       use bashrs::linter::Severity;
src/mcp/handlers.rs:   use bashrs::linter::Severity;
```

So bashrs' lint behaviour *is* forjar's user-visible behaviour, via `forjar lint`, the MCP handlers, and the purifier.

## Floor bump, not just a lockfile refresh

Deliberate. bashrs 6.66.3 **retires MAKE016, whose autofix corrupted Makefiles**. A caret range still admitting `6.64.0` would let a consumer resolve back into a Makefile-corrupting autofix — and v1.12's headline feature is **Makefile ingest**. The floor makes that unreachable.

## What forjar users gain

- **No spurious diagnostics inside quoted heredocs.** A `<<'EOF'` body is literal text, not shell — and provisioning scripts and `command:` blocks are full of them.
- **MAKE003** no longer trips over Make's `$$` escape.
- **MAKE010** recognises `|| exit` / `|| return` / `|| die` tails as error handling.

## Not a security fix

`crossbeam-epoch` was already **0.9.20** in forjar's lockfile, so RUSTSEC-2026-0204 never affected forjar. This is functional only.

## Verification

- No API changes required — full suite passes unmodified against 6.66.3: **12776 passed, 0 failed**
- `Cargo.lock` regenerated in the same commit (bashrs 6.66.0 → 6.66.3)
- bashrs 6.66.3 is published and tagged `v6.66.3`, gated by its own clean-room run (10/10 gates, 1756s, **14596 unit + 246 integration tests**, 0 failed)

Publish gated on a fresh forjar clean-room run, then tagged `v1.12.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)