### PR TITLE
chore(release): 1.12.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.12.6] - 2026-08-12
+
+### Fixed
+
+- **`build --push` now names the missing binary instead of reporting an errno**
+  ([#224](https://github.com/paiml/forjar/issues/224)). Every OCI registry
+  request shells out to `curl`, an undeclared runtime dependency. On a host
+  without it the first HEAD died as `curl HEAD: No such file or directory (os
+  error 2)` — which names neither curl nor the fact that a required external
+  binary is absent, and reads like a network or registry fault.
+
+  A preflight at `push_image()` — the single funnel every push goes through —
+  now fails early with an actionable message, before any partial upload begins.
+
+  Found by infra's clean-room gate (a container holding only what the crate
+  declares) while GitHub CI was green on the same commit, because the CI image
+  happens to ship curl. A user running `cargo install forjar` on a minimal host
+  would have hit the original error.
+
+  This makes the dependency legible; it does not remove it. The crate already
+  compiles `reqwest`, so doing the registry HEAD/PUT natively would drop the
+  shell-out entirely — tracked in #224.
+
 ## [1.12.5] - 2026-08-12
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1117,7 +1117,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "forjar"
-version = "1.12.5"
+version = "1.12.6"
 dependencies = [
  "age",
  "aprender-contracts",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forjar"
-version = "1.12.5"
+version = "1.12.6"
 edition.workspace = true
 rust-version = "1.89.0"
 authors = ["Pragmatic AI Labs"]


### PR DESCRIPTION
Ships the **#224** fix.

`forjar build --push` shells out to `curl` for every OCI registry request — an undeclared runtime dependency. On a host without it, the first HEAD died as:

```
curl HEAD: No such file or directory (os error 2)
```

That names neither curl nor the fact that a required external binary is missing, and reads like a network or registry fault. A preflight at `push_image()` — the single funnel every push goes through — now fails early with an actionable message, **before any partial upload starts**.

Found by infra's clean-room gate (a container holding only what the crate declares) while **GitHub CI was green on the same commit**, because the CI image happens to ship curl. A user running `cargo install forjar` on a minimal host would have hit the original error.

## Release hygiene

`Cargo.lock` regenerated **in this commit** — 0 occurrences of `1.12.5` remain. 1.12.4 tripped its own `lockfile-preflight` by bumping `Cargo.toml` alone; not repeating that.

Publish gated on the mandatory infra clean-room run, then tagged `v1.12.6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)