### PR TITLE
fix(planner): plan is non-idempotent for state: absent

### DIFF
--- a/src/core/planner/mod.rs
+++ b/src/core/planner/mod.rs
@@ -217,7 +217,7 @@ fn determine_action(
         .unwrap_or_else(|| default_state(&resource.resource_type));
 
     if state == "absent" {
-        let action = determine_absent_action(resource_id, machine_name, locks);
+        let action = determine_absent_action(resource_id, resource, machine_name, locks);
 
         // FJ-1220: prevent_destroy blocks Destroy actions
         if action == PlanAction::Destroy {
@@ -236,17 +236,51 @@ fn determine_action(
 }
 
 /// Determine action for a resource with state=absent.
+///
+/// GH-229: this used to return `Destroy` for any resource present in the lock,
+/// using "is in the lock" as a proxy for "still exists on the machine". That
+/// proxy is false — a SUCCESSFUL destroy writes the resource back into the lock
+/// as `converged`, so the plan re-emitted `Destroy` on every subsequent run and
+/// never reached a fixed point (observed as a permanent "N to destroy" on
+/// infra's lambda-labs, pending for days across two unrelated resource sets).
+///
+/// Two situations look identical under `status: converged` and must not be
+/// conflated:
+///   (A) converged as PRESENT, now redeclared absent  -> must Destroy
+///   (B) converged TO ABSENT (destroy already ran)    -> must NoOp
+///
+/// The stored hash separates them, because `state` is itself a component of
+/// `hash_desired_state` (see hashing.rs `push_opt(components, &resource.state)`).
+/// A lock written by a present-state apply cannot match the absent form's hash.
+/// This is the same rule `determine_present_action` already applies, so the two
+/// branches now share one idempotency contract rather than one having none.
+///
+/// The FJ-2200 idempotency postcondition (converged + matching hash → NoOp) is
+/// structural here — it is the literal final branch — so it needs no
+/// `debug_assert` to restate it.
 fn determine_absent_action(
     resource_id: &str,
+    resource: &Resource,
     machine_name: &str,
     locks: &std::collections::HashMap<String, StateLock>,
 ) -> PlanAction {
-    if let Some(lock) = locks.get(machine_name) {
-        if lock.resources.contains_key(resource_id) {
-            return PlanAction::Destroy;
-        }
+    let Some(rl) = locks
+        .get(machine_name)
+        .and_then(|lock| lock.resources.get(resource_id))
+    else {
+        return PlanAction::NoOp;
+    };
+
+    // A destroy that failed or drifted must be retried.
+    if rl.status != ResourceStatus::Converged {
+        return PlanAction::Destroy;
     }
-    PlanAction::NoOp
+
+    if rl.hash == hash_desired_state(resource) {
+        PlanAction::NoOp // (B) already converged to absent
+    } else {
+        PlanAction::Destroy // (A) lock holds a present-state hash
+    }
 }
 
 /// Determine action for a resource with a present/running/mounted state.

--- a/src/core/planner/tests_advanced.rs
+++ b/src/core/planner/tests_advanced.rs
@@ -116,6 +116,148 @@ fn test_fj036_plan_absent_resource_destroy() {
     assert_eq!(p.changes[0].resource_id, "old-config");
 }
 
+/// GH-229: the plan must reach a fixed point for `state: absent`.
+///
+/// A successful destroy writes the resource back into the lock as `converged`
+/// with the ABSENT form's desired hash. Before the fix, the planner treated
+/// mere presence in the lock as "still exists" and re-emitted Destroy forever,
+/// so `apply` never converged (observed as a permanent "N to destroy" on
+/// infra's lambda-labs).
+#[test]
+fn test_gh229_absent_converged_to_absent_is_noop() {
+    let yaml = "\nversion: \"1.0\"\nname: test\nmachines:\n  m1:\n    hostname: m1\n    addr: 127.0.0.1\nresources:\n  old-config:\n    type: file\n    machine: m1\n    path: /etc/old.conf\n    state: absent\n";
+    let config: ForjarConfig = serde_yaml_ng::from_str(yaml).unwrap();
+    let order = vec!["old-config".to_string()];
+
+    // Exactly what apply records after the destroy succeeds: converged, with
+    // the hash of the ABSENT declaration.
+    let absent_hash = hash_desired_state(&config.resources["old-config"]);
+    let mut lock_resources = indexmap::IndexMap::new();
+    lock_resources.insert(
+        "old-config".to_string(),
+        ResourceLock {
+            resource_type: ResourceType::File,
+            status: ResourceStatus::Converged,
+            applied_at: None,
+            duration_seconds: None,
+            hash: absent_hash,
+            details: HashMap::new(),
+        },
+    );
+    let lock = StateLock {
+        schema: "1.0".to_string(),
+        machine: "m1".to_string(),
+        hostname: "m1".to_string(),
+        generated_at: "2026-01-01T00:00:00Z".to_string(),
+        generator: "forjar".to_string(),
+        blake3_version: "1.8".to_string(),
+        resources: lock_resources,
+    };
+    let mut locks = HashMap::new();
+    locks.insert("m1".to_string(), lock);
+
+    let p = plan(&config, &order, &locks, None);
+
+    assert_eq!(
+        p.to_destroy, 0,
+        "an already-destroyed absent resource must not be re-destroyed"
+    );
+    assert_eq!(p.unchanged, 1, "it should count as unchanged");
+}
+
+/// GH-229 companion: the fix must NOT silently stop destroying things.
+///
+/// A resource that converged while declared PRESENT and is now redeclared
+/// `absent` still has to be destroyed. `state` is a component of
+/// hash_desired_state, so the lock's present-form hash cannot match the absent
+/// form — which is exactly what keeps these two cases apart.
+#[test]
+fn test_gh229_absent_converged_as_present_still_destroys() {
+    let present_yaml = "\nversion: \"1.0\"\nname: test\nmachines:\n  m1:\n    hostname: m1\n    addr: 127.0.0.1\nresources:\n  old-config:\n    type: file\n    machine: m1\n    path: /etc/old.conf\n    content: hello\n";
+    let absent_yaml = "\nversion: \"1.0\"\nname: test\nmachines:\n  m1:\n    hostname: m1\n    addr: 127.0.0.1\nresources:\n  old-config:\n    type: file\n    machine: m1\n    path: /etc/old.conf\n    content: hello\n    state: absent\n";
+    let present: ForjarConfig = serde_yaml_ng::from_str(present_yaml).unwrap();
+    let config: ForjarConfig = serde_yaml_ng::from_str(absent_yaml).unwrap();
+    let order = vec!["old-config".to_string()];
+
+    let present_hash = hash_desired_state(&present.resources["old-config"]);
+    assert_ne!(
+        present_hash,
+        hash_desired_state(&config.resources["old-config"]),
+        "state must participate in the desired-state hash, or the two cases alias"
+    );
+
+    let mut lock_resources = indexmap::IndexMap::new();
+    lock_resources.insert(
+        "old-config".to_string(),
+        ResourceLock {
+            resource_type: ResourceType::File,
+            status: ResourceStatus::Converged,
+            applied_at: None,
+            duration_seconds: None,
+            hash: present_hash,
+            details: HashMap::new(),
+        },
+    );
+    let lock = StateLock {
+        schema: "1.0".to_string(),
+        machine: "m1".to_string(),
+        hostname: "m1".to_string(),
+        generated_at: "2026-01-01T00:00:00Z".to_string(),
+        generator: "forjar".to_string(),
+        blake3_version: "1.8".to_string(),
+        resources: lock_resources,
+    };
+    let mut locks = HashMap::new();
+    locks.insert("m1".to_string(), lock);
+
+    let p = plan(&config, &order, &locks, None);
+
+    assert_eq!(
+        p.to_destroy, 1,
+        "present->absent transition must still destroy"
+    );
+    assert_eq!(p.changes[0].action, PlanAction::Destroy);
+}
+
+/// GH-229: a destroy that FAILED must be retried, not swallowed by the new
+/// NoOp path.
+#[test]
+fn test_gh229_absent_failed_destroy_is_retried() {
+    let yaml = "\nversion: \"1.0\"\nname: test\nmachines:\n  m1:\n    hostname: m1\n    addr: 127.0.0.1\nresources:\n  old-config:\n    type: file\n    machine: m1\n    path: /etc/old.conf\n    state: absent\n";
+    let config: ForjarConfig = serde_yaml_ng::from_str(yaml).unwrap();
+    let order = vec!["old-config".to_string()];
+
+    // Same hash as the absent declaration, but the apply did not succeed.
+    let absent_hash = hash_desired_state(&config.resources["old-config"]);
+    let mut lock_resources = indexmap::IndexMap::new();
+    lock_resources.insert(
+        "old-config".to_string(),
+        ResourceLock {
+            resource_type: ResourceType::File,
+            status: ResourceStatus::Failed,
+            applied_at: None,
+            duration_seconds: None,
+            hash: absent_hash,
+            details: HashMap::new(),
+        },
+    );
+    let lock = StateLock {
+        schema: "1.0".to_string(),
+        machine: "m1".to_string(),
+        hostname: "m1".to_string(),
+        generated_at: "2026-01-01T00:00:00Z".to_string(),
+        generator: "forjar".to_string(),
+        blake3_version: "1.8".to_string(),
+        resources: lock_resources,
+    };
+    let mut locks = HashMap::new();
+    locks.insert("m1".to_string(), lock);
+
+    let p = plan(&config, &order, &locks, None);
+
+    assert_eq!(p.to_destroy, 1, "a failed destroy must be retried");
+}
+
 #[test]
 fn test_plan_absent_resource_no_lock() {
     let yaml = "\nversion: \"1.0\"\nname: test\nmachines:\n  m1:\n    hostname: m1\n    addr: 127.0.0.1\nresources:\n  gone-file:\n    type: file\n    machine: m1\n    path: /tmp/gone.txt\n    state: absent\n";


### PR DESCRIPTION
Closes #229.

## Problem

A `state: absent` resource that had already converged was re-planned as `Destroy` on **every subsequent plan**. The plan never reached a fixed point — observed on infra's `lambda-labs` as a permanent "N to destroy" across two unrelated resource sets, one pending for days.

Not merely cosmetic: a non-zero plan stops being evidence of real pending work, so genuine changes hide inside permanent noise. `--diff-only` is exactly what a human reads to decide whether an apply is safe.

## Root cause

`determine_absent_action` used presence in the state lock as a proxy for *"still exists on the machine"*:

```rust
if lock.resources.contains_key(resource_id) {
    return PlanAction::Destroy;
}
```

That proxy is false. A **successful** destroy writes the resource back into the lock as `converged`, so `contains_key` stays true forever and `Destroy` is returned forever.

## The subtlety

Two situations look identical under `status: converged` and must not be conflated:

| | |
|---|---|
| **(A)** converged as PRESENT, now redeclared absent | must **Destroy** |
| **(B)** converged TO ABSENT (destroy already ran) | must **NoOp** |

Collapsing "converged → NoOp" would have silently broken (A) — a `present` → `absent` transition would stop destroying anything.

The stored hash separates them, because **`state` is itself a component of `hash_desired_state`** (`hashing.rs`: `push_opt(components, &resource.state)`). A lock written by a present-state apply cannot match the absent form's hash.

This is the same rule `determine_present_action` already applies. The fix makes both branches share one idempotency contract instead of one branch having none. `Failed`/`Drifted` destroys are still retried.

## Tests

Three regression tests: (B) NoOp, (A) still-destroys, failed-destroy-retried.

I verified the (B) test **fails against the old implementation** and passes after; the other two pass on both, guarding against over-correction. The existing `test_fj036_plan_absent_resource_destroy` is untouched and still passes — its lock hash is a dummy that differs from the absent form, which is precisely case (A).

## End-to-end on infra `machines/lambda-labs`

| target | before | after |
|---|---|---|
| `-t zram` | 4 destroy, 1 change | **0 destroy, 0 change**, 12 unchanged |
| `-t audio` | 7 destroy, 1 change | **0 destroy, 0 change**, 25 unchanged |
| untagged | — | **0 add, 0 change, 0 destroy**, 74 unchanged |

12,780 lib tests pass; fmt, clippy, and the TDG gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)