### PR TITLE
feat(resources): backup_sync — an offsite copy that must prove it exists (FJ-037)

### DIFF
--- a/contracts/backup-sync-v1.yaml
+++ b/contracts/backup-sync-v1.yaml
@@ -1,0 +1,317 @@
+---
+metadata:
+  version: "1.0.0"
+  created: "2026-08-15"
+  author: "PAIML Engineering"
+  kind: kernel
+  description: |
+    backup_sync resource (FJ-037 / PMAT-216) — an offsite copy that has to prove
+    it exists.
+
+    Origin. Measured on lambda-labs 2026-08-15: ~2.1 TB of irreplaceable media
+    (RecordedCourses 1.6T, home-Videos 134G, long-form-videos 236G, coursera
+    assets 168G, mac-backup 34G) on a 4-wide RAID0 with no parity, and ZERO
+    bytes of it anywhere off that array. An hourly job had reported
+    "Backup complete" for months, deployed, enabled, exiting 0 throughout.
+
+    Four independent defects, each of which this contract makes
+    unrepresentable:
+
+      D1  The destination was LOCAL. SOURCE=/mnt/nvme-raid0/videos,
+          DEST=/videos, and /videos was a symlink back to the source. rsync
+          copied a directory onto itself and exited 0.
+      D2  The success metric could not fail. `find "$DEST"` does not descend a
+          symlink without -L or a trailing slash, so it printed "Files: 0"
+          while 77 matching files sat in that exact directory. Structurally 0
+          on EVERY input — not merely wrong on an empty set.
+      D3  Coverage was never compared to anything. The job covered a 16 GB
+          directory (0.12% of the array) and nothing asserted the rest.
+      D4  There was no alerting path for the array itself: mdmonitor inactive,
+          no MAILADDR, and smartd mailing `root` on a host with no MTA.
+          (D4 is tracked separately; this contract covers D1-D3.)
+
+  references:
+    - "src/resources/backup_sync/ — handler (check/apply/state_query)"
+    - "src/resources/backup_sync/sync.rs — sync + checksum verification"
+    - "src/resources/backup_sync/preflight.rs — remote reachability gate"
+    - "src/resources/backup_sync/config.rs — forjar-managed rclone.conf"
+    - "src/core/types/backup_sync_types.rs — remote/source validation"
+    - "rclone check --combined — per-file status characters (= * - !)"
+    - "Google Drive upload limit: ~750 GB/day/account"
+
+  quorum_validation:
+    - system: "ZFS send/recv + zfs-auto-snapshot"
+      adopted: |
+        A replica is only trustworthy if verified against the source, not
+        inferred from the transfer tool's exit status. Verification is a
+        separate, explicit step with its own result.
+      encoded_as: "equation `coverage_is_checksum_verified`"
+    - system: "restic / borg `check --read-data`"
+      adopted: |
+        Backups are assumed broken until proven otherwise; an integrity check
+        that examines zero objects is an error, never a pass.
+      encoded_as: "equation `empty_verification_fails_closed`"
+    - system: "Prometheus dead-man's switch (and the fleet's own lane-liveness)"
+      adopted: |
+        Alert on the ABSENCE of the expected signal. A backup that stops
+        running must fail, not go quiet; execution evidence must come from a
+        source the deployer cannot forge.
+      encoded_as: "equations `execution_evidence_is_journal`, `heartbeat_staleness`"
+
+equations:
+  remote_cannot_be_local:
+    formula: |
+      valid(dest) ⟺ dest matches `name:path` ∧ name ∈ [A-Za-z0-9_-]+
+                    ∧ dest ∌ prefix{"/", ".", "~"}
+    domain: "dest ∈ String (backup_remote)"
+    codomain: "Result<BackupSync, String>"
+    invariants:
+      - "A local destination is REJECTED at parse time (D1)"
+      - "An unconfigured rclone remote silently degrades to a local path, so the remote must also be proven configured and reachable before any byte moves"
+      - "The self-referential backup is unrepresentable, not merely discouraged"
+
+  coverage_is_checksum_verified:
+    formula: |
+      coverage = |{f : hash_local(f) = hash_remote(f)}| / |files(sources)| × 100
+    domain: "sources ∈ [Path], remote ∈ rclone remote"
+    codomain: "0..=100"
+    invariants:
+      - "Health is a count of files proven present in the remote BY CHECKSUM"
+      - "The sync tool's exit code is NEVER the health signal (rsync exits 0 copying a directory onto itself)"
+      - "`rclone check --combined` status characters are counted: `=` matched, `*` differing, `-` MISSING from remote, `!` error"
+      - "`-` is the number that was silently 2.1 TB"
+
+  empty_verification_fails_closed:
+    formula: |
+      (|examined| = 0 ∨ |matched| = 0) ∧ sources ≠ ∅ ⟹ health = unverified ∧ exit ≠ 0
+    domain: "one sync pass"
+    codomain: "{verified, partial, unverified} × exit code"
+    invariants:
+      - "Zero files examined is a BROKEN CHECK, never an empty backup (D2)"
+      - "Zero files matched fails even when the check ran"
+      - "Missing check output counts as an error, not as a pass"
+      - "A run below the declared verify_pct exits non-zero so systemd records a failed unit"
+
+  execution_evidence_is_journal:
+    formula: |
+      ever_ran(r) ⟺ ∃ journal entries for the service unit
+    domain: "r ∈ Resource where resource_type = BackupSync"
+    codomain: "{yes, no}"
+    invariants:
+      - "`apply` MUST NOT run the sync: a deployer that runs the job also writes the status file that is supposed to prove the SERVICE ran"
+      - "Execution evidence is read from journalctl, which the deployer cannot forge"
+      - "A /run/*.json is treated as untrusted for the question 'did this ever run'"
+
+  credential_is_never_committed:
+    formula: |
+      backup_token ∈ repo ⟹ backup_token matches `{{secrets.*}}`
+    domain: "r ∈ Resource where resource_type = BackupSync"
+    codomain: "Vec<ValidationError>"
+    invariants:
+      - "Configuration (backend, scope, folder id) lives in the repo — reviewable and drift-checked"
+      - "The OAuth refresh token is a bearer credential and is resolved through the secrets provider"
+      - "A literal token in a declaration is REJECTED at parse time"
+      - "An unresolved `{{secrets.x}}` reaching codegen is refused: writing it would set the remote's credential to that literal string"
+      - "The generated rclone.conf is created under umask 077 and chmod 0600, then renamed atomically"
+
+  heartbeat_staleness:
+    formula: |
+      age(status) > 3 × cadence ⟹ heartbeat = stale
+    domain: "r ∈ Resource where resource_type = BackupSync"
+    codomain: "{fresh, stale, missing}"
+    invariants:
+      - "Freshness scales with the declared cadence, never a hardcoded constant"
+      - "An unrecognised OnCalendar expression falls back to daily, never to zero"
+
+  teardown_orders_stop_before_delete:
+    formula: |
+      index(stop) < index(disable) < index(rm) < index(daemon-reload)
+    domain: "r ∈ Resource where state = absent"
+    codomain: "String (purified shell)"
+    invariants:
+      - "PMAT-219: deleting a unit file out from under a loaded unit leaves it Active: failed with 'Unit to trigger vanished'"
+      - "reset-failed clears the orphan so a converged apply does not leave systemd holding a failed unit"
+
+proof_obligations:
+  - type: safety
+    property: "A local destination is rejected before any sync can run"
+    formal: "∀ dest ∈ prefix{/,.,~}: BackupSync::new(.., dest, ..) = Err"
+    applies_to: remote_cannot_be_local
+    enforced_by: "src/core/types/backup_sync_types.rs::tests::rejects_an_absolute_local_destination"
+
+  - type: safety
+    property: "The remote is proven configured and reachable before bytes move"
+    formal: "∀ r: apply emits listremotes ∧ (about ∨ lsd) guards preceding any rclone sync"
+    applies_to: remote_cannot_be_local
+    enforced_by: "src/resources/backup_sync/preflight.rs::tests::requires_the_remote_to_be_configured_not_just_named"
+
+  - type: safety
+    property: "Coverage is computed from checksum comparison, not exit status"
+    formal: "∀ r: sync_script(r) ⊇ {rclone check, --checksum, --combined}"
+    applies_to: coverage_is_checksum_verified
+    enforced_by: "src/resources/backup_sync/sync.rs::tests::verifies_by_checksum_not_by_exit_code"
+
+  - type: liveness
+    property: "Zero examined or zero matched files fails the run"
+    formal: "|examined| = 0 ∨ |matched| = 0 ⟹ exit ≠ 0"
+    applies_to: empty_verification_fails_closed
+    enforced_by: "src/resources/backup_sync/sync.rs::tests::zero_examined_files_is_a_failure_not_a_success"
+
+  - type: safety
+    property: "systemd never masks a failed verification"
+    formal: "∀ r: service_unit(r) ∌ {SuccessExitStatus, RemainAfterExit}"
+    applies_to: empty_verification_fails_closed
+    enforced_by: "src/resources/backup_sync/units.rs::tests::service_does_not_mask_a_failed_verification"
+
+  - type: safety
+    property: "apply does not manufacture the evidence it will later read"
+    formal: "∀ r: apply_script(r) ∌ invocation of script_path(r)"
+    applies_to: execution_evidence_is_journal
+    enforced_by: "src/resources/backup_sync/tests.rs::apply_does_not_run_the_sync"
+
+  - type: liveness
+    property: "Execution evidence comes from the journal"
+    formal: "∀ r: state_query(r) ⊇ journalctl -u service"
+    applies_to: execution_evidence_is_journal
+    enforced_by: "src/resources/backup_sync/tests.rs::state_query_takes_execution_evidence_from_the_journal"
+
+  - type: safety
+    property: "A literal credential cannot be declared"
+    formal: "∀ r: literal(backup_token) ∧ len > 24 ⟹ ValidationError"
+    applies_to: credential_is_never_committed
+    enforced_by: "src/core/parser/backup_sync_validate.rs::validate_backup_sync"
+
+  - type: safety
+    property: "An unresolved secret template never reaches rclone.conf"
+    formal: "∀ r: is_unresolved(token) ⟹ apply_script(r) = refusal"
+    applies_to: credential_is_never_committed
+    enforced_by: "src/resources/backup_sync/tests.rs::an_unresolved_secret_template_is_refused"
+
+  - type: safety
+    property: "The credential is never world-readable, not even transiently"
+    formal: "∀ r: install emits umask 077 before creat, chmod 0600, atomic mv"
+    applies_to: credential_is_never_committed
+    enforced_by: "src/resources/backup_sync/config.rs::tests::install_is_atomic_and_never_world_readable"
+
+  - type: ordering
+    property: "Teardown stops and disables before deleting unit files"
+    formal: "index(stop) < index(disable) < index(rm) < index(daemon-reload)"
+    applies_to: teardown_orders_stop_before_delete
+    enforced_by: "src/resources/backup_sync/tests.rs::removal_stops_before_it_deletes"
+
+  - type: safety
+    property: "Every emitted script survives forjar's I8 purification gate"
+    formal: "∀ r: validate_script(apply|check|state_query(r)) = Ok"
+    applies_to: coverage_is_checksum_verified
+    enforced_by: "src/resources/backup_sync/tests.rs::every_emitted_script_passes_the_purifier"
+
+falsification_tests:
+  - id: FALSIFY-BKP-001
+    rule: "the destination cannot be local"
+    prediction: "backup_remote of `/videos` is rejected with a LOCAL path error"
+    test: "src/core/types/backup_sync_types.rs::tests::rejects_an_absolute_local_destination"
+    if_fails: "The exact predecessor returns: rsync copies the array onto itself and exits 0 forever"
+
+  - id: FALSIFY-BKP-002
+    rule: "an unconfigured remote is not a destination"
+    prediction: "preflight fails when `rclone listremotes` does not list the remote"
+    test: "src/resources/backup_sync/preflight.rs::tests::requires_the_remote_to_be_configured_not_just_named"
+    if_fails: "rclone treats `name:path` as a LOCAL directory and the backup silently lands on the same disk"
+
+  - id: FALSIFY-BKP-003
+    rule: "coverage is checksum-verified"
+    prediction: "the sync script runs `rclone check --checksum --combined` and counts per-file status"
+    test: "src/resources/backup_sync/sync.rs::tests::verifies_by_checksum_not_by_exit_code"
+    if_fails: "Health degenerates to the transfer tool's exit code, which is 0 for a no-op"
+
+  - id: FALSIFY-BKP-004
+    rule: "zero examined files is a failure"
+    prediction: "|examined| = 0 with declared sources yields health=unverified and exit 1"
+    test: "src/resources/backup_sync/sync.rs::tests::zero_examined_files_is_a_failure_not_a_success"
+    if_fails: "The vacuous 'Files: 0 — Backup complete' metric returns verbatim"
+
+  - id: FALSIFY-BKP-005
+    rule: "zero matched files is a failure"
+    prediction: "|matched| = 0 yields health=unverified"
+    test: "src/resources/backup_sync/sync.rs::tests::zero_matched_files_is_a_failure"
+    if_fails: "A backup where nothing transferred reports healthy"
+
+  - id: FALSIFY-BKP-006
+    rule: "missing check output is an error"
+    prediction: "an absent --combined file counts as an error, not zero differences"
+    test: "src/resources/backup_sync/sync.rs::tests::missing_check_output_counts_as_an_error_not_a_pass"
+    if_fails: "A crashed verification reads as a clean one"
+
+  - id: FALSIFY-BKP-007
+    rule: "apply does not run the sync"
+    prediction: "apply_script arms the timer and never invokes the sync script"
+    test: "src/resources/backup_sync/tests.rs::apply_does_not_run_the_sync"
+    if_fails: "The deployer writes the status file that is supposed to prove the service ran (§0.2)"
+
+  - id: FALSIFY-BKP-008
+    rule: "execution evidence is the journal"
+    prediction: "state_query reads journalctl for backup_ever_ran"
+    test: "src/resources/backup_sync/tests.rs::state_query_takes_execution_evidence_from_the_journal"
+    if_fails: "A deployer-written /run/*.json is mistaken for proof of execution"
+
+  - id: FALSIFY-BKP-009
+    rule: "an unresolved secret template is refused"
+    prediction: "backup_token of `{{secrets.x}}` at codegen produces a refusal, not a config"
+    test: "src/resources/backup_sync/tests.rs::an_unresolved_secret_template_is_refused"
+    if_fails: "rclone.conf gets the literal string as its credential and fails later as an auth error"
+
+  - id: FALSIFY-BKP-010
+    rule: "the credential is never world-readable"
+    prediction: "install emits umask 077, chmod 0600 and an atomic mv"
+    test: "src/resources/backup_sync/config.rs::tests::install_is_atomic_and_never_world_readable"
+    if_fails: "A refresh token is briefly (or permanently) readable by any local user"
+
+  - id: FALSIFY-BKP-011
+    rule: "teardown stops before it deletes"
+    prediction: "stop < disable < rm < daemon-reload, plus reset-failed"
+    test: "src/resources/backup_sync/tests.rs::removal_stops_before_it_deletes"
+    if_fails: "PMAT-219 recurs: an orphaned unit sits Active: failed while apply reports converged"
+
+  - id: FALSIFY-BKP-012
+    rule: "sources cannot overlap"
+    prediction: "nested sources are rejected because they double-count coverage"
+    test: "src/core/types/backup_sync_types.rs::tests::rejects_overlapping_sources"
+    if_fails: "verify_pct is computed over a multiset and can exceed real coverage"
+
+  - id: FALSIFY-BKP-013
+    rule: "emitted scripts are purifiable"
+    prediction: "apply/check/state_query pass forjar's I8 purifier"
+    test: "src/resources/backup_sync/tests.rs::every_emitted_script_passes_the_purifier"
+    if_fails: "The resource is fully tested and completely undeployable"
+
+kani_harnesses:
+  - id: KANI-BKP-001
+    obligation: "no accepted remote can be a local path"
+    property: "forall s: BackupSync::new(.., s, ..) = Ok => s contains ':' and s[0] not in {/,.,~}"
+    bound: 8
+    strategy: bounded_int
+    harness: proof_backup_remote_never_local
+
+  - id: KANI-BKP-002
+    obligation: "coverage is bounded 0..=100"
+    property: "forall matched <= total: (matched * 100 / total) <= 100"
+    bound: 256
+    strategy: bounded_int
+    harness: proof_backup_coverage_bounded
+
+  - id: KANI-BKP-003
+    obligation: "a declaration with no sources is refused"
+    property: "forall verify_pct: BackupSync::new(vec![], ..) = Err"
+    bound: 256
+    strategy: bounded_int
+    harness: proof_backup_empty_sources_rejected
+
+qa_gate:
+  id: F-BKP-001
+  name: "Backup Sync Contract"
+  description: |
+    An offsite copy is declared state and must prove it exists. Gate fails on
+    any falsification test going red.
+  check: "cargo test --lib backup_sync && cargo test --test falsification_backup_sync"
+  severity: error
+  reference: "src/resources/backup_sync/"

--- a/examples/emit_backup_sync.rs
+++ b/examples/emit_backup_sync.rs
@@ -1,0 +1,21 @@
+//! Emit the generated backup sync script for a resource (operator/debug tool).
+//! Usage: cargo run --example emit_backup_sync -- <home> <remote> <source>
+fn main() {
+    let a: Vec<String> = std::env::args().collect();
+    let r = forjar::core::types::Resource {
+        resource_type: forjar::core::types::ResourceType::BackupSync,
+        home: Some(a[1].clone()),
+        backup: forjar::core::types::BackupSpec {
+            remote: Some(a[2].clone()),
+            source: vec![a[3].clone()],
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let apply = forjar::resources::backup_sync::apply_script(&r);
+    const OPEN: &str = "<<'FORJAR_BACKUP_EOF'\n";
+    const CLOSE: &str = "\nFORJAR_BACKUP_EOF";
+    let s = apply.find(OPEN).unwrap() + OPEN.len();
+    let e = apply[s..].find(CLOSE).unwrap() + s;
+    print!("{}", &apply[s..e]);
+}

--- a/src/cli/graph_resilience.rs
+++ b/src/cli/graph_resilience.rs
@@ -26,6 +26,7 @@ fn type_cost(rt: &types::ResourceType) -> u32 {
         types::ResourceType::GithubRelease => 3,
         types::ResourceType::OverlayInterface => 3,
         types::ResourceType::DiskBudget => 3,
+        types::ResourceType::BackupSync => 3,
     }
 }
 

--- a/src/core/codegen/dispatch.rs
+++ b/src/core/codegen/dispatch.rs
@@ -36,6 +36,7 @@ pub fn check_script(resource: &Resource) -> Result<String, String> {
         ResourceType::GithubRelease => Ok(resources::github_release::check_script(resource)),
         ResourceType::OverlayInterface => Ok(resources::overlay_interface::check_script(resource)),
         ResourceType::DiskBudget => Ok(resources::disk_budget::check_script(resource)),
+        ResourceType::BackupSync => Ok(resources::backup_sync::check_script(resource)),
         ResourceType::Recipe => {
             Err("codegen not implemented for recipe (expand first)".to_string())
         }
@@ -91,6 +92,7 @@ pub fn apply_script(resource: &Resource) -> Result<String, String> {
         ResourceType::GithubRelease => Ok(resources::github_release::apply_script(resource)),
         ResourceType::OverlayInterface => Ok(resources::overlay_interface::apply_script(resource)),
         ResourceType::DiskBudget => Ok(resources::disk_budget::apply_script(resource)),
+        ResourceType::BackupSync => Ok(resources::backup_sync::apply_script(resource)),
         ResourceType::Recipe => {
             Err("codegen not implemented for recipe (expand first)".to_string())
         }
@@ -138,6 +140,7 @@ pub fn state_query_script(resource: &Resource) -> Result<String, String> {
             Ok(resources::overlay_interface::state_query_script(resource))
         }
         ResourceType::DiskBudget => Ok(resources::disk_budget::state_query_script(resource)),
+        ResourceType::BackupSync => Ok(resources::backup_sync::state_query_script(resource)),
         ResourceType::Recipe => {
             Err("codegen not implemented for recipe (expand first)".to_string())
         }

--- a/src/core/kani_proofs_backup_sync.rs
+++ b/src/core/kani_proofs_backup_sync.rs
@@ -1,0 +1,85 @@
+//! FJ-037: Kani bounded-model proofs for the `backup_sync` resource.
+//!
+//! Gated behind `#[cfg(kani)]`; normal builds ignore them.
+//! Run with: `cargo kani --harness proof_backup_remote_never_local`.
+//!
+//! These prove the destination algebra over the whole input space a unit test
+//! can only sample. The deletion-free parts that matter operationally — does a
+//! zero-match verification actually fail? — are proved by execution instead, in
+//! `tests/falsification_backup_sync.rs`, because a bounded model cannot say
+//! anything useful about what `rclone` reports.
+
+// ── Backup Sync Proofs (FJ-037 / backup-sync-v1) ──────────────────────
+
+/// Contract `remote_cannot_be_local`: no accepted destination is a local path.
+///
+/// The predecessor's destination was `/videos`, a symlink back to its own
+/// source. For every short string over a character set that includes the
+/// dangerous prefixes, an accepted `BackupSync` must contain a `:` and must not
+/// begin with `/`, `.` or `~` — so a local destination cannot be constructed.
+#[cfg(kani)]
+#[kani::proof]
+#[kani::unwind(10)]
+fn proof_backup_remote_never_local() {
+    use super::types::BackupSync;
+
+    // A small alphabet that deliberately includes every rejected prefix.
+    const ALPHABET: [u8; 6] = [b'/', b'.', b'~', b':', b'a', b'1'];
+    let i0: usize = kani::any();
+    let i1: usize = kani::any();
+    let i2: usize = kani::any();
+    kani::assume(i0 < ALPHABET.len() && i1 < ALPHABET.len() && i2 < ALPHABET.len());
+
+    let bytes = [ALPHABET[i0], ALPHABET[i1], ALPHABET[i2]];
+    let remote = core::str::from_utf8(&bytes).unwrap();
+
+    if let Ok(b) = BackupSync::new(vec!["/mnt/a".to_string()], remote, "daily", 99, 700, None) {
+        // Accepted => provably not a local path.
+        assert!(b.remote.contains(':'));
+        assert!(!b.remote.starts_with('/'));
+        assert!(!b.remote.starts_with('.'));
+        assert!(!b.remote.starts_with('~'));
+        // ...and the remote name is non-empty, so `name:` is well formed.
+        assert!(!b.remote_name().is_empty());
+    }
+}
+
+/// Contract `coverage_is_checksum_verified`: coverage is bounded 0..=100.
+///
+/// The percentage is computed in POSIX shell integer arithmetic as
+/// `matched * 100 / total`. This pins that it cannot exceed 100 (which would
+/// let a broken counter report over-full coverage and mask a real gap) and
+/// cannot divide by zero.
+#[cfg(kani)]
+#[kani::proof]
+fn proof_backup_coverage_bounded() {
+    let matched: u32 = kani::any();
+    let total: u32 = kani::any();
+    kani::assume(total > 0 && total <= 1_000_000);
+    kani::assume(matched <= total);
+
+    let coverage = matched * 100 / total;
+    assert!(coverage <= 100);
+    // Full coverage is reachable only when every file matched.
+    if coverage == 100 {
+        assert!(matched == total);
+    }
+    // And a zero-match run can never look healthy.
+    if matched == 0 {
+        assert!(coverage == 0);
+    }
+}
+
+/// Contract `remote_cannot_be_local`: a declaration with no sources is refused.
+///
+/// A backup of nothing verifies trivially — 0 of 0 files — and would otherwise
+/// report perfect coverage while protecting nothing.
+#[cfg(kani)]
+#[kani::proof]
+fn proof_backup_empty_sources_rejected() {
+    use super::types::BackupSync;
+
+    let verify_pct: u8 = kani::any();
+    let result = BackupSync::new(vec![], "gdrive:x", "daily", verify_pct, 700, None);
+    assert!(result.is_err());
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -57,6 +57,7 @@ pub mod ferrocene;
 pub mod flight_grade;
 mod kani_production_proofs;
 mod kani_proofs;
+mod kani_proofs_backup_sync;
 mod kani_proofs_disk_budget;
 mod kani_proofs_overlay;
 pub mod mcdc;

--- a/src/core/parser/backup_sync_validate.rs
+++ b/src/core/parser/backup_sync_validate.rs
@@ -1,0 +1,31 @@
+//! FJ-037: `backup_sync` declaration validation.
+
+use super::*;
+
+/// A backup must name a real remote and at least one existing-looking source.
+pub(super) fn validate_backup_sync(
+    id: &str,
+    resource: &Resource,
+    errors: &mut Vec<ValidationError>,
+) {
+    if let Err(e) = crate::resources::backup_sync::backup_of(resource) {
+        errors.push(ValidationError {
+            message: format!("resource '{id}' (backup_sync): {e}"),
+        });
+        return;
+    }
+    // A literal token in the repo is a committed bearer credential. Templates
+    // (`{{secrets.x}}`) are the supported form; anything else is refused here
+    // rather than discovered in a git history audit later.
+    if let Some(t) = resource.backup.token.as_deref() {
+        if !t.contains("{{") && t.len() > 24 {
+            errors.push(ValidationError {
+                message: format!(
+                    "resource '{id}' (backup_sync) has a literal `backup_token`. Use \
+                     `{{{{secrets.NAME}}}}` so the credential is resolved through the \
+                     secrets provider instead of being committed."
+                ),
+            });
+        }
+    }
+}

--- a/src/core/parser/known_fields.rs
+++ b/src/core/parser/known_fields.rs
@@ -130,6 +130,16 @@ pub(crate) const RESOURCE_FIELDS: &[&str] = &[
     "budget_critical_free_gb",
     "budget_schedule",
     "budget_reclaim",
+    // FJ-037: backup_sync
+    "backup_source",
+    "backup_remote",
+    "backup_schedule",
+    "backup_verify_pct",
+    "backup_daily_cap_gb",
+    "backup_bandwidth_limit",
+    "backup_remote_type",
+    "backup_remote_config",
+    "backup_token",
 ];
 
 pub(crate) const MACHINE_FIELDS: &[&str] = &[

--- a/src/core/parser/mod.rs
+++ b/src/core/parser/mod.rs
@@ -6,6 +6,7 @@
 //! - depends_on references must exist
 //! - Required fields per resource type
 
+mod backup_sync_validate;
 mod disk_budget_validate;
 mod expansion;
 mod format_validation;

--- a/src/core/parser/resource_types.rs
+++ b/src/core/parser/resource_types.rs
@@ -1,5 +1,6 @@
 //! Type-specific required-field validation for each resource type.
 
+use super::backup_sync_validate::validate_backup_sync;
 use super::disk_budget_validate::validate_disk_budget;
 use super::*;
 
@@ -28,6 +29,7 @@ pub(super) fn validate_resource_type(
         ResourceType::GithubRelease => validate_github_release(id, resource, errors),
         ResourceType::OverlayInterface => validate_overlay_interface(id, resource, errors),
         ResourceType::DiskBudget => validate_disk_budget(id, resource, errors),
+        ResourceType::BackupSync => validate_backup_sync(id, resource, errors),
     }
 }
 

--- a/src/core/planner/mod.rs
+++ b/src/core/planner/mod.rs
@@ -200,7 +200,8 @@ fn default_state(resource_type: &ResourceType) -> &'static str {
         | ResourceType::Build
         | ResourceType::GithubRelease
         | ResourceType::OverlayInterface
-        | ResourceType::DiskBudget => "present",
+        | ResourceType::DiskBudget
+        | ResourceType::BackupSync => "present",
     }
 }
 
@@ -395,7 +396,8 @@ fn describe_action(resource_id: &str, resource: &Resource, action: &PlanAction) 
             | ResourceType::Build
             | ResourceType::GithubRelease
             | ResourceType::OverlayInterface
-            | ResourceType::DiskBudget => format!("{resource_id}: create"),
+            | ResourceType::DiskBudget
+            | ResourceType::BackupSync => format!("{resource_id}: create"),
         },
         PlanAction::Update => format!("{resource_id}: update (state changed)"),
         PlanAction::Destroy => format!("{resource_id}: destroy"),

--- a/src/core/planner/proof_obligation.rs
+++ b/src/core/planner/proof_obligation.rs
@@ -54,6 +54,10 @@ fn classify_create(rtype: &ResourceType) -> ProofObligation {
         // different set of paths — the invariant is the watermark it converges
         // to, never the specific deletions it performs to get there.
         ResourceType::DiskBudget => ProofObligation::Convergent,
+        // Convergent: repeated passes drive coverage toward the declared
+        // threshold; the invariant is verified coverage, not a byte-identical
+        // transfer set.
+        ResourceType::BackupSync => ProofObligation::Convergent,
     }
 }
 
@@ -85,7 +89,9 @@ fn classify_destroy(rtype: &ResourceType) -> ProofObligation {
         ResourceType::WasmBundle | ResourceType::Image => ProofObligation::Destructive,
         ResourceType::Build => ProofObligation::Convergent,
         ResourceType::GithubRelease => ProofObligation::Convergent,
-        ResourceType::OverlayInterface | ResourceType::DiskBudget => ProofObligation::Convergent,
+        ResourceType::OverlayInterface | ResourceType::DiskBudget | ResourceType::BackupSync => {
+            ProofObligation::Convergent
+        }
     }
 }
 

--- a/src/core/planner/reversibility.rs
+++ b/src/core/planner/reversibility.rs
@@ -64,6 +64,8 @@ fn classify_destroy(resource: &Resource) -> Reversibility {
         // not un-reclaim. (The reclaim itself is irreversible by design — that
         // is what `budget_reclaim` authorises.)
         ResourceType::DiskBudget => Reversibility::Reversible,
+        // Destroying the resource removes the schedule, never the remote data.
+        ResourceType::BackupSync => Reversibility::Reversible,
     }
 }
 

--- a/src/core/resolver/resource.rs
+++ b/src/core/resolver/resource.rs
@@ -149,6 +149,21 @@ fn resolve_build_and_overlay_fields(
         rule.roots = resolve_list(&rule.roots, params, machines, secrets)?;
     }
 
+    // Backup sync. `backup_token` is the important one: it arrives as
+    // `{{secrets.NAME}}` and an unresolved value would be written into
+    // rclone.conf as the literal credential. The sources matter for the same
+    // reason budget roots do — an unexpanded path matches nothing, and a backup
+    // that silently protects nothing is exactly what this resource replaced.
+    r.backup.remote = resolve_opt(&r.backup.remote, params, machines, secrets)?;
+    r.backup.remote_type = resolve_opt(&r.backup.remote_type, params, machines, secrets)?;
+    r.backup.schedule = resolve_opt(&r.backup.schedule, params, machines, secrets)?;
+    r.backup.bandwidth_limit = resolve_opt(&r.backup.bandwidth_limit, params, machines, secrets)?;
+    r.backup.token = resolve_opt(&r.backup.token, params, machines, secrets)?;
+    r.backup.source = resolve_list(&r.backup.source, params, machines, secrets)?;
+    for v in r.backup.remote_config.values_mut() {
+        *v = resolve_template_with_secrets(v, params, machines, secrets)?;
+    }
+
     Ok(())
 }
 

--- a/src/core/types/backup_sync_types.rs
+++ b/src/core/types/backup_sync_types.rs
@@ -1,0 +1,339 @@
+//! FJ-037: Backup sync types — offsite copy as declared, *verified* state.
+//!
+//! # Why this type exists
+//!
+//! lambda-labs held ~2.1 TB of irreplaceable media on a 4-wide RAID0 with no
+//! parity, and a job that had been reporting `Backup complete` hourly for
+//! months while copying the array onto itself. Measured 2026-08-15: zero bytes
+//! existed anywhere off that array.
+//!
+//! Three independent defects produced that, and each one is something a type
+//! can forbid:
+//!
+//!   1. **The destination was not remote.** `SOURCE=/mnt/nvme-raid0/videos`,
+//!      `DEST=/videos`, and `/videos` was a symlink back to the source. rsync
+//!      dutifully copied a directory onto itself and exited 0.
+//!   2. **The success metric could not fail.** It reported `Files: 0` while 77
+//!      matching files sat in that exact directory, because `find "$DEST"` does
+//!      not descend a symlink without `-L` or a trailing slash. Not "0 reported
+//!      as healthy on an empty set" — structurally 0 on *every* input.
+//!   3. **Coverage was never compared to anything.** The job synced a 16 GB
+//!      directory and nothing anywhere asserted that the other 2.1 TB was
+//!      covered.
+//!
+//! So: the remote must be syntactically incapable of being a local path, the
+//! health signal is a count of files *verified present in the remote by
+//! checksum*, and that count is compared against the source. A run that cannot
+//! demonstrate coverage fails.
+
+/// Default minimum % of source files that must verify against the remote.
+///
+/// Not 100: a file written or renamed between the sync and the verify pass is
+/// a routine race on a live media box, and a threshold that flags it makes the
+/// signal noisy and therefore ignored. 99 tolerates churn while still failing
+/// on any real coverage gap.
+pub const DEFAULT_VERIFY_PCT: u8 = 99;
+/// Default cadence.
+pub const DEFAULT_BACKUP_SCHEDULE: &str = "daily";
+/// Default per-run upload ceiling, GiB.
+///
+/// Google Drive rejects uploads past ~750 GB/day/account. Seeding 2.1 TB
+/// therefore takes days no matter how fast the link is; the ceiling makes that
+/// a designed-for property rather than a nightly burst of 403s.
+pub const DEFAULT_DAILY_CAP_GB: u64 = 700;
+
+// Compile-time, not a test: a default that violated these would ship to every
+// machine that omits the knobs, which is the common case.
+const _: () = assert!(DEFAULT_VERIFY_PCT >= 95 && DEFAULT_VERIFY_PCT <= 100);
+const _: () = assert!(
+    DEFAULT_DAILY_CAP_GB < 750,
+    "must stay under Drive's daily cap"
+);
+
+/// Declaration fields for a `backup_sync` resource.
+///
+/// Grouped into their own struct and `#[serde(flatten)]`-ed into `Resource`:
+/// the YAML shape is unchanged (`backup_remote:` stays top level), but the nine
+/// fields live with the type that understands them instead of enlarging an
+/// already-large kitchen-sink struct.
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct BackupSpec {
+    /// Absolute source paths to protect.
+    #[serde(rename = "backup_source", default)]
+    pub source: Vec<String>,
+
+    /// Destination in `remote:path` form. A local path is rejected at parse time.
+    #[serde(rename = "backup_remote", default)]
+    pub remote: Option<String>,
+
+    /// rclone backend for the remote (default "drive").
+    #[serde(rename = "backup_remote_type", default)]
+    pub remote_type: Option<String>,
+
+    /// Non-secret rclone remote options, written verbatim into rclone.conf.
+    #[serde(rename = "backup_remote_config", default)]
+    pub remote_config: std::collections::HashMap<String, String>,
+
+    /// OAuth token for the remote. Supply as `{{secrets.NAME}}`.
+    #[serde(rename = "backup_token", default)]
+    pub token: Option<String>,
+
+    /// systemd `OnCalendar` cadence for the sync (default "daily").
+    #[serde(rename = "backup_schedule", default)]
+    pub schedule: Option<String>,
+
+    /// Min % of source files that must verify by checksum (default 99).
+    #[serde(rename = "backup_verify_pct", default)]
+    pub verify_pct: Option<u8>,
+
+    /// Upload ceiling per run in GiB (default 700, under Drive's 750/day).
+    #[serde(rename = "backup_daily_cap_gb", default)]
+    pub daily_cap_gb: Option<u64>,
+
+    /// Optional rclone bandwidth limit, e.g. "50M".
+    #[serde(rename = "backup_bandwidth_limit", default)]
+    pub bandwidth_limit: Option<String>,
+}
+
+/// Resolved, validated backup declaration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BackupSync {
+    /// Absolute source paths to protect.
+    pub sources: Vec<String>,
+    /// Destination in `remote:path` form (an rclone remote).
+    pub remote: String,
+    /// systemd `OnCalendar` cadence.
+    pub schedule: String,
+    /// Minimum % of source files that must verify by checksum.
+    pub verify_pct: u8,
+    /// Upload ceiling per run, GiB.
+    pub daily_cap_gb: u64,
+    /// Optional rclone bandwidth limit (e.g. "50M").
+    pub bandwidth_limit: Option<String>,
+}
+
+impl BackupSync {
+    /// Build a declaration, rejecting anything that cannot be a real backup.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` when there are no sources, a source is not absolute, the
+    /// remote is not in `remote:path` form, sources overlap, or `verify_pct` is
+    /// out of range.
+    pub fn new(
+        sources: Vec<String>,
+        remote: &str,
+        schedule: &str,
+        verify_pct: u8,
+        daily_cap_gb: u64,
+        bandwidth_limit: Option<String>,
+    ) -> Result<Self, String> {
+        if sources.is_empty() {
+            return Err(
+                "backup_sync requires at least one `backup_source` — a backup of \
+                        nothing verifies trivially and protects nothing"
+                    .to_string(),
+            );
+        }
+        for s in &sources {
+            if !s.starts_with('/') {
+                return Err(format!("backup_sync source '{s}' is not an absolute path"));
+            }
+        }
+        validate_no_overlap(&sources)?;
+        validate_remote(remote)?;
+        if verify_pct == 0 || verify_pct > 100 {
+            return Err(format!(
+                "backup_sync verify_pct must be in 1..=100, got {verify_pct}"
+            ));
+        }
+        Ok(Self {
+            sources,
+            remote: remote.to_string(),
+            schedule: schedule.to_string(),
+            verify_pct,
+            daily_cap_gb,
+            bandwidth_limit,
+        })
+    }
+
+    /// The remote's name (the part before `:`).
+    pub fn remote_name(&self) -> &str {
+        self.remote.split(':').next().unwrap_or("")
+    }
+}
+
+/// A destination must be an rclone remote, never a local path.
+///
+/// This is the single most load-bearing check in the type. The job this
+/// replaces had a *local* destination that symlinked back to its own source,
+/// so it copied the array onto itself and exited 0 for months. `remote:path`
+/// cannot name a local directory, and rejecting everything else makes the
+/// self-referential backup unrepresentable rather than merely discouraged.
+///
+/// # Errors
+///
+/// Returns `Err` for absolute paths, relative paths, bare names with no colon,
+/// and empty remote names.
+fn validate_remote(remote: &str) -> Result<(), String> {
+    if remote.starts_with('/') || remote.starts_with('.') || remote.starts_with('~') {
+        return Err(format!(
+            "backup_sync remote '{remote}' is a LOCAL path. The destination must be an \
+             rclone remote in `remote:path` form — a local destination is how the \
+             predecessor came to copy the array onto itself and report success."
+        ));
+    }
+    let Some((name, _path)) = remote.split_once(':') else {
+        return Err(format!(
+            "backup_sync remote '{remote}' has no `remote:` prefix; expected `remote:path`"
+        ));
+    };
+    if name.is_empty() {
+        return Err(format!(
+            "backup_sync remote '{remote}' has an empty remote name"
+        ));
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err(format!(
+            "backup_sync remote name '{name}' must be alphanumeric/-/_ (rclone remote name)"
+        ));
+    }
+    Ok(())
+}
+
+/// Overlapping sources double-count coverage and make the percentage a lie.
+fn validate_no_overlap(sources: &[String]) -> Result<(), String> {
+    for (i, a) in sources.iter().enumerate() {
+        for b in sources.iter().skip(i + 1) {
+            let (outer, inner) = if a.len() <= b.len() { (a, b) } else { (b, a) };
+            let prefix = outer.trim_end_matches('/');
+            if inner == outer || inner.starts_with(&format!("{prefix}/")) {
+                return Err(format!(
+                    "backup_sync sources overlap ('{outer}' contains '{inner}'), which \
+                     double-counts files and makes verify_pct meaningless"
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ok_sources() -> Vec<String> {
+        vec!["/mnt/a".into(), "/mnt/b".into()]
+    }
+
+    fn build(remote: &str) -> Result<BackupSync, String> {
+        BackupSync::new(ok_sources(), remote, "daily", 99, 700, None)
+    }
+
+    #[test]
+    fn accepts_a_real_remote() {
+        let b = build("gdrive:lambda-labs-media").unwrap();
+        assert_eq!(b.remote_name(), "gdrive");
+    }
+
+    #[test]
+    fn rejects_an_absolute_local_destination() {
+        // THE bug: DEST=/videos, a symlink back to SOURCE.
+        let e = build("/videos").unwrap_err();
+        assert!(e.contains("LOCAL path"), "{e}");
+        assert!(e.contains("copy the array onto itself"), "{e}");
+    }
+
+    #[test]
+    fn rejects_relative_and_home_destinations() {
+        assert!(build("./backup").is_err());
+        assert!(build("../backup").is_err());
+        assert!(build("~/backup").is_err());
+    }
+
+    #[test]
+    fn rejects_a_bare_name_with_no_colon() {
+        assert!(build("gdrive").is_err());
+    }
+
+    #[test]
+    fn rejects_an_empty_remote_name() {
+        assert!(build(":path").is_err());
+    }
+
+    #[test]
+    fn rejects_a_remote_name_with_path_separators() {
+        // `mnt/nvme-raid0:x` would be a directory, not a remote.
+        assert!(build("mnt/nvme-raid0:x").is_err());
+    }
+
+    #[test]
+    fn rejects_an_empty_source_list() {
+        let e = BackupSync::new(vec![], "gdrive:x", "daily", 99, 700, None).unwrap_err();
+        assert!(e.contains("at least one"), "{e}");
+        assert!(e.contains("verifies trivially"), "{e}");
+    }
+
+    #[test]
+    fn rejects_a_relative_source() {
+        assert!(BackupSync::new(vec!["media".into()], "gdrive:x", "daily", 99, 700, None).is_err());
+    }
+
+    #[test]
+    fn rejects_overlapping_sources() {
+        let e = BackupSync::new(
+            vec!["/mnt/media".into(), "/mnt/media/courses".into()],
+            "gdrive:x",
+            "daily",
+            99,
+            700,
+            None,
+        )
+        .unwrap_err();
+        assert!(e.contains("overlap"), "{e}");
+    }
+
+    #[test]
+    fn sibling_sources_sharing_a_prefix_are_fine() {
+        // /mnt/media-a is NOT inside /mnt/media.
+        assert!(BackupSync::new(
+            vec!["/mnt/media".into(), "/mnt/media-a".into()],
+            "gdrive:x",
+            "daily",
+            99,
+            700,
+            None
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn rejects_duplicate_sources() {
+        assert!(BackupSync::new(
+            vec!["/mnt/a".into(), "/mnt/a".into()],
+            "gdrive:x",
+            "daily",
+            99,
+            700,
+            None
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn rejects_out_of_range_verify_pct() {
+        assert!(BackupSync::new(ok_sources(), "gdrive:x", "daily", 0, 700, None).is_err());
+        assert!(BackupSync::new(ok_sources(), "gdrive:x", "daily", 101, 700, None).is_err());
+        assert!(BackupSync::new(ok_sources(), "gdrive:x", "daily", 100, 700, None).is_ok());
+    }
+
+    #[test]
+    fn defaults_are_sane() {
+        // The numeric bounds are compile-time assertions above; this pins the
+        // cadence, which cannot be checked in a const context.
+        assert_eq!(DEFAULT_BACKUP_SCHEDULE, "daily");
+    }
+}

--- a/src/core/types/mod.rs
+++ b/src/core/types/mod.rs
@@ -3,6 +3,7 @@
 //! Defines the YAML schema types for machines, resources, policy, state locks,
 //! and provenance events. All types derive Serialize/Deserialize for YAML roundtripping.
 
+mod backup_sync_types;
 mod behavior_types;
 mod build_metrics;
 mod ci_pipeline_types;
@@ -51,6 +52,7 @@ mod undo_types;
 mod validation_types;
 mod wasm_types;
 
+pub use backup_sync_types::*;
 pub use behavior_types::*;
 pub use build_metrics::*;
 pub use ci_pipeline_types::*;

--- a/src/core/types/resource.rs
+++ b/src/core/types/resource.rs
@@ -1,5 +1,6 @@
 //! Resource type definitions: Resource, ResourceType, MachineTarget.
 
+use super::backup_sync_types::BackupSpec;
 use super::disk_budget_types::ReclaimRule;
 use super::resource_enums::{MachineTarget, ResourceType};
 use super::service_mode_types::RestartPolicy;
@@ -448,6 +449,11 @@ pub struct Resource {
     /// Ordered reclaim rules, most-disposable first.
     #[serde(default)]
     pub budget_reclaim: Vec<ReclaimRule>,
+
+    // -- Backup sync (FJ-037) --
+    /// Verified offsite copy. Flattened, so the YAML keys stay top level.
+    #[serde(flatten)]
+    pub backup: BackupSpec,
 }
 
 /// FJ-1220: Lifecycle protection rules for a resource.

--- a/src/core/types/resource_enums.rs
+++ b/src/core/types/resource_enums.rs
@@ -53,6 +53,8 @@ pub enum ResourceType {
     OverlayInterface,
     /// FJ-36: Filesystem disk budget — watermarks + reclaim reaper + drift.
     DiskBudget,
+    /// FJ-37: Verified offsite backup sync (rclone remote + checksum proof).
+    BackupSync,
 }
 
 impl fmt::Display for ResourceType {
@@ -77,6 +79,7 @@ impl fmt::Display for ResourceType {
             Self::GithubRelease => write!(f, "github_release"),
             Self::OverlayInterface => write!(f, "overlay_interface"),
             Self::DiskBudget => write!(f, "disk_budget"),
+            Self::BackupSync => write!(f, "backup_sync"),
         }
     }
 }
@@ -204,6 +207,7 @@ mod tests {
             (ResourceType::GithubRelease, "github_release"),
             (ResourceType::OverlayInterface, "overlay_interface"),
             (ResourceType::DiskBudget, "disk_budget"),
+            (ResourceType::BackupSync, "backup_sync"),
         ];
         for (variant, expected) in &cases {
             assert_eq!(variant.to_string(), *expected);

--- a/src/resources/backup_sync/config.rs
+++ b/src/resources/backup_sync/config.rs
@@ -1,0 +1,198 @@
+//! FJ-037: forjar-managed `rclone.conf`.
+//!
+//! # Why forjar owns this file
+//!
+//! An rclone remote that is not configured does not fail — rclone falls back to
+//! treating `name:path` as a *local* path. That is the same class of failure as
+//! the predecessor on lambda-labs, which synced `/mnt/nvme-raid0/videos` to
+//! `/videos` (a symlink back to itself) and reported success hourly for months.
+//! Leaving the remote definition as a manual step reintroduces exactly that
+//! risk, so the definition is declared state like anything else.
+//!
+//! # The split, and why it is a split
+//!
+//! `rclone.conf` mixes two things with very different handling rules:
+//!
+//!   * **Configuration** — backend, scope, folder id, tuning. Belongs in the
+//!     repo, reviewable, diffable, drift-checked.
+//!   * **The OAuth refresh token** — a bearer credential. Must never be
+//!     committed in cleartext.
+//!
+//! So `backup_remote_config` is written verbatim from the declaration, and
+//! `backup_token` is expected to arrive as `{{secrets.NAME}}`, resolved through
+//! whichever provider the config declares (`sops`/age keeps the ciphertext in
+//! the repo). The generated file is written 0600, and the token is redacted
+//! everywhere it could otherwise surface.
+
+use crate::core::shell_escape::sh_squote;
+use crate::core::types::Resource;
+
+/// Path of the managed rclone config for a given home directory.
+pub(super) fn conf_path(home: &str) -> String {
+    format!("{}/.config/rclone/rclone.conf", home.trim_end_matches('/'))
+}
+
+/// A token value that is still an unresolved template never reached the
+/// secrets provider — writing it would produce a config whose password is the
+/// literal string `{{secrets.foo}}`.
+pub(super) fn is_unresolved(token: &str) -> bool {
+    token.contains("{{") && token.contains("}}")
+}
+
+/// Render the `[remote]` stanza. Keys are emitted sorted so the file — and
+/// therefore its hash, and therefore drift — is stable across runs.
+pub(super) fn stanza(resource: &Resource, remote_name: &str, token: Option<&str>) -> String {
+    let backend = resource.backup.remote_type.as_deref().unwrap_or("drive");
+    let mut keys: Vec<(&String, &String)> = resource.backup.remote_config.iter().collect();
+    keys.sort_by(|a, b| a.0.cmp(b.0));
+
+    let mut out = format!("[{remote_name}]\ntype = {backend}\n");
+    for (k, v) in keys {
+        // `token` is owned by the secret path; a config key of that name would
+        // silently shadow it.
+        if k == "token" {
+            continue;
+        }
+        out.push_str(&format!("{k} = {v}\n"));
+    }
+    if let Some(t) = token {
+        out.push_str(&format!("token = {t}\n"));
+    }
+    out
+}
+
+/// Shell that installs the config atomically at 0600.
+///
+/// Written via a quoted heredoc so nothing in the token is expanded by the
+/// shell, to a temp file in the same directory (atomic rename), and with the
+/// mode set *before* the content lands so the token is never briefly readable.
+pub(super) fn install(home: &str, body: &str) -> String {
+    let path = conf_path(home);
+    let path_q = sh_squote(&path);
+    let dir_q = sh_squote(&format!("{}/.config/rclone", home.trim_end_matches('/')));
+    format!(
+        r#"mkdir -p {dir_q}
+chmod 0700 {dir_q}
+BS_CONF_TMP={path_q}.tmp
+# umask before creation: the token must never exist world-readable, not even
+# for the instant between creat() and chmod().
+( umask 077; cat > "$BS_CONF_TMP" <<'FORJAR_RCLONE_CONF'
+{body}
+FORJAR_RCLONE_CONF
+)
+chmod 0600 "$BS_CONF_TMP"
+mv -f "$BS_CONF_TMP" {path_q}
+"#
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::types::{BackupSpec, ResourceType};
+    use std::collections::HashMap;
+
+    fn res() -> Resource {
+        let mut cfg = HashMap::new();
+        cfg.insert("scope".to_string(), "drive.file".to_string());
+        cfg.insert("root_folder_id".to_string(), "ABC123".to_string());
+        Resource {
+            resource_type: ResourceType::BackupSync,
+            backup: BackupSpec {
+                remote_config: cfg,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn stanza_declares_the_backend_and_config_keys() {
+        let s = stanza(&res(), "gdrive", None);
+        assert!(s.starts_with("[gdrive]\ntype = drive\n"));
+        assert!(s.contains("scope = drive.file"));
+        assert!(s.contains("root_folder_id = ABC123"));
+    }
+
+    #[test]
+    fn backend_is_overridable() {
+        let r = Resource {
+            backup: BackupSpec {
+                remote_type: Some("s3".into()),
+                ..res().backup
+            },
+            ..res()
+        };
+        assert!(stanza(&r, "x", None).contains("type = s3"));
+    }
+
+    #[test]
+    fn keys_are_sorted_so_the_hash_is_stable() {
+        // HashMap iteration order varies per process; an unsorted stanza would
+        // make the config hash — and therefore drift — flap at random.
+        let a = stanza(&res(), "gdrive", None);
+        for _ in 0..8 {
+            assert_eq!(stanza(&res(), "gdrive", None), a);
+        }
+        let scope = a.find("scope").unwrap();
+        let root = a.find("root_folder_id").unwrap();
+        assert!(root < scope, "keys must be sorted");
+    }
+
+    #[test]
+    fn a_config_key_named_token_cannot_shadow_the_secret() {
+        let mut r = res();
+        r.backup
+            .remote_config
+            .insert("token".into(), "NOT-THE-REAL-TOKEN".into());
+        let s = stanza(&r, "gdrive", Some("REAL"));
+        assert!(!s.contains("NOT-THE-REAL-TOKEN"));
+        assert_eq!(s.matches("token = ").count(), 1);
+        assert!(s.contains("token = REAL"));
+    }
+
+    #[test]
+    fn token_is_omitted_when_absent() {
+        assert!(!stanza(&res(), "gdrive", None).contains("token ="));
+    }
+
+    #[test]
+    fn detects_an_unresolved_secret_template() {
+        // Writing this literally yields a config whose credential is the string
+        // "{{secrets.rclone_token}}" — rclone would fail in a way that looks
+        // like an auth problem rather than a config-resolution bug.
+        assert!(is_unresolved("{{secrets.rclone_token}}"));
+        assert!(!is_unresolved("ya29.a0Af..."));
+    }
+
+    #[test]
+    fn install_is_atomic_and_never_world_readable() {
+        let s = install("/home/noah", "[gdrive]\ntype = drive\n");
+        assert!(
+            s.contains("umask 077"),
+            "token must not exist world-readable"
+        );
+        assert!(s.contains("chmod 0600"));
+        assert!(s.contains("chmod 0700"));
+        assert!(s.contains("mv -f"), "install must be atomic");
+    }
+
+    #[test]
+    fn install_uses_a_quoted_heredoc() {
+        // An unquoted heredoc would let `$` or backticks in a token be expanded
+        // by the shell, silently corrupting the credential.
+        assert!(install("/home/noah", "x").contains("<<'FORJAR_RCLONE_CONF'"));
+    }
+
+    #[test]
+    fn conf_path_is_the_standard_location() {
+        assert_eq!(
+            conf_path("/home/noah"),
+            "/home/noah/.config/rclone/rclone.conf"
+        );
+        assert_eq!(
+            conf_path("/home/noah/"),
+            "/home/noah/.config/rclone/rclone.conf"
+        );
+    }
+}

--- a/src/resources/backup_sync/mod.rs
+++ b/src/resources/backup_sync/mod.rs
@@ -1,0 +1,277 @@
+//! FJ-037: `backup_sync` — an offsite copy that has to prove it exists.
+//!
+//! # Problem
+//!
+//! Measured on lambda-labs, 2026-08-15: ~2.1 TB of irreplaceable media on a
+//! 4-wide RAID0 with no parity, and **zero bytes** of it anywhere off that
+//! array. An hourly job had been reporting `Backup complete` for months. It was
+//! deployed, enabled, and exiting 0 the whole time.
+//!
+//! It failed in three ways at once, and each is now unrepresentable:
+//!
+//!   1. Its destination was local — `/videos`, a symlink back to its own
+//!      source — so rsync copied a directory onto itself. `backup_remote` is
+//!      rejected at parse time unless it is an rclone `remote:path`.
+//!   2. Its success metric could not fail: `find "$DEST"` on a symlink returns
+//!      nothing without `-L`, so it printed `Files: 0` while 77 matching files
+//!      sat in that exact directory. Health here is a count of files verified
+//!      present in the remote **by checksum**, and zero examined files is an
+//!      error rather than a pass.
+//!   3. Nothing compared coverage to the source. Coverage is now a percentage
+//!      of source files proven present, and a run below the declared threshold
+//!      exits non-zero.
+//!
+//! # Design note: `apply` does not run the sync
+//!
+//! [`crate::resources::disk_budget`] deliberately runs its reaper during apply,
+//! because a budget should converge immediately. This resource deliberately
+//! does **not**. Two reasons, one practical and one about evidence:
+//!
+//!   * Seeding terabytes takes days (Google Drive caps uploads at ~750 GB per
+//!     day per account); an apply that blocks on it would never return.
+//!   * If the deployer runs the job, the deployer writes the status file that
+//!     is supposed to be evidence the *service* ran. The observability signal
+//!     would be manufactured by the thing being observed. `apply` installs and
+//!     arms the timer; the first real pass is systemd's, and `state_query`
+//!     reads the journal to confirm that.
+//!
+//! # YAML
+//!
+//! ```yaml
+//! media-backup:
+//!   type: backup_sync
+//!   machine: lambda-labs
+//!   remote: "gdrive:lambda-labs-media"
+//!   remote_type: drive
+//!   remote_config:
+//!     scope: drive.file
+//!   token: "{{secrets.rclone-gdrive-token}}"
+//!   schedule: daily
+//!   verify_pct: 99
+//!   source:
+//!     - /mnt/nvme-raid0/RecordedCourses
+//!     - /mnt/nvme-raid0/home-Videos
+//! ```
+
+use crate::core::shell_escape::sh_squote;
+use crate::core::types::{BackupSync, Resource};
+use crate::core::types::{DEFAULT_BACKUP_SCHEDULE, DEFAULT_DAILY_CAP_GB, DEFAULT_VERIFY_PCT};
+
+mod config;
+mod preflight;
+mod sync;
+mod units;
+
+#[cfg(test)]
+mod tests;
+
+/// Heartbeat window as a multiple of the cadence.
+const STALE_AFTER_MISSED_RUNS: u64 = 3;
+
+/// Resolve a validated [`BackupSync`] from a resource declaration.
+///
+/// # Errors
+///
+/// Returns `Err` when sources are missing/relative/overlapping, or the remote
+/// is not a valid `remote:path`.
+pub fn backup_of(resource: &Resource) -> Result<BackupSync, String> {
+    let remote = resource.backup.remote.as_deref().ok_or_else(|| {
+        "backup_sync requires `backup_remote` (an rclone remote:path)".to_string()
+    })?;
+    BackupSync::new(
+        resource.backup.source.clone(),
+        remote,
+        resource
+            .backup
+            .schedule
+            .as_deref()
+            .unwrap_or(DEFAULT_BACKUP_SCHEDULE),
+        resource.backup.verify_pct.unwrap_or(DEFAULT_VERIFY_PCT),
+        resource.backup.daily_cap_gb.unwrap_or(DEFAULT_DAILY_CAP_GB),
+        resource.backup.bandwidth_limit.clone(),
+    )
+}
+
+fn slug(remote: &str) -> String {
+    let s: String = remote
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect();
+    let t = s.trim_matches('-').to_string();
+    if t.is_empty() {
+        "backup".to_string()
+    } else {
+        t
+    }
+}
+
+fn script_path(remote: &str) -> String {
+    format!("/usr/local/sbin/forjar-backup-{}.sh", slug(remote))
+}
+fn service_name(remote: &str) -> String {
+    format!("forjar-backup-{}", slug(remote))
+}
+fn service_path(remote: &str) -> String {
+    format!("/etc/systemd/system/{}.service", service_name(remote))
+}
+fn timer_path(remote: &str) -> String {
+    format!("/etc/systemd/system/{}.timer", service_name(remote))
+}
+fn status_json(remote: &str) -> String {
+    format!("/run/forjar-backup-{}.json", slug(remote))
+}
+
+fn home_of(resource: &Resource) -> String {
+    resource.home.clone().unwrap_or_else(|| "/root".to_string())
+}
+
+fn reject(msg: &str) -> String {
+    format!("echo {} >&2; exit 1", sh_squote(&format!("ERROR: {msg}")))
+}
+
+fn stale_secs(schedule: &str) -> u64 {
+    let period = match schedule {
+        "hourly" => 3600,
+        "daily" => 86400,
+        "weekly" => 604_800,
+        _ => 86400,
+    };
+    period * STALE_AFTER_MISSED_RUNS
+}
+
+/// Check: is a verified backup currently in place?
+pub fn check_script(resource: &Resource) -> String {
+    let cfg = match backup_of(resource) {
+        Ok(c) => c,
+        Err(e) => return reject(&e),
+    };
+    let scr = script_path(&cfg.remote);
+    let svc = service_path(&cfg.remote);
+    let status = sh_squote(&status_json(&cfg.remote));
+    format!(
+        "set -u\n\
+         if [ ! -f {scr} ] || [ ! -f {svc} ]; then echo 'absent'; exit 0; fi\n\
+         HE=\"$(sed -n 's/.*\"health\":\"\\([a-z][a-z]*\\)\".*/\\1/p' {status} 2>/dev/null | head -1)\"\n\
+         if [ \"${{HE:-none}}\" = \"verified\" ]; then echo 'present'; else echo 'unverified'; fi\n"
+    )
+}
+
+/// Apply: install config + script + units, arm the timer. Does NOT sync.
+pub fn apply_script(resource: &Resource) -> String {
+    let cfg = match backup_of(resource) {
+        Ok(c) => c,
+        Err(e) => return reject(&e),
+    };
+    if resource.state.as_deref() == Some("absent") {
+        return remove_script(&cfg);
+    }
+    if let Some(t) = resource.backup.token.as_deref() {
+        if config::is_unresolved(t) {
+            return reject(&format!(
+                "backup_token is still an unresolved template ({t}) — the secrets provider \
+                 did not supply it. Writing this would set the remote's credential to that \
+                 literal string and fail later as an auth error."
+            ));
+        }
+    }
+
+    let home = home_of(resource);
+    let name = service_name(&cfg.remote);
+    let scr = script_path(&cfg.remote);
+    let scr_q = sh_squote(&scr);
+    let body = sync::script(&cfg, &status_json(&cfg.remote), &name);
+    let stanza = config::stanza(
+        resource,
+        cfg.remote_name(),
+        resource.backup.token.as_deref(),
+    );
+    let svc = units::service_unit(&scr, &cfg.remote);
+    let tmr = units::timer_unit(&cfg.schedule, &cfg.remote);
+    let svc_q = sh_squote(&service_path(&cfg.remote));
+    let tmr_q = sh_squote(&timer_path(&cfg.remote));
+
+    format!(
+        r#"set -eu
+{conf_install}
+mkdir -p /usr/local/sbin
+cat > {scr_q} <<'FORJAR_BACKUP_EOF'
+{body}
+FORJAR_BACKUP_EOF
+chmod 0755 {scr_q}
+
+cat > {svc_q} <<'FORJAR_BACKUP_SVC'
+{svc}
+FORJAR_BACKUP_SVC
+
+cat > {tmr_q} <<'FORJAR_BACKUP_TMR'
+{tmr}
+FORJAR_BACKUP_TMR
+
+systemctl daemon-reload
+systemctl enable {name}.timer >/dev/null 2>&1 || true
+systemctl restart {name}.timer
+# The sync is NOT run here. Seeding takes days, and a deployer that runs the
+# job also writes the status file that is supposed to prove the SERVICE ran.
+echo 'backup_sync armed; first pass runs on the timer'
+"#,
+        conf_install = config::install(&home, &stanza),
+    )
+}
+
+fn remove_script(cfg: &BackupSync) -> String {
+    let name = service_name(&cfg.remote);
+    let scr = sh_squote(&script_path(&cfg.remote));
+    let svc = sh_squote(&service_path(&cfg.remote));
+    let tmr = sh_squote(&timer_path(&cfg.remote));
+    // Stop and disable BEFORE removing the files (PMAT-219): deleting a unit
+    // file out from under a loaded unit leaves it Active: failed with
+    // "Unit to trigger vanished", invisible to a converged-looking apply.
+    format!(
+        "set -u\n\
+         systemctl stop {name}.timer {name}.service >/dev/null 2>&1 || true\n\
+         systemctl disable {name}.timer >/dev/null 2>&1 || true\n\
+         rm -f {scr} {svc} {tmr}\n\
+         systemctl daemon-reload || true\n\
+         systemctl reset-failed {name}.timer {name}.service >/dev/null 2>&1 || true\n"
+    )
+}
+
+/// State query: drift-visible health classes, verified against the journal.
+pub fn state_query_script(resource: &Resource) -> String {
+    let cfg = match backup_of(resource) {
+        Ok(c) => c,
+        Err(e) => return reject(&e),
+    };
+    let name = service_name(&cfg.remote);
+    let scr = script_path(&cfg.remote);
+    let status = sh_squote(&status_json(&cfg.remote));
+    let stale_min = stale_secs(&cfg.schedule) / 60;
+    let conf = sh_squote(&config::conf_path(&home_of(resource)));
+
+    format!(
+        "set -u\n\
+         echo \"backup_installed=$([ -f {scr} ] && echo yes || echo no)\"\n\
+         echo \"backup_conf_sha=$( (sha256sum {conf} 2>/dev/null || echo missing) | awk '{{print $1}}')\"\n\
+         TMR_STATE=\"$(systemctl is-active {name}.timer 2>/dev/null | head -1)\"\n\
+         UNIT_STATE=\"$(systemctl is-failed {name}.service 2>/dev/null | head -1)\"\n\
+         echo \"backup_timer=${{TMR_STATE:-unknown}}\"\n\
+         echo \"backup_unit=${{UNIT_STATE:-unknown}}\"\n\
+         # Execution evidence comes from the JOURNAL, not from a status file the\n\
+         # deployer could have written. No journal entries => never ran.\n\
+         if journalctl -u {name}.service -n 1 --no-pager 2>/dev/null | grep -q .; then\n\
+         \x20 echo 'backup_ever_ran=yes'\n\
+         else\n\
+         \x20 echo 'backup_ever_ran=no'\n\
+         fi\n\
+         HE=\"$(sed -n 's/.*\"health\":\"\\([a-z][a-z]*\\)\".*/\\1/p' {status} 2>/dev/null | head -1)\"\n\
+         CV=\"$(sed -n 's/.*\"coverage_pct\":\\([0-9][0-9]*\\).*/\\1/p' {status} 2>/dev/null | head -1)\"\n\
+         MI=\"$(sed -n 's/.*\"missing\":\\([0-9][0-9]*\\).*/\\1/p' {status} 2>/dev/null | head -1)\"\n\
+         AGED=\"$(find {status} -mmin +{stale_min} 2>/dev/null)\"\n\
+         if [ ! -f {status} ]; then echo 'backup_heartbeat=missing'\n\
+         elif [ -n \"$AGED\" ]; then echo 'backup_heartbeat=stale'\n\
+         else echo 'backup_heartbeat=fresh'; fi\n\
+         echo \"backup_health=${{HE:-unknown}}\"\n\
+         # Volatile counters -> stderr only, never into the drift hash.\n\
+         echo \"backup_coverage_pct=${{CV:-0}} backup_missing=${{MI:-0}}\" >&2\n"
+    )
+}

--- a/src/resources/backup_sync/preflight.rs
+++ b/src/resources/backup_sync/preflight.rs
@@ -1,0 +1,129 @@
+//! FJ-037: preflight — refuse to run without a real, configured remote.
+//!
+//! The credential itself is deliberately NOT managed by forjar: an OAuth token
+//! is a secret and does not belong in a git repo. But "not managed" must never
+//! degrade into "not checked". A backup that runs with an unconfigured remote
+//! is the failure this resource exists to prevent, so every precondition is
+//! asserted before a single byte moves, and a missing one is a hard exit.
+
+use crate::core::shell_escape::sh_squote;
+use crate::core::types::BackupSync;
+
+/// Preflight assertions, emitted once at the top of the sync script.
+pub(super) fn block(cfg: &BackupSync) -> String {
+    let remote_name = sh_squote(cfg.remote_name());
+    let remote_disp = cfg.remote_name();
+    let sources: Vec<String> = cfg.sources.iter().map(|s| sh_squote(s)).collect();
+    let source_checks: String = sources
+        .iter()
+        .map(|s| {
+            format!(
+                "if [ ! -d {s} ]; then\n  \
+                 bs_log \"FATAL: source {s} does not exist\"\n  \
+                 exit 1\nfi\n"
+            )
+        })
+        .collect();
+
+    format!(
+        r#"
+# --- preflight ---------------------------------------------------------
+if ! command -v rclone >/dev/null 2>&1; then
+  bs_log "FATAL: rclone is not installed"
+  exit 1
+fi
+
+# The remote must be CONFIGURED, not merely named. An unconfigured remote makes
+# rclone treat the destination as a local path, which is exactly how a backup
+# silently becomes a copy onto the same disk.
+if ! rclone listremotes 2>/dev/null | grep -qx {remote_name}:; then
+  bs_log "FATAL: rclone remote {remote_disp}: is not configured on this host."
+  bs_log "       Run: rclone config   (or install the credential out-of-band)."
+  bs_log "       forjar does not manage the OAuth token - it is a secret - but it"
+  bs_log "       refuses to run a backup that cannot reach its destination."
+  exit 1
+fi
+
+# Prove the remote actually answers before claiming to protect anything.
+if ! rclone about {remote_name}: >/dev/null 2>&1; then
+  if ! rclone lsd {remote_name}: >/dev/null 2>&1; then
+    bs_log "FATAL: remote {remote_disp}: is configured but unreachable (auth expired?)"
+    exit 1
+  fi
+fi
+
+{source_checks}bs_log "preflight ok: rclone present, remote {remote_disp}: reachable"
+"#
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg() -> BackupSync {
+        BackupSync::new(
+            vec!["/mnt/media".into()],
+            "gdrive:bk",
+            "daily",
+            99,
+            700,
+            None,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn requires_rclone_to_be_installed() {
+        let s = block(&cfg());
+        assert!(s.contains("command -v rclone"));
+        assert!(s.contains("FATAL: rclone is not installed"));
+    }
+
+    #[test]
+    fn requires_the_remote_to_be_configured_not_just_named() {
+        // An unconfigured remote makes rclone fall back to a LOCAL path — the
+        // precise mechanism behind the self-referential predecessor.
+        let s = block(&cfg());
+        assert!(s.contains("rclone listremotes"));
+        assert!(s.contains("grep -qx 'gdrive':"));
+        assert!(s.contains("is not configured"));
+    }
+
+    #[test]
+    fn proves_the_remote_answers_before_syncing() {
+        let s = block(&cfg());
+        assert!(s.contains("rclone about") || s.contains("rclone lsd"));
+        assert!(s.contains("unreachable"));
+    }
+
+    #[test]
+    fn every_source_must_exist() {
+        let c = BackupSync::new(
+            vec!["/mnt/a".into(), "/mnt/b".into()],
+            "gdrive:bk",
+            "daily",
+            99,
+            700,
+            None,
+        )
+        .unwrap();
+        let s = block(&c);
+        assert!(s.contains("[ ! -d '/mnt/a' ]"));
+        assert!(s.contains("[ ! -d '/mnt/b' ]"));
+        assert_eq!(s.matches("does not exist").count(), 2);
+    }
+
+    #[test]
+    fn every_precondition_hard_exits() {
+        // No `|| true`, no warn-and-continue: a failed precondition must stop
+        // the run, or the backup reports success having done nothing.
+        let s = block(&cfg());
+        assert_eq!(s.matches("exit 1").count(), 4);
+    }
+
+    #[test]
+    fn explains_that_the_token_is_deliberately_unmanaged() {
+        assert!(block(&cfg()).contains("does not manage the OAuth token"));
+    }
+}

--- a/src/resources/backup_sync/sync.rs
+++ b/src/resources/backup_sync/sync.rs
@@ -1,0 +1,313 @@
+//! FJ-037: the sync + verify pass.
+//!
+//! The pass does two separable things, and the second is the one that matters:
+//! it copies, and then it *proves* the copy exists by comparing checksums
+//! against the remote. The predecessor did only the first, and reported
+//! success from rsync's exit code — which is 0 when you copy a directory onto
+//! itself.
+//!
+//! Verification uses `rclone check --combined`, which emits one line per file
+//! with a status character, so coverage is a count of files the remote
+//! actually holds with a matching hash — not a log line saying "complete".
+//!
+//! `-` means present locally and MISSING from the remote. That is the number
+//! that was silently 2.1 TB.
+
+use super::preflight;
+use crate::core::shell_escape::sh_squote;
+use crate::core::types::BackupSync;
+
+/// Per-source sync + verify block.
+fn source_block(src: &str, remote: &str, cap_gb: u64, bwlimit: &str) -> String {
+    let src_q = sh_squote(src);
+    // Each source lands under its own basename in the remote so two sources
+    // can never collide into one directory.
+    let leaf = src
+        .trim_end_matches('/')
+        .rsplit('/')
+        .next()
+        .unwrap_or("root");
+    let dest = format!("{remote}/{leaf}");
+    let dest_q = sh_squote(&dest);
+    let leaf_q = sh_squote(leaf);
+
+    format!(
+        r#"
+# -- source: {leaf} --
+bs_log "sync {leaf}: starting"
+rclone sync {src_q} {dest_q} \
+  --checksum \
+  --max-transfer {cap_gb}G \
+  --cutoff-mode soft \
+  {bwlimit}--transfers 4 \
+  --retries 3 \
+  --low-level-retries 10 \
+  --stats-one-line \
+  --stats 5m 2>&1 | tail -20 || bs_log "sync {leaf}: rclone exited nonzero (may be transfer cap)"
+
+# Verify by CHECKSUM, one line per file. Never trust the sync's exit code:
+# rsync exits 0 having copied a directory onto itself, which is the whole
+# reason this resource exists.
+rclone check {src_q} {dest_q} --checksum --combined "$BS_TMP/check-{leaf}" >/dev/null 2>&1 || true
+if [ -f "$BS_TMP/check-{leaf}" ]; then
+  bs_m=$(bs_count '^= ' "$BS_TMP/check-{leaf}")
+  bs_x=$(bs_count '^\* ' "$BS_TMP/check-{leaf}")
+  bs_o=$(bs_count '^- ' "$BS_TMP/check-{leaf}")
+  bs_e=$(bs_count '^! ' "$BS_TMP/check-{leaf}")
+else
+  bs_m=0; bs_x=0; bs_o=0; bs_e=1
+  bs_log "verify {leaf}: rclone check produced NO output - treating as unverified"
+fi
+BS_MATCH=$((BS_MATCH + bs_m))
+BS_DIFFER=$((BS_DIFFER + bs_x))
+BS_MISSING=$((BS_MISSING + bs_o))
+BS_ERROR=$((BS_ERROR + bs_e))
+bs_log "verify {leaf_q}: matched=$bs_m differing=$bs_x missing=$bs_o errors=$bs_e"
+"#
+    )
+}
+
+/// Generate the complete sync script.
+pub(super) fn script(cfg: &BackupSync, status_json: &str, log_tag: &str) -> String {
+    let tag = sh_squote(log_tag);
+    let remote = cfg.remote.trim_end_matches('/');
+    let verify_pct = cfg.verify_pct;
+    let bwlimit = cfg
+        .bandwidth_limit
+        .as_ref()
+        .map(|b| format!("--bwlimit {} ", sh_squote(b)))
+        .unwrap_or_default();
+    let blocks: String = cfg
+        .sources
+        .iter()
+        .map(|s| source_block(s, remote, cfg.daily_cap_gb, &bwlimit))
+        .collect();
+
+    format!(
+        r#"#!/bin/sh
+# forjar-managed backup sync. DO NOT EDIT - regenerate with `forjar apply`.
+set -u
+
+BS_STATUS="${{FORJAR_BACKUP_STATUS:-{status_json}}}"
+BS_TMP=$(mktemp -d) || exit 1
+# SEC011: guard the teardown. An unset or truncated BS_TMP would make the trap
+# an `rm -rf /`, and a trap fires on paths that never reach normal cleanup.
+bs_cleanup() {{
+  [ -n "${{BS_TMP:-}}" ] || return 0
+  [ "$BS_TMP" != "/" ] || return 0
+  # Deliberately not `rm -rf`: `find -delete` cannot recurse outside the tree it
+  # was given, and `rmdir` only removes an EMPTY directory. A wrong or truncated
+  # BS_TMP therefore fails harmlessly instead of destroying whatever it names.
+  find "$BS_TMP" -mindepth 1 -delete 2>/dev/null || true
+  rmdir "$BS_TMP" 2>/dev/null || true
+}}
+trap bs_cleanup EXIT INT TERM
+
+BS_MATCH=0
+BS_DIFFER=0
+BS_MISSING=0
+BS_ERROR=0
+BS_VERIFY_PCT={verify_pct}
+
+bs_log() {{ echo "{tag}: $*"; }}
+
+# `grep -c` PRINTS a count and still exits 1 when that count is zero. A
+# `$(grep -c ... || echo 0)` therefore captures BOTH the real "0" and the
+# fallback "0" as two lines, and the later $(( )) dies with "Illegal number".
+# Same shape as `systemctl is-failed`, which also prints a state and exits
+# non-zero: take the first line, default only when genuinely empty.
+bs_count() {{
+  bs_c=$(grep -c "$1" "$2" 2>/dev/null | head -1)
+  echo "${{bs_c:-0}}"
+}}
+{preflight}
+{blocks}
+BS_TOTAL=$((BS_MATCH + BS_DIFFER + BS_MISSING + BS_ERROR))
+if [ "$BS_TOTAL" -gt 0 ]; then
+  BS_COVERAGE=$((BS_MATCH * 100 / BS_TOTAL))
+else
+  BS_COVERAGE=0
+fi
+
+# Fail closed on an empty result set.
+#
+# The predecessor's metric reported "Files: 0" and called it "Backup complete"
+# - it could not distinguish "nothing to protect" from "protected nothing".
+# Zero files examined is never healthy when sources are declared: it means the
+# check did not run, not that the backup is fine.
+if [ "$BS_TOTAL" -eq 0 ]; then
+  BS_HEALTH=unverified
+  bs_log "FAILED: verification examined 0 files. Sources are declared, so this is a"
+  bs_log "        broken check, not an empty backup."
+elif [ "$BS_MATCH" -eq 0 ]; then
+  BS_HEALTH=unverified
+  bs_log "FAILED: 0 of $BS_TOTAL files verified present in the remote."
+elif [ "$BS_COVERAGE" -lt "$BS_VERIFY_PCT" ]; then
+  BS_HEALTH=partial
+else
+  BS_HEALTH=verified
+fi
+
+cat > "$BS_STATUS" <<EOF
+{{"remote":"{remote}","matched":$BS_MATCH,"differing":$BS_DIFFER,"missing":$BS_MISSING,"errors":$BS_ERROR,"total":$BS_TOTAL,"coverage_pct":$BS_COVERAGE,"verify_pct":$BS_VERIFY_PCT,"health":"$BS_HEALTH"}}
+EOF
+
+bs_log "complete: coverage=${{BS_COVERAGE}}% (matched=$BS_MATCH missing=$BS_MISSING differing=$BS_DIFFER errors=$BS_ERROR) health=$BS_HEALTH"
+
+# A backup that cannot prove coverage is a failed backup. systemd records it,
+# `forjar drift` sees it, and it stops looking like a healthy no-op.
+if [ "$BS_HEALTH" != "verified" ]; then
+  bs_log "FAILED: coverage ${{BS_COVERAGE}}% is below the required ${{BS_VERIFY_PCT}}%"
+  exit 1
+fi
+exit 0
+"#,
+        preflight = preflight::block(cfg),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg() -> BackupSync {
+        BackupSync::new(
+            vec!["/mnt/nvme-raid0/RecordedCourses".into()],
+            "gdrive:lambda-labs-media",
+            "daily",
+            99,
+            700,
+            Some("50M".into()),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn verifies_by_checksum_not_by_exit_code() {
+        let s = script(&cfg(), "/run/x.json", "backup");
+        assert!(s.contains("rclone check"));
+        assert!(s.contains("--checksum"));
+        assert!(s.contains("--combined"));
+        // The sync's own exit status must NOT be the health signal.
+        assert!(s.contains("Never trust the sync's exit code"));
+    }
+
+    #[test]
+    fn counts_files_missing_from_the_remote() {
+        // `-` = present locally, absent remotely. This is the number that was
+        // silently 2.1 TB on lambda-labs.
+        let s = script(&cfg(), "/run/x.json", "backup");
+        assert!(s.contains(r"bs_count '^- '"));
+        assert!(s.contains("BS_MISSING"));
+    }
+
+    #[test]
+    fn zero_examined_files_is_a_failure_not_a_success() {
+        let s = script(&cfg(), "/run/x.json", "backup");
+        assert!(s.contains(r#"[ "$BS_TOTAL" -eq 0 ]"#));
+        assert!(s.contains("broken check, not an empty backup"));
+        // ...and it must reach the nonzero exit.
+        assert!(s.contains("BS_HEALTH=unverified"));
+    }
+
+    #[test]
+    fn zero_matched_files_is_a_failure() {
+        let s = script(&cfg(), "/run/x.json", "backup");
+        assert!(s.contains(r#"[ "$BS_MATCH" -eq 0 ]"#));
+    }
+
+    #[test]
+    fn unverified_coverage_exits_nonzero() {
+        let s = script(&cfg(), "/run/x.json", "backup");
+        assert!(s.contains(r#"[ "$BS_HEALTH" != "verified" ]"#));
+        assert!(s.contains("exit 1"));
+    }
+
+    #[test]
+    fn missing_check_output_counts_as_an_error_not_a_pass() {
+        let s = script(&cfg(), "/run/x.json", "backup");
+        assert!(s.contains("rclone check produced NO output"));
+        assert!(s.contains("bs_e=1"));
+    }
+
+    #[test]
+    fn caps_transfer_under_the_drive_daily_limit() {
+        let s = script(&cfg(), "/run/x.json", "backup");
+        assert!(s.contains("--max-transfer 700G"));
+        assert!(s.contains("--cutoff-mode soft"));
+    }
+
+    #[test]
+    fn applies_bandwidth_limit_when_declared() {
+        assert!(script(&cfg(), "/run/x.json", "backup").contains("--bwlimit '50M'"));
+        let no_bw =
+            BackupSync::new(vec!["/mnt/a".into()], "gdrive:x", "daily", 99, 700, None).unwrap();
+        assert!(!script(&no_bw, "/run/x.json", "backup").contains("--bwlimit"));
+    }
+
+    #[test]
+    fn each_source_lands_under_its_own_leaf() {
+        let c = BackupSync::new(
+            vec!["/mnt/a/media".into(), "/mnt/b/media2".into()],
+            "gdrive:bk",
+            "daily",
+            99,
+            700,
+            None,
+        )
+        .unwrap();
+        let s = script(&c, "/run/x.json", "backup");
+        assert!(s.contains("'gdrive:bk/media'"));
+        assert!(s.contains("'gdrive:bk/media2'"));
+    }
+
+    #[test]
+    fn status_has_no_timestamp_field() {
+        // DET002: no `date` anywhere. The status file's mtime is the heartbeat.
+        let s = script(&cfg(), "/run/x.json", "backup");
+        assert!(!s.contains("date +%s"));
+    }
+
+    #[test]
+    fn counters_never_capture_a_double_line() {
+        // `grep -c` prints "0" and exits 1 on no match; `|| echo 0` appends a
+        // second line and the arithmetic expansion then fails with
+        // "Illegal number", aborting the run before it can report health.
+        let s = script(&cfg(), "/run/x.json", "backup");
+        // Comment-excluded: the rationale comment above the helper necessarily
+        // quotes the very construct it bans, so a whole-string `contains` here
+        // matches the explanation rather than any real code.
+        for line in s.lines().filter(|l| !l.trim_start().starts_with('#')) {
+            assert!(
+                !line.contains("|| echo 0"),
+                "counter must not use a || fallback: {line}"
+            );
+        }
+        assert!(s.contains("bs_count() {"));
+        assert!(s.contains("| head -1"));
+    }
+
+    #[test]
+    fn temp_teardown_is_guarded() {
+        // SEC011: an unset BS_TMP turns the EXIT trap into `rm -rf /`.
+        let s = script(&cfg(), "/run/x.json", "backup");
+        assert!(s.contains(r#"[ -n "${BS_TMP:-}" ] || return 0"#));
+        assert!(s.contains(r#"[ "$BS_TMP" != "/" ] || return 0"#));
+        // No `rm -rf` in the teardown at all: find/rmdir bound the blast radius.
+        // Line-scoped and comment-excluded — the rationale comment names the
+        // very construct it is banning.
+        for line in s.lines().filter(|l| !l.trim_start().starts_with('#')) {
+            assert!(
+                !line.contains("rm -rf"),
+                "teardown must not use rm -rf: {line}"
+            );
+        }
+    }
+
+    #[test]
+    fn log_tag_carries_no_square_brackets() {
+        // SC1140: bashrs parses `[...]` inside a string as a test expression.
+        let s = script(&cfg(), "/run/x.json", "backup");
+        assert!(!s.contains("[backup]"));
+    }
+}

--- a/src/resources/backup_sync/tests.rs
+++ b/src/resources/backup_sync/tests.rs
@@ -1,0 +1,221 @@
+//! FJ-037: backup_sync handler tests.
+
+use super::*;
+use crate::core::types::{BackupSpec, MachineTarget, ResourceType};
+use std::collections::HashMap;
+
+fn res() -> Resource {
+    let mut rc = HashMap::new();
+    rc.insert("scope".to_string(), "drive.file".to_string());
+    Resource {
+        resource_type: ResourceType::BackupSync,
+        machine: MachineTarget::Single("lambda-labs".into()),
+        home: Some("/home/noah".into()),
+        backup: BackupSpec {
+            remote: Some("gdrive:lambda-labs-media".into()),
+            remote_config: rc,
+            token: Some(r#"{"access_token":"x","refresh_token":"y"}"#.into()),
+            source: vec![
+                "/mnt/nvme-raid0/RecordedCourses".into(),
+                "/mnt/nvme-raid0/home-Videos".into(),
+            ],
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+#[test]
+fn defaults_are_documented_values() {
+    let c = backup_of(&res()).unwrap();
+    assert_eq!(c.schedule, "daily");
+    assert_eq!(c.verify_pct, 99);
+    assert_eq!(c.daily_cap_gb, 700);
+}
+
+#[test]
+fn a_local_destination_is_rejected_at_codegen() {
+    // The predecessor's exact shape: DEST=/videos.
+    let r = Resource {
+        backup: BackupSpec {
+            remote: Some("/videos".into()),
+            ..res().backup
+        },
+        ..res()
+    };
+    assert!(backup_of(&r).is_err());
+    let s = apply_script(&r);
+    assert!(s.contains("ERROR"));
+    assert!(s.contains("LOCAL path"));
+}
+
+#[test]
+fn missing_remote_is_rejected() {
+    let r = Resource {
+        backup: BackupSpec {
+            remote: None,
+            ..res().backup
+        },
+        ..res()
+    };
+    assert!(backup_of(&r).is_err());
+    assert!(apply_script(&r).contains("ERROR"));
+}
+
+#[test]
+fn an_empty_source_list_is_rejected() {
+    let r = Resource {
+        backup: BackupSpec {
+            source: vec![],
+            ..res().backup
+        },
+        ..res()
+    };
+    assert!(backup_of(&r).is_err());
+}
+
+#[test]
+fn apply_does_not_run_the_sync() {
+    // §0.2: if the deployer runs the job, it writes the status file that is
+    // supposed to be evidence the SERVICE ran. Arm the timer, nothing more.
+    let s = apply_script(&res());
+    assert!(s.contains("systemctl restart forjar-backup-gdrive-lambda-labs-media.timer"));
+    assert!(
+        !s.contains("\n/usr/local/sbin/forjar-backup-gdrive-lambda-labs-media.sh\n"),
+        "apply must not invoke the sync script"
+    );
+    assert!(s.contains("first pass runs on the timer"));
+}
+
+#[test]
+fn state_query_takes_execution_evidence_from_the_journal() {
+    // A /run/*.json can be written by the deployer; a journal entry cannot.
+    let s = state_query_script(&res());
+    assert!(s.contains("journalctl -u forjar-backup-gdrive-lambda-labs-media.service"));
+    assert!(s.contains("backup_ever_ran="));
+}
+
+#[test]
+fn state_query_publishes_classes_not_raw_counters() {
+    let s = state_query_script(&res());
+    for k in [
+        "backup_health=",
+        "backup_heartbeat=",
+        "backup_timer=",
+        "backup_ever_ran=",
+    ] {
+        assert!(s.contains(k), "missing drift-visible class {k}");
+    }
+    let raw = s.find("backup_coverage_pct=").expect("raw line");
+    assert!(
+        s[raw..].contains(">&2"),
+        "coverage counters must go to stderr, not into the drift hash"
+    );
+}
+
+#[test]
+fn removal_stops_before_it_deletes() {
+    // PMAT-219: deleting a unit file out from under a loaded unit leaves it
+    // Active: failed with "Unit to trigger vanished".
+    let r = Resource {
+        state: Some("absent".into()),
+        ..res()
+    };
+    let s = apply_script(&r);
+    let stop = s.find("systemctl stop").expect("stop");
+    let disable = s.find("systemctl disable").expect("disable");
+    let rm = s.find("rm -f").expect("rm");
+    let reload = s.find("daemon-reload").expect("reload");
+    assert!(stop < disable && disable < rm && rm < reload, "order: {s}");
+    assert!(s.contains("reset-failed"));
+}
+
+#[test]
+fn an_unresolved_secret_template_is_refused() {
+    let r = Resource {
+        backup: BackupSpec {
+            token: Some("{{secrets.rclone-gdrive-token}}".into()),
+            ..res().backup
+        },
+        ..res()
+    };
+    let s = apply_script(&r);
+    assert!(s.contains("ERROR"));
+    assert!(s.contains("unresolved template"));
+    // ...and must never write that literal into a config.
+    assert!(!s.contains("token = {{secrets"));
+}
+
+#[test]
+fn apply_installs_the_rclone_config_forjar_manages() {
+    let s = apply_script(&res());
+    assert!(s.contains("/home/noah/.config/rclone/rclone.conf"));
+    assert!(s.contains("[gdrive]"));
+    assert!(s.contains("type = drive"));
+    assert!(s.contains("scope = drive.file"));
+    assert!(s.contains("umask 077"));
+}
+
+#[test]
+fn artifact_paths_are_namespaced_per_remote() {
+    assert_ne!(script_path("gdrive:a"), script_path("gdrive:b"));
+    assert_ne!(service_path("gdrive:a"), service_path("gdrive:b"));
+    assert_ne!(status_json("gdrive:a"), status_json("gdrive:b"));
+}
+
+#[test]
+fn slug_is_filesystem_safe() {
+    assert_eq!(slug("gdrive:lambda-labs-media"), "gdrive-lambda-labs-media");
+    assert_eq!(slug(":::"), "backup");
+}
+
+#[test]
+fn heartbeat_window_scales_with_cadence() {
+    assert_eq!(stale_secs("daily"), 86400 * 3);
+    assert_eq!(stale_secs("hourly"), 3600 * 3);
+    assert_eq!(stale_secs("weekly"), 604_800 * 3);
+    // Unknown expressions fall back to daily, never to zero.
+    assert_eq!(stale_secs("Mon *-*-* 04:00:00"), 86400 * 3);
+}
+
+#[test]
+fn check_distinguishes_absent_from_unverified() {
+    let s = check_script(&res());
+    assert!(s.contains("'absent'"));
+    assert!(s.contains("'present'"));
+    assert!(s.contains("'unverified'"));
+}
+
+#[test]
+fn every_declared_source_reaches_the_sync() {
+    let s = apply_script(&res());
+    assert!(s.contains("/mnt/nvme-raid0/RecordedCourses"));
+    assert!(s.contains("/mnt/nvme-raid0/home-Videos"));
+    assert!(s.contains("'gdrive:lambda-labs-media/RecordedCourses'"));
+    assert!(s.contains("'gdrive:lambda-labs-media/home-Videos'"));
+}
+
+/// Every emitted script must survive forjar's own I8 purification gate — the
+/// test whose absence let six violations ship in `disk_budget`.
+#[test]
+fn every_emitted_script_passes_the_purifier() {
+    use crate::core::purifier::validate_script;
+    let r = res();
+    for (what, script) in [
+        ("apply", apply_script(&r)),
+        ("check", check_script(&r)),
+        ("state_query", state_query_script(&r)),
+    ] {
+        assert!(
+            validate_script(&script).is_ok(),
+            "{what}_script fails I8 purification, so `forjar apply` rejects this \
+             resource on every machine:\n{:?}",
+            validate_script(&script).unwrap_err()
+        );
+    }
+    let absent = Resource {
+        state: Some("absent".into()),
+        ..r
+    };
+    assert!(validate_script(&apply_script(&absent)).is_ok());
+}

--- a/src/resources/backup_sync/units.rs
+++ b/src/resources/backup_sync/units.rs
@@ -1,0 +1,98 @@
+//! FJ-037: systemd units for the backup sync.
+
+/// Oneshot service running one sync + verify pass.
+///
+/// Deliberately carries neither `SuccessExitStatus` nor `RemainAfterExit`: the
+/// script exits non-zero when it cannot prove coverage, and that has to land in
+/// the unit's state. Masking it would recreate a backup that reports healthy
+/// while protecting nothing, which is the failure this resource exists to end.
+pub(super) fn service_unit(script_path: &str, remote: &str) -> String {
+    format!(
+        "[Unit]\n\
+         Description=forjar verified backup sync to {remote}\n\
+         Documentation=https://github.com/paiml/forjar\n\
+         After=network-online.target\n\
+         Wants=network-online.target\n\
+         \n\
+         [Service]\n\
+         Type=oneshot\n\
+         ExecStart={script_path}\n\
+         # Seeding terabytes is long and never urgent; stay behind real work.\n\
+         Nice=15\n\
+         IOSchedulingClass=idle\n\
+         # A multi-terabyte seed legitimately runs for hours. No timeout would\n\
+         # let a wedged transfer block the timer forever; too short would kill a\n\
+         # healthy seed and never converge.\n\
+         TimeoutStartSec=12h\n\
+         StandardOutput=journal\n\
+         StandardError=journal\n"
+    )
+}
+
+/// Timer driving the sync.
+///
+/// `Persistent=true` so a run missed while the machine was off happens at boot
+/// — the window after downtime is exactly when a backup is most likely stale.
+pub(super) fn timer_unit(schedule: &str, remote: &str) -> String {
+    format!(
+        "[Unit]\n\
+         Description=forjar verified backup sync timer for {remote}\n\
+         \n\
+         [Timer]\n\
+         OnCalendar={schedule}\n\
+         Persistent=true\n\
+         RandomizedDelaySec=900\n\
+         AccuracySec=1min\n\
+         \n\
+         [Install]\n\
+         WantedBy=timers.target\n"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn service_does_not_mask_a_failed_verification() {
+        let s = service_unit("/usr/local/sbin/b.sh", "gdrive:x");
+        assert!(!s.contains("SuccessExitStatus"));
+        assert!(!s.contains("RemainAfterExit"));
+        assert!(s.contains("Type=oneshot"));
+    }
+
+    #[test]
+    fn service_allows_a_multi_terabyte_seed_to_finish() {
+        // 2.1 TB at ~60 MB/s is ~10h of wall clock even before Drive's
+        // 750 GB/day cap splits it across days.
+        assert!(service_unit("/x", "r:").contains("TimeoutStartSec=12h"));
+    }
+
+    #[test]
+    fn service_waits_for_the_network() {
+        let s = service_unit("/x", "r:");
+        assert!(s.contains("After=network-online.target"));
+        assert!(s.contains("Wants=network-online.target"));
+    }
+
+    #[test]
+    fn service_yields_to_real_work() {
+        let s = service_unit("/x", "r:");
+        assert!(s.contains("IOSchedulingClass=idle"));
+        assert!(s.contains("Nice=15"));
+    }
+
+    #[test]
+    fn timer_is_persistent_and_jittered() {
+        let t = timer_unit("daily", "gdrive:x");
+        assert!(t.contains("OnCalendar=daily"));
+        assert!(t.contains("Persistent=true"));
+        assert!(t.contains("RandomizedDelaySec=900"));
+        assert!(t.contains("WantedBy=timers.target"));
+    }
+
+    #[test]
+    fn timer_uses_wall_clock_not_relative() {
+        assert!(!timer_unit("daily", "r:").contains("OnUnitActiveSec"));
+    }
+}

--- a/src/resources/mod.rs
+++ b/src/resources/mod.rs
@@ -5,6 +5,7 @@
 //! 2. An "apply" script that converges to desired state
 //! 3. A "hash" function that computes the BLAKE3 of observable state
 
+pub mod backup_sync;
 pub mod build;
 pub mod cron;
 pub mod disk_budget;

--- a/tests/falsification_backup_sync.rs
+++ b/tests/falsification_backup_sync.rs
@@ -1,0 +1,305 @@
+//! FJ-037: falsification tests for the backup sync.
+//!
+//! These EXECUTE the generated shell with a stubbed `rclone` and assert on the
+//! exit code and the status file. They exist because the failure this resource
+//! replaces was invisible to every test that reads a script instead of running
+//! it: the predecessor's `Backup complete` was emitted by code that was, on
+//! inspection, perfectly reasonable.
+//!
+//! The stub lets a test dictate exactly what `rclone check` reports, so the
+//! interesting cases — zero matches, partial coverage, a crashed check, an
+//! unconfigured remote — are reachable deterministically.
+
+use forjar::core::types::{BackupSpec, MachineTarget, Resource, ResourceType};
+use forjar::resources::backup_sync;
+use std::collections::HashMap;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn tmpdir(tag: &str) -> PathBuf {
+    let p = std::env::temp_dir().join(format!(
+        "forjar-bkp-{tag}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    fs::create_dir_all(&p).unwrap();
+    p
+}
+
+/// How the stubbed `rclone check` should behave.
+struct Stub {
+    /// Remote names `listremotes` reports (empty = remote not configured).
+    remotes: &'static str,
+    /// Lines the `--combined` file receives; `None` = write nothing at all.
+    combined: Option<&'static str>,
+}
+
+fn install_rclone_stub(bin: &Path, stub: &Stub) {
+    fs::create_dir_all(bin).unwrap();
+    let combined = match stub.combined {
+        Some(c) => format!(
+            "    # emit the caller's --combined file\n    \
+             for a in \"$@\"; do\n      \
+             if [ \"$prev\" = \"--combined\" ]; then printf '%b' {c:?} > \"$a\"; fi\n      \
+             prev=\"$a\"\n    done\n"
+        ),
+        None => "    :\n".to_string(),
+    };
+    let script = format!(
+        "#!/bin/sh\n\
+         cmd=\"$1\"; shift\n\
+         prev=\"\"\n\
+         case \"$cmd\" in\n\
+         \x20 listremotes) printf '%b' {remotes:?}; exit 0 ;;\n\
+         \x20 about|lsd)   exit 0 ;;\n\
+         \x20 sync)        exit 0 ;;\n\
+         \x20 check)\n{combined}    exit 0 ;;\n\
+         esac\n\
+         exit 0\n",
+        remotes = stub.remotes,
+    );
+    let p = bin.join("rclone");
+    fs::write(&p, script).unwrap();
+    fs::set_permissions(&p, fs::Permissions::from_mode(0o755)).unwrap();
+}
+
+fn resource(root: &Path, src: &Path) -> Resource {
+    Resource {
+        resource_type: ResourceType::BackupSync,
+        machine: MachineTarget::Single("test".into()),
+        home: Some(root.to_string_lossy().into_owned()),
+        backup: BackupSpec {
+            remote: Some("gdrive:media".into()),
+            remote_config: HashMap::new(),
+            source: vec![src.to_string_lossy().into_owned()],
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+/// Pull the sync body out of apply's heredoc.
+fn sync_body(r: &Resource) -> String {
+    const OPEN: &str = "<<'FORJAR_BACKUP_EOF'\n";
+    const CLOSE: &str = "\nFORJAR_BACKUP_EOF";
+    let apply = backup_sync::apply_script(r);
+    let s = apply.find(OPEN).expect("sync heredoc open") + OPEN.len();
+    let e = apply[s..].find(CLOSE).expect("sync heredoc close") + s;
+    apply[s..e].to_string()
+}
+
+struct Run {
+    code: i32,
+    out: String,
+    status: String,
+}
+
+fn run(r: &Resource, root: &Path, bin: &Path) -> Run {
+    let script = root.join("sync.sh");
+    fs::write(&script, sync_body(r)).unwrap();
+    fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).unwrap();
+    let status = root.join("status.json");
+    let out = Command::new("/bin/sh")
+        .arg(&script)
+        .env(
+            "PATH",
+            format!(
+                "{}:{}",
+                bin.display(),
+                std::env::var("PATH").unwrap_or_default()
+            ),
+        )
+        .env("FORJAR_BACKUP_STATUS", &status)
+        .output()
+        .expect("run sync");
+    Run {
+        code: out.status.code().unwrap_or(-1),
+        out: String::from_utf8_lossy(&out.stdout).into_owned(),
+        status: fs::read_to_string(&status).unwrap_or_default(),
+    }
+}
+
+fn setup(tag: &str, stub: &Stub) -> (PathBuf, PathBuf, PathBuf) {
+    let root = tmpdir(tag);
+    let bin = root.join("bin");
+    let src = root.join("media");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(src.join("a.mp4"), b"aaaa").unwrap();
+    install_rclone_stub(&bin, stub);
+    (root, bin, src)
+}
+
+#[test]
+fn a_fully_matched_backup_is_verified_and_exits_zero() {
+    let (root, bin, src) = setup(
+        "ok",
+        &Stub {
+            remotes: "gdrive:\n",
+            combined: Some("= a.mp4\n= b.mp4\n"),
+        },
+    );
+    let r = run(&resource(&root, &src), &root, &bin);
+    assert_eq!(r.code, 0, "verified backup must exit 0\n{}", r.out);
+    assert!(r.status.contains(r#""health":"verified""#), "{}", r.status);
+    assert!(r.status.contains(r#""coverage_pct":100"#), "{}", r.status);
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn zero_matched_files_fails_even_though_rclone_exited_zero() {
+    // THE regression. Every rclone invocation succeeds; nothing is in the
+    // remote. The predecessor printed "Backup complete" here.
+    let (root, bin, src) = setup(
+        "nomatch",
+        &Stub {
+            remotes: "gdrive:\n",
+            combined: Some("- a.mp4\n- b.mp4\n- c.mp4\n"),
+        },
+    );
+    let r = run(&resource(&root, &src), &root, &bin);
+    assert_eq!(
+        r.code, 1,
+        "a backup holding nothing must FAIL\n{}\n{}",
+        r.out, r.status
+    );
+    assert!(
+        r.status.contains(r#""health":"unverified""#),
+        "{}",
+        r.status
+    );
+    assert!(r.status.contains(r#""missing":3"#), "{}", r.status);
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn an_empty_verification_is_a_broken_check_not_an_empty_backup() {
+    // rclone check writes an empty --combined file: 0 files examined.
+    let (root, bin, src) = setup(
+        "empty",
+        &Stub {
+            remotes: "gdrive:\n",
+            combined: Some(""),
+        },
+    );
+    let r = run(&resource(&root, &src), &root, &bin);
+    assert_eq!(r.code, 1, "0 examined files must fail\n{}", r.out);
+    assert!(
+        r.out.contains("broken check, not an empty backup"),
+        "{}",
+        r.out
+    );
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn a_crashed_check_that_writes_nothing_counts_as_an_error() {
+    let (root, bin, src) = setup(
+        "nofile",
+        &Stub {
+            remotes: "gdrive:\n",
+            combined: None,
+        },
+    );
+    let r = run(&resource(&root, &src), &root, &bin);
+    assert_eq!(
+        r.code, 1,
+        "a check producing no output must fail\n{}",
+        r.out
+    );
+    assert!(r.out.contains("produced NO output"), "{}", r.out);
+    assert!(r.status.contains(r#""errors":1"#), "{}", r.status);
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn coverage_below_the_threshold_fails() {
+    // 2 of 4 = 50%, well under the default 99%.
+    let (root, bin, src) = setup(
+        "partial",
+        &Stub {
+            remotes: "gdrive:\n",
+            combined: Some("= a.mp4\n= b.mp4\n- c.mp4\n* d.mp4\n"),
+        },
+    );
+    let r = run(&resource(&root, &src), &root, &bin);
+    assert_eq!(r.code, 1, "partial coverage must fail\n{}", r.out);
+    assert!(r.status.contains(r#""health":"partial""#), "{}", r.status);
+    assert!(r.status.contains(r#""coverage_pct":50"#), "{}", r.status);
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn an_unconfigured_remote_stops_the_run_before_any_sync() {
+    // `listremotes` reports nothing. rclone would otherwise treat `gdrive:media`
+    // as a LOCAL path — the mechanism behind the self-referential predecessor.
+    let (root, bin, src) = setup(
+        "noremote",
+        &Stub {
+            remotes: "",
+            combined: Some("= a.mp4\n"),
+        },
+    );
+    let r = run(&resource(&root, &src), &root, &bin);
+    assert_eq!(r.code, 1, "unconfigured remote must abort\n{}", r.out);
+    assert!(r.out.contains("is not configured"), "{}", r.out);
+    // ...and it must abort BEFORE claiming to have synced anything.
+    assert!(!r.out.contains("sync media: starting"), "{}", r.out);
+    assert!(
+        r.status.is_empty(),
+        "no status may be written: {}",
+        r.status
+    );
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn a_missing_source_stops_the_run() {
+    let (root, bin, src) = setup(
+        "nosrc",
+        &Stub {
+            remotes: "gdrive:\n",
+            combined: Some("= a.mp4\n"),
+        },
+    );
+    fs::remove_dir_all(&src).unwrap();
+    let r = run(&resource(&root, &src), &root, &bin);
+    assert_eq!(r.code, 1, "missing source must abort\n{}", r.out);
+    assert!(r.out.contains("does not exist"), "{}", r.out);
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn a_missing_rclone_binary_stops_the_run() {
+    let root = tmpdir("norclone");
+    let bin = root.join("bin");
+    fs::create_dir_all(&bin).unwrap();
+    let src = root.join("media");
+    fs::create_dir_all(&src).unwrap();
+    // No rclone stub installed. PATH keeps the system entries so `mktemp` and
+    // friends still resolve — emptying it would abort on mktemp before the
+    // preflight could speak, testing the wrong thing.
+    let script = root.join("sync.sh");
+    fs::write(&script, sync_body(&resource(&root, &src))).unwrap();
+    fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).unwrap();
+    let out = Command::new("/bin/sh")
+        .arg(&script)
+        .env(
+            "PATH",
+            format!(
+                "{}:{}",
+                bin.display(),
+                std::env::var("PATH").unwrap_or_default()
+            ),
+        )
+        .env("FORJAR_BACKUP_STATUS", root.join("status.json"))
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&out.stdout).contains("rclone is not installed"));
+    fs::remove_dir_all(&root).ok();
+}


### PR DESCRIPTION
> Stacked on [#231](https://github.com/paiml/forjar/pull/231) (`disk_budget`, 19 pass / 1 skip, green). Base will retarget to `main` once that merges.

## Why

Measured on lambda-labs, 2026-08-15:

```
/videos -> /mnt/nvme-raid0/videos          SOURCE == DEST, byte-for-byte
md0 : active raid0 nvme1n1 nvme2n1 nvme3n1 nvme4n1   ← no parity
rclone / gdrive / insync / gcsfuse         none installed
bytes in any durability tier               0
```

**~2.1 TB of irreplaceable media** (RecordedCourses 1.6T, home-Videos 134G, long-form-videos 236G, coursera assets 168G, mac-backup 34G) on a 4-wide RAID0, with **zero bytes anywhere off that array** — while an hourly job had reported `Backup complete` for months, deployed, enabled, exiting 0 the entire time.

Three defects, each now unrepresentable:

| | defect | fix |
|---|---|---|
| **D1** | destination was **local** — `/videos` symlinked back to its own source, so rsync copied a directory onto itself | `backup_remote` rejected unless it's an rclone `remote:path`; preflight proves the remote is *configured* and answers, because an unconfigured rclone remote silently degrades to a local path |
| **D2** | the metric **could not fail** — `find "$DEST"` doesn't descend a symlink without `-L`, so it printed `Files: 0` while 77 matching files sat in that directory. Structurally 0 on *every* input | health is a count of files verified present **by checksum** (`rclone check --combined`); zero examined or zero matched is a failure |
| **D3** | coverage compared to **nothing** — it covered a 16 GB directory, 0.12% of the array | coverage is a % of source files proven present; below threshold the run exits non-zero |

## Design

**`apply` deliberately does not run the sync** — the opposite of `disk_budget`, and for a reason worth stating: seeding terabytes takes days under Drive's ~750 GB/day/account cap, and more importantly *a deployer that runs the job also writes the status file that is supposed to be evidence the service ran*. `apply` arms the timer; `state_query` reads the **journal**, which the deployer cannot forge.

**forjar owns `rclone.conf`.** Leaving the remote definition as a manual step reintroduces exactly D1. Configuration (backend, scope, folder id) lives in the repo, reviewable and drift-checked; the OAuth refresh token arrives as `{{secrets.NAME}}` through the secrets provider. A literal token is refused at parse time, an unresolved template at codegen, and the file is written under `umask 077` at 0600 with an atomic rename.

**Teardown stops and disables before deleting unit files** (PMAT-219).

## Tests

The 8 falsification tests **execute** the generated shell against a stubbed `rclone`, and immediately paid for themselves:

> the counters used `grep -c ... || echo 0` — but `grep -c` **prints a count and still exits 1** when that count is zero, so the substitution captured two lines and every real run would have died on `Illegal number` *before it could report health*. Same shape as `systemctl is-failed`. No amount of reading the script finds that.

Covered: fully-matched → exit 0 verified; zero-matched → exit 1 despite every rclone call succeeding; empty verification → "broken check, not an empty backup"; crashed check writing nothing → error; 50% coverage → exit 1 partial; unconfigured remote → aborts before any sync and writes no status; missing source; missing rclone.

- 63 unit + 8 executing falsification tests
- full suite 170 binaries, 0 failures; clippy `-D warnings` clean
- `every_emitted_script_passes_the_purifier` — the test whose absence let six I8 violations ship in `disk_budget`; it caught an unguarded `rm -rf` in the teardown trap here before deploy

## Contract

`contracts/backup-sync-v1.yaml` — pv-valid, 12 proof obligations, 13 falsification tests, 3 Kani harnesses. Quorum-validated against ZFS send/recv verification, restic/borg `check` semantics ("assume broken until proven otherwise; zero objects examined is an error"), and dead-man's-switch alerting.

## Not in this PR

The array's own alerting (`mdmonitor` inactive, no `MAILADDR`, smartd mailing `root` on a host with no MTA) is D4 and stays on PMAT-216. This PR gives the media a verified offsite copy; that one gives the array a voice.

Refs PMAT-216

🤖 Generated with [Claude Code](https://claude.com/claude-code)