### PR TITLE
fix(backup_sync): rclone --combined characters were backwards — coverage was inflated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.13.1] - 2026-08-15
+
+### Fixed
+
+- **`backup_sync` read rclone's `--combined` status characters backwards, and
+  the error inflated coverage.** They are not the intuitive way round:
+
+  ```
+  + path   missing on the DESTINATION  -> present locally, NOT backed up
+  - path   missing on the SOURCE       -> only in the remote (stale)
+  ```
+
+  1.13.0 counted `-` as "missing from the remote". Files that were genuinely
+  not backed up produce `+`, which nothing counted — so they fell out of the
+  coverage denominator entirely and a backup **missing data reported higher
+  coverage than one that had all of it**. That is the precise class of
+  overstated-health failure the resource exists to prevent, shipped inside it.
+
+  `+` now feeds the missing count. `-` is tracked separately as
+  `stale_in_remote` and deliberately excluded from the denominator: a file
+  present only in the remote means the local copy was deleted, not that
+  anything is unprotected, and counting it would make every local deletion read
+  as a backup fault until the next sync.
+
+  Caught by running `rclone check --combined` against a real fixture rather
+  than trusting the flag's name. The regression test now asserts the mapping
+  explicitly, and the falsification stub emits rclone's real characters.
+
+- **`a_missing_rclone_binary_stops_the_run` was host-dependent.** It relied on
+  rclone not being installed on the machine running the tests, and broke the
+  moment rclone was deployed. It now builds a hermetic PATH containing only the
+  utilities the preflight needs.
+
+
 ## [1.13.0] - 2026-08-15
 
 Two new resource types, both born from the same failure mode on one machine:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1117,7 +1117,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "forjar"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "age",
  "aprender-contracts",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forjar"
-version = "1.13.0"
+version = "1.13.1"
 edition.workspace = true
 rust-version = "1.89.0"
 authors = ["Pragmatic AI Labs"]

--- a/contracts/backup-sync-v1.yaml
+++ b/contracts/backup-sync-v1.yaml
@@ -72,14 +72,16 @@ equations:
 
   coverage_is_checksum_verified:
     formula: |
-      coverage = |{f : hash_local(f) = hash_remote(f)}| / |files(sources)| × 100
+      coverage = |{= }| / (|{= }| + |{* }| + |{+ }| + |{! }|) × 100
+                 (|{- }| — only-in-remote — is excluded from the denominator)
     domain: "sources ∈ [Path], remote ∈ rclone remote"
     codomain: "0..=100"
     invariants:
       - "Health is a count of files proven present in the remote BY CHECKSUM"
       - "The sync tool's exit code is NEVER the health signal (rsync exits 0 copying a directory onto itself)"
-      - "`rclone check --combined` status characters are counted: `=` matched, `*` differing, `-` MISSING from remote, `!` error"
-      - "`-` is the number that was silently 2.1 TB"
+      - "`rclone check --combined` characters, verified against rclone v1.75.0 --help and an executed fixture: `=` identical, `*` differing, `+` missing on the DESTINATION (present locally, NOT backed up), `-` missing on the SOURCE (only in the remote), `!` error"
+      - "`+` is the number that was silently 2.1 TB — NOT `-`. Reading them backwards drops un-backed-up files out of the denominator, so a backup missing data reports HIGHER coverage than one that has it all"
+      - "Files only in the remote (`-`) are stale, not unprotected; they are reported but never counted against coverage, or every local deletion would read as a backup fault"
 
   empty_verification_fails_closed:
     formula: |
@@ -277,6 +279,12 @@ falsification_tests:
     prediction: "nested sources are rejected because they double-count coverage"
     test: "src/core/types/backup_sync_types.rs::tests::rejects_overlapping_sources"
     if_fails: "verify_pct is computed over a multiset and can exceed real coverage"
+
+  - id: FALSIFY-BKP-014
+    rule: "stale remote files do not affect coverage"
+    prediction: "a `-` line (only in remote) leaves a fully-covered backup at 100% and exit 0"
+    test: "tests/falsification_backup_sync.rs::files_only_in_the_remote_are_stale_and_do_not_fail_the_backup"
+    if_fails: "Every local deletion reads as a backup failure until the next sync"
 
   - id: FALSIFY-BKP-013
     rule: "emitted scripts are purifiable"

--- a/src/resources/backup_sync/sync.rs
+++ b/src/resources/backup_sync/sync.rs
@@ -10,8 +10,17 @@
 //! with a status character, so coverage is a count of files the remote
 //! actually holds with a matching hash — not a log line saying "complete".
 //!
-//! `-` means present locally and MISSING from the remote. That is the number
-//! that was silently 2.1 TB.
+//! Verified against `rclone check --help` on v1.75.0 — the characters are NOT
+//! the intuitive way round, and getting them backwards inflates coverage:
+//!
+//!   `=` in both, identical          `*` in both, different
+//!   `+` missing on the DESTINATION  -> present locally, NOT backed up
+//!   `-` missing on the SOURCE       -> only in the remote (stale/extra)
+//!   `!` error reading or hashing
+//!
+//! `+` is the number that was silently 2.1 TB. Counting `-` instead would leave
+//! un-backed-up files out of the denominator entirely, so a backup missing data
+//! would report BETTER coverage than one that had it all.
 
 use super::preflight;
 use crate::core::shell_escape::sh_squote;
@@ -52,17 +61,22 @@ rclone check {src_q} {dest_q} --checksum --combined "$BS_TMP/check-{leaf}" >/dev
 if [ -f "$BS_TMP/check-{leaf}" ]; then
   bs_m=$(bs_count '^= ' "$BS_TMP/check-{leaf}")
   bs_x=$(bs_count '^\* ' "$BS_TMP/check-{leaf}")
-  bs_o=$(bs_count '^- ' "$BS_TMP/check-{leaf}")
+  # `+` = missing on the destination = present locally and NOT in the remote.
+  bs_o=$(bs_count '^+ ' "$BS_TMP/check-{leaf}")
+  # `-` = missing on the source = only in the remote. Stale, not unprotected,
+  # so it is reported but never counted against coverage.
+  bs_s=$(bs_count '^- ' "$BS_TMP/check-{leaf}")
   bs_e=$(bs_count '^! ' "$BS_TMP/check-{leaf}")
 else
-  bs_m=0; bs_x=0; bs_o=0; bs_e=1
+  bs_m=0; bs_x=0; bs_o=0; bs_s=0; bs_e=1
   bs_log "verify {leaf}: rclone check produced NO output - treating as unverified"
 fi
 BS_MATCH=$((BS_MATCH + bs_m))
 BS_DIFFER=$((BS_DIFFER + bs_x))
 BS_MISSING=$((BS_MISSING + bs_o))
 BS_ERROR=$((BS_ERROR + bs_e))
-bs_log "verify {leaf_q}: matched=$bs_m differing=$bs_x missing=$bs_o errors=$bs_e"
+BS_STALE=$((BS_STALE + bs_s))
+bs_log "verify {leaf_q}: matched=$bs_m differing=$bs_x missing=$bs_o stale=$bs_s errors=$bs_e"
 "#
     )
 }
@@ -106,6 +120,7 @@ trap bs_cleanup EXIT INT TERM
 BS_MATCH=0
 BS_DIFFER=0
 BS_MISSING=0
+BS_STALE=0
 BS_ERROR=0
 BS_VERIFY_PCT={verify_pct}
 
@@ -149,10 +164,10 @@ else
 fi
 
 cat > "$BS_STATUS" <<EOF
-{{"remote":"{remote}","matched":$BS_MATCH,"differing":$BS_DIFFER,"missing":$BS_MISSING,"errors":$BS_ERROR,"total":$BS_TOTAL,"coverage_pct":$BS_COVERAGE,"verify_pct":$BS_VERIFY_PCT,"health":"$BS_HEALTH"}}
+{{"remote":"{remote}","matched":$BS_MATCH,"differing":$BS_DIFFER,"missing":$BS_MISSING,"stale_in_remote":$BS_STALE,"errors":$BS_ERROR,"total":$BS_TOTAL,"coverage_pct":$BS_COVERAGE,"verify_pct":$BS_VERIFY_PCT,"health":"$BS_HEALTH"}}
 EOF
 
-bs_log "complete: coverage=${{BS_COVERAGE}}% (matched=$BS_MATCH missing=$BS_MISSING differing=$BS_DIFFER errors=$BS_ERROR) health=$BS_HEALTH"
+bs_log "complete: coverage=${{BS_COVERAGE}}% (matched=$BS_MATCH missing=$BS_MISSING differing=$BS_DIFFER stale=$BS_STALE errors=$BS_ERROR) health=$BS_HEALTH"
 
 # A backup that cannot prove coverage is a failed backup. systemd records it,
 # `forjar drift` sees it, and it stops looking like a healthy no-op.
@@ -194,11 +209,38 @@ mod tests {
 
     #[test]
     fn counts_files_missing_from_the_remote() {
-        // `-` = present locally, absent remotely. This is the number that was
-        // silently 2.1 TB on lambda-labs.
+        // Verified against `rclone check --help` v1.75.0: `+` means missing on
+        // the DESTINATION, i.e. present locally and not backed up. `-` means
+        // missing on the SOURCE, i.e. only in the remote.
+        //
+        // These are easy to get backwards, and backwards is not a harmless
+        // mislabel: un-backed-up files would leave the denominator entirely and
+        // coverage would read HIGHER for a backup that is missing data.
         let s = script(&cfg(), "/run/x.json", "backup");
-        assert!(s.contains(r"bs_count '^- '"));
+        assert!(
+            s.contains(r"bs_o=$(bs_count '^+ '"),
+            "missing-from-remote must count `+`, not `-`"
+        );
+        assert!(
+            s.contains(r"bs_s=$(bs_count '^- '"),
+            "`-` is only-in-remote and must be tracked separately as stale"
+        );
         assert!(s.contains("BS_MISSING"));
+        assert!(s.contains("BS_STALE"));
+    }
+
+    #[test]
+    fn stale_remote_files_do_not_inflate_or_deflate_coverage() {
+        // Files present only in the remote are stale, not unprotected. They are
+        // reported for operator visibility but must not enter the coverage
+        // denominator, or deleting a local file would look like a backup fault.
+        let s = script(&cfg(), "/run/x.json", "backup");
+        assert!(s.contains("BS_TOTAL=$((BS_MATCH + BS_DIFFER + BS_MISSING + BS_ERROR))"));
+        assert!(
+            !s.contains("BS_STALE))"),
+            "stale count must stay out of BS_TOTAL"
+        );
+        assert!(s.contains(r#""stale_in_remote":$BS_STALE"#));
     }
 
     #[test]

--- a/tests/falsification_backup_sync.rs
+++ b/tests/falsification_backup_sync.rs
@@ -154,11 +154,15 @@ fn a_fully_matched_backup_is_verified_and_exits_zero() {
 fn zero_matched_files_fails_even_though_rclone_exited_zero() {
     // THE regression. Every rclone invocation succeeds; nothing is in the
     // remote. The predecessor printed "Backup complete" here.
+    //
+    // `+` is rclone's character for "missing on the destination" — i.e. present
+    // locally and NOT backed up. Using `-` here (only-in-remote) would make
+    // this test pass against an implementation that cannot see a missing file.
     let (root, bin, src) = setup(
         "nomatch",
         &Stub {
             remotes: "gdrive:\n",
-            combined: Some("- a.mp4\n- b.mp4\n- c.mp4\n"),
+            combined: Some("+ a.mp4\n+ b.mp4\n+ c.mp4\n"),
         },
     );
     let r = run(&resource(&root, &src), &root, &bin);
@@ -223,7 +227,7 @@ fn coverage_below_the_threshold_fails() {
         "partial",
         &Stub {
             remotes: "gdrive:\n",
-            combined: Some("= a.mp4\n= b.mp4\n- c.mp4\n* d.mp4\n"),
+            combined: Some("= a.mp4\n= b.mp4\n+ c.mp4\n* d.mp4\n"),
         },
     );
     let r = run(&resource(&root, &src), &root, &bin);
@@ -280,26 +284,61 @@ fn a_missing_rclone_binary_stops_the_run() {
     fs::create_dir_all(&bin).unwrap();
     let src = root.join("media");
     fs::create_dir_all(&src).unwrap();
-    // No rclone stub installed. PATH keeps the system entries so `mktemp` and
-    // friends still resolve — emptying it would abort on mktemp before the
-    // preflight could speak, testing the wrong thing.
+
+    // Hermetic PATH: symlink in exactly the utilities the preflight needs and
+    // nothing else. Relying on "rclone happens not to be installed on this
+    // host" is not a test — it broke the moment rclone was deployed here.
+    for tool in [
+        "sh", "mktemp", "grep", "find", "rmdir", "head", "awk", "sed", "cat", "du", "stat",
+    ] {
+        for dir in ["/usr/bin", "/bin", "/usr/local/bin"] {
+            let p = Path::new(dir).join(tool);
+            if p.exists() {
+                let _ = std::os::unix::fs::symlink(&p, bin.join(tool));
+                break;
+            }
+        }
+    }
+    assert!(
+        !bin.join("rclone").exists(),
+        "the hermetic bin must not contain rclone"
+    );
+
     let script = root.join("sync.sh");
     fs::write(&script, sync_body(&resource(&root, &src))).unwrap();
     fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).unwrap();
     let out = Command::new("/bin/sh")
         .arg(&script)
-        .env(
-            "PATH",
-            format!(
-                "{}:{}",
-                bin.display(),
-                std::env::var("PATH").unwrap_or_default()
-            ),
-        )
+        .env("PATH", bin.display().to_string())
         .env("FORJAR_BACKUP_STATUS", root.join("status.json"))
         .output()
         .unwrap();
     assert_eq!(out.status.code(), Some(1));
     assert!(String::from_utf8_lossy(&out.stdout).contains("rclone is not installed"));
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn files_only_in_the_remote_are_stale_and_do_not_fail_the_backup() {
+    // `-` = missing on the source = present only in the remote. That means the
+    // local file was deleted, not that anything is unprotected. It must be
+    // reported but must not drag coverage below threshold, or every legitimate
+    // local deletion would show up as a backup failure until the next sync.
+    let (root, bin, src) = setup(
+        "stale",
+        &Stub {
+            remotes: "gdrive:\n",
+            combined: Some("= a.mp4\n= b.mp4\n- old.mp4\n"),
+        },
+    );
+    let r = run(&resource(&root, &src), &root, &bin);
+    assert_eq!(
+        r.code, 0,
+        "stale remote files must not fail a fully-covered backup\n{}\n{}",
+        r.out, r.status
+    );
+    assert!(r.status.contains(r#""health":"verified""#), "{}", r.status);
+    assert!(r.status.contains(r#""coverage_pct":100"#), "{}", r.status);
+    assert!(r.status.contains(r#""stale_in_remote":1"#), "{}", r.status);
     fs::remove_dir_all(&root).ok();
 }


### PR DESCRIPTION
## The bug

`rclone check --combined` status characters are not the intuitive way round:

```
+ path   missing on the DESTINATION  -> present locally, NOT backed up
- path   missing on the SOURCE       -> only in the remote (stale)
```

1.13.0 counted `-` as "missing from the remote". Files that are genuinely **not backed up** produce `+`, which nothing counted — so they dropped out of the coverage denominator entirely, and **a backup missing data reported *higher* coverage than one that had all of it.**

That is precisely the overstated-health failure `backup_sync` was built to make impossible, shipped inside `backup_sync`.

## The fix

- `+` feeds `missing` — the count that was silently 2.1 TB on lambda-labs
- `-` becomes `stale_in_remote`: reported for operators, **excluded from the denominator**. A file only in the remote means the local copy was deleted, not that anything is unprotected; counting it would make every ordinary local deletion read as a backup fault until the next sync.

```
coverage = |=| / (|=| + |*| + |+| + |!|) × 100
```

## How it was found

By running the real tool against a four-case fixture instead of trusting the flag names:

```
$ rclone check src dst --checksum --combined out.txt   # rclone v1.75.0
+ onlylocal.txt      present locally, not in remote
- onlyremote.txt     only in remote
* diff.txt           differs
= both.txt           identical
```

Worth noting the earlier tests could not have caught this: the falsification stub emitted whatever characters I believed in, so it faithfully confirmed my own misreading. It now emits rclone's real characters, and a new test asserts the mapping explicitly with the reason getting it backwards is not a harmless mislabel.

## Also

`a_missing_rclone_binary_stops_the_run` depended on rclone being absent from the host machine and broke the moment rclone was deployed there. It now builds a hermetic PATH containing only the utilities preflight needs, so it tests the code rather than the environment.

## Verification

- 64 unit + 9 falsification tests green; full suite 170 binaries, 0 failures
- clippy `-D warnings` clean, contract re-validated with `pv`
- new falsification test `files_only_in_the_remote_are_stale_and_do_not_fail_the_backup`

Releases as **1.13.1**. 1.13.0 is on crates.io with the inverted mapping; `backup_sync` is new in that release and not yet deployed anywhere, but its coverage figure there is not trustworthy.

Refs #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)