### PR TITLE
fix: five contracts had never passed pv validate

### DIFF
--- a/contracts/apply-summary-distinguishability-v1.yaml
+++ b/contracts/apply-summary-distinguishability-v1.yaml
@@ -65,7 +65,7 @@ proof_obligations:
     applies_to: all
     enforced_by: "src/cli/apply_output.rs::print_apply_summary"
 
-  - type: test
+  - type: classification
     property: "All four step shapes from issue #129 hold (Q1 semantics)"
     formal: |
       apply(fresh)            → converged=N, forced=0

--- a/contracts/destroy-undo-roundtrip-v1.yaml
+++ b/contracts/destroy-undo-roundtrip-v1.yaml
@@ -63,7 +63,7 @@ proof_obligations:
     applies_to: all
     enforced_by: "src/cli/generation.rs::rollback_to_generation debug_assert_eq!"
 
-  - type: test
+  - type: roundtrip
     property: "Roundtrip restores the snapshot byte-for-byte"
     formal: "snapshot(S → g); mutate(S); rollback(g) ⟹ locks(state_dir) = locks(S)"
     applies_to: all

--- a/contracts/idempotent-apply-v1.yaml
+++ b/contracts/idempotent-apply-v1.yaml
@@ -64,7 +64,7 @@ proof_obligations:
     applies_to: all
     enforced_by: "src/core/planner/mod.rs::plan debug_assert_eq!"
 
-  - type: test
+  - type: idempotency
     property: "Second plan over converged locks is all-NoOp (f(f(x)) = f(x))"
     formal: "locks = converged(c) ⟹ plan(c, locks).{to_create, to_update, to_destroy} = 0"
     applies_to: all

--- a/contracts/plan-apply-equivalence-v1.yaml
+++ b/contracts/plan-apply-equivalence-v1.yaml
@@ -56,7 +56,7 @@ proof_obligations:
     applies_to: all
     enforced_by: "src/core/executor/machine.rs::apply_machine debug_assert!"
 
-  - type: test
+  - type: equivalence
     property: "Apply outcome counts match the plan's prediction"
     formal: |
       apply(fresh)     → converged = to_create + to_update ∧ unchanged = plan.unchanged

--- a/contracts/provable-iac-v1.yaml
+++ b/contracts/provable-iac-v1.yaml
@@ -38,7 +38,7 @@ proof_obligations:
     property: "Acyclicity is a config-transferable theorem"
     formal: "acyclic(R,E) => a topological apply order of length |R| exists"
     applies_to: I1
-  - type: honesty
+  - type: soundness
     property: "No vacuous green"
     formal: "exists opaque r in R => state(I3) in {Unknown} (never Proved/Checked as if total)"
     applies_to: I3

--- a/tests/falsification_contracts_parse.rs
+++ b/tests/falsification_contracts_parse.rs
@@ -1,0 +1,192 @@
+//! GH-251: every contract must actually be checkable.
+//!
+//! Six of them were not. `pv validate` failed on
+//! `apply-summary-distinguishability-v1`, `destroy-undo-roundtrip-v1`,
+//! `idempotent-apply-v1`, `plan-apply-equivalence-v1` and `provable-iac-v1`
+//! because their `proof_obligations[].type` used `test` and `honesty`, which
+//! are not in the schema's vocabulary. Those files had therefore **never**
+//! passed validation, and nothing noticed, because nothing ran it.
+//!
+//! That matters beyond tidiness. `apply-summary-distinguishability-v1` is the
+//! planned-vs-actual contract cited as the correct precedent in GH-249, and
+//! `provable-iac-v1` backs `forjar prove`'s structural invariants — its results
+//! are mapped straight into the `N/N proofs passed` line a user acts on. Both
+//! read as authority while being checked by nothing.
+//!
+//! This is the same failure shape as GH-242 one level down: proofs cited by
+//! name as evidence that no CI job ran, and which had stopped compiling.
+//!
+//! Implemented against the YAML directly rather than by shelling out to `pv`,
+//! deliberately. A test that needs an external tool installed is a test that
+//! silently stops running when the tool is missing — which is precisely how the
+//! contracts went unvalidated in the first place, and how the kani/lean gate in
+//! GH-242 currently reports red.
+
+use std::path::{Path, PathBuf};
+
+/// The proof-obligation vocabulary the contract schema accepts.
+///
+/// Copied from the validator's own error message rather than invented. If the
+/// schema gains a variant this list must grow with it — and until then, a
+/// contract using an unknown one does not validate, which is the whole point.
+const KNOWN_OBLIGATION_TYPES: &[&str] = &[
+    "invariant",
+    "equivalence",
+    "bound",
+    "monotonicity",
+    "idempotency",
+    "linearity",
+    "symmetry",
+    "associativity",
+    "conservation",
+    "ordering",
+    "completeness",
+    "soundness",
+    "involution",
+    "determinism",
+    "roundtrip",
+    "state_machine",
+    "classification",
+    "independence",
+    "termination",
+    "safety",
+    "liveness",
+    "precondition",
+    "postcondition",
+    "frame",
+    "loop_invariant",
+    "loop_variant",
+    "old_state",
+    "subcontract",
+];
+
+/// Files under `contracts/` that are deliberately NOT contracts.
+///
+/// `binding.yaml` is a binding REGISTRY — it maps contract equations to the
+/// Rust items implementing them (`contract_coverage.rs` reads it). Validating
+/// it as a contract is a category error, not a defect in the file, and its
+/// "missing field `metadata`" failure is that category error reporting itself.
+const NOT_CONTRACTS: &[&str] = &["binding.yaml"];
+
+fn contracts_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("contracts")
+}
+
+fn contract_files() -> Vec<PathBuf> {
+    let mut files: Vec<PathBuf> = std::fs::read_dir(contracts_dir())
+        .expect("contracts/ must exist")
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .filter(|p| p.extension().is_some_and(|x| x == "yaml"))
+        .filter(|p| {
+            let name = p
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .to_string();
+            !NOT_CONTRACTS.contains(&name.as_str())
+        })
+        .collect();
+    files.sort();
+    files
+}
+
+#[test]
+fn there_are_contracts_to_check() {
+    // Guards the guard. A glob that silently matches nothing would make every
+    // test below pass by checking zero files — the vacuous-green shape that
+    // `provable-iac-v1` itself has an obligation about.
+    let files = contract_files();
+    assert!(
+        files.len() >= 20,
+        "expected the full contract set, found {}: {:?}",
+        files.len(),
+        files
+    );
+}
+
+#[test]
+fn every_contract_parses_as_yaml() {
+    for path in contract_files() {
+        let text = std::fs::read_to_string(&path).expect("readable");
+        let parsed: Result<serde_yaml_ng::Value, _> = serde_yaml_ng::from_str(&text);
+        assert!(
+            parsed.is_ok(),
+            "{} is not parseable YAML: {}",
+            path.display(),
+            parsed.unwrap_err()
+        );
+    }
+}
+
+#[test]
+fn every_proof_obligation_uses_a_known_type() {
+    // The GH-251 regression itself. `type: test` and `type: honesty` are not in
+    // the schema, so five contracts failed to parse and had never been checked.
+    let mut offenders = Vec::new();
+
+    for path in contract_files() {
+        let text = std::fs::read_to_string(&path).expect("readable");
+        let doc: serde_yaml_ng::Value = match serde_yaml_ng::from_str(&text) {
+            Ok(d) => d,
+            Err(_) => continue, // reported by the parse test above
+        };
+        let Some(obligations) = doc.get("proof_obligations").and_then(|v| v.as_sequence()) else {
+            continue;
+        };
+        for (i, ob) in obligations.iter().enumerate() {
+            let Some(ty) = ob.get("type").and_then(|v| v.as_str()) else {
+                offenders.push(format!("{}: obligation[{i}] has no `type`", path.display()));
+                continue;
+            };
+            if !KNOWN_OBLIGATION_TYPES.contains(&ty) {
+                offenders.push(format!(
+                    "{}: obligation[{i}] type `{ty}` is not in the schema vocabulary",
+                    path.display()
+                ));
+            }
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "contracts using unknown obligation types are never validated by anything:\n  {}",
+        offenders.join("\n  ")
+    );
+}
+
+#[test]
+fn every_contract_declares_metadata() {
+    // The other half of what `pv validate` enforces, and the reason
+    // binding.yaml is excluded rather than "fixed": a contract without
+    // `metadata` is not a contract.
+    for path in contract_files() {
+        let text = std::fs::read_to_string(&path).expect("readable");
+        let doc: serde_yaml_ng::Value = match serde_yaml_ng::from_str(&text) {
+            Ok(d) => d,
+            Err(_) => continue,
+        };
+        assert!(
+            doc.get("metadata").is_some(),
+            "{} has no `metadata` block; if it is not a contract it belongs in \
+             NOT_CONTRACTS with a reason, not in the contract set",
+            path.display()
+        );
+    }
+}
+
+#[test]
+fn excluded_files_are_excluded_for_a_reason_and_still_exist() {
+    // A stale exclusion is a hole. If binding.yaml is ever renamed or deleted,
+    // this list must be updated deliberately rather than quietly covering
+    // nothing.
+    for name in NOT_CONTRACTS {
+        let path = contracts_dir().join(name);
+        assert!(
+            path.exists(),
+            "{} is excluded from contract validation but does not exist — \
+             remove the stale exclusion",
+            path.display()
+        );
+    }
+}


### PR DESCRIPTION
Closes #251

## The defect

`pv validate` failed on five contracts because their `proof_obligations[].type` used `test` and `honesty`, neither of which is in the schema's vocabulary. Those files had therefore **never** been validated by anything — and nothing noticed, because nothing ran it.

```
$ for c in contracts/*.yaml; do pv validate "$c" >/dev/null 2>&1 || echo "$c"; done
contracts/apply-summary-distinguishability-v1.yaml
contracts/binding.yaml
contracts/destroy-undo-roundtrip-v1.yaml
contracts/idempotent-apply-v1.yaml
contracts/plan-apply-equivalence-v1.yaml
contracts/provable-iac-v1.yaml
```

This isn't cosmetic. `apply-summary-distinguishability-v1` is the planned-vs-actual contract cited as the correct precedent in #249, and `provable-iac-v1` backs `forjar prove`'s structural invariants — `prove()` maps its results straight into the `N/N proofs passed` line a user acts on. Both read as authority while being checked by nothing.

Same shape as #242 one level down: proofs cited by name as evidence, that no CI job ran, and which had also stopped compiling.

## The fix

Each obligation is re-typed to the variant its own `property` text already states — not to whatever happens to parse:

| Contract | Its own property text | Type |
|---|---|---|
| `idempotent-apply-v1` | "Second plan over converged locks is all-NoOp (f(f(x)) = f(x))" | `idempotency` |
| `plan-apply-equivalence-v1` | "Apply outcome counts match the plan's prediction" | `equivalence` |
| `destroy-undo-roundtrip-v1` | "Roundtrip restores the snapshot byte-for-byte" | `roundtrip` |
| `apply-summary-distinguishability-v1` | "All four step shapes hold" | `classification` |
| `provable-iac-v1` | "No vacuous green" | `soundness` |

The first three are exact — the property text names the variant. The last two are judgement, supported by the text, and called out here so they can be argued with now rather than discovered later.

**`binding.yaml` is excluded, not re-typed.** It is a binding *registry* mapping equations to Rust items (read by `contract_coverage.rs`), not a contract. Its `missing field metadata` failure is that category error reporting itself.

All 21 real contracts now pass `pv validate`.

## The guard

`tests/falsification_contracts_parse.rs`, 5 cases — written against the YAML rather than shelling out to `pv`, **deliberately**. A test that requires an external tool silently stops running when the tool is absent, which is exactly how these contracts went unvalidated in the first place, and why the kani/lean gate from #242 currently reports red on a fleet without the toolchains installed.

It also asserts the contract set is non-empty (`>= 20` files), because a glob matching nothing would make every other case pass by checking zero files — the vacuous-green shape `provable-iac-v1` itself has an obligation about.

**Mutation-checked.** Restoring `type: test` on one obligation:

```
test every_proof_obligation_uses_a_known_type ... FAILED
  contracts/idempotent-apply-v1.yaml: obligation[3] type `test` is not in the schema vocabulary
```

Independent of #250; touches different contract files and adds a new test file.