### PR TITLE
fix: a task must not report converged without reaching its declared state

### DIFF
--- a/src/resources/task.rs
+++ b/src/resources/task.rs
@@ -180,6 +180,35 @@ fn batch_script(resource: &Resource) -> String {
     if let Some(gather) = gather_script(resource) {
         script.push_str(&gather);
     }
+
+    // GH-254: re-assert the completion_check AFTER running.
+    //
+    // The check was used only as a guard on whether to run, never as evidence
+    // that running worked, so `converged` meant "the command exited 0" rather
+    // than "the resource reached its declared state". A task could do
+    // everything right, exit 0, and leave the declared condition false — and
+    // the lock recorded success, so the next `plan` reported `no changes` over
+    // a host that never converged.
+    //
+    // Observed on paiml/infra's `lean-toolchain`: `sudo: true` made $HOME=/root,
+    // so the toolchain installed where the runner user could not read it. Every
+    // command succeeded, `forjar apply` reported `1 converged, 0 failed`, and
+    // `command -v lean` failed immediately afterwards.
+    //
+    // The check is already written and already cheap — it just ran. Running it
+    // once more turns an exit code into a statement about the world.
+    if let Some(ref check) = resource.completion_check {
+        script.push_str("if ! { ");
+        script.push_str(check);
+        script.push_str(" ; }; then\n");
+        script.push_str(
+            "  echo 'task=not-converged: command exited 0 but completion_check still fails' >&2\n",
+        );
+        script.push_str("  echo 'task=not-converged: the declared state was not reached' >&2\n");
+        script.push_str("  exit 1\n");
+        script.push_str("fi\n");
+    }
+
     script
 }
 

--- a/tests/falsification_task_verifies_completion.rs
+++ b/tests/falsification_task_verifies_completion.rs
@@ -1,0 +1,142 @@
+//! GH-254: a task must not report converged without reaching its declared state.
+//!
+//! `completion_check` was consulted only as a guard on whether to RUN the
+//! command. It was never re-evaluated afterwards, so `converged` meant "the
+//! command exited 0", not "the resource is in the state it declares". The lock
+//! then recorded success and the next `plan` reported `no changes` over a host
+//! that had never converged.
+//!
+//! This is not hypothetical. On paiml/infra's `lean-toolchain`, `sudo: true`
+//! made `$HOME=/root`, so the Lean toolchain installed where the runner user
+//! could not read it. Every command in the script succeeded. `forjar apply`
+//! reported `1 converged, 0 failed`. `command -v lean` failed immediately
+//! afterwards.
+//!
+//! The distinction these tests pin is between two different failures that
+//! previously looked identical — except that the second looked like a success:
+//!
+//!   * the command errored                      -> already reported as failure
+//!   * the command ran and achieved nothing     -> reported as CONVERGED
+//!
+//! The emitted script is EXECUTED here rather than pattern-matched. A
+//! `script.contains("completion_check")` assertion would pass on a script that
+//! never runs the check, which is the class of test that let the original
+//! defect through.
+
+use forjar::core::types::{MachineTarget, Resource, ResourceType};
+use std::process::Command;
+
+fn task(command: &str, completion_check: Option<&str>) -> Resource {
+    Resource {
+        resource_type: ResourceType::Task,
+        machine: MachineTarget::Single("local".to_string()),
+        command: Some(command.to_string()),
+        completion_check: completion_check.map(str::to_string),
+        ..Default::default()
+    }
+}
+
+/// Run an emitted apply script under bash and return its exit status.
+fn run(script: &str) -> std::process::Output {
+    Command::new("bash")
+        .arg("-c")
+        .arg(script)
+        .output()
+        .expect("bash must run")
+}
+
+#[test]
+fn a_command_that_succeeds_without_converging_fails() {
+    // THE REGRESSION. `true` exits 0 and achieves nothing; `false` is a
+    // completion_check that can never hold. Before GH-254 this emitted a script
+    // that exited 0, and forjar reported the resource converged.
+    let script = forjar::resources::task::apply_script(&task("true", Some("false")));
+    let out = run(&script);
+
+    assert!(
+        !out.status.success(),
+        "a task whose completion_check still fails must NOT converge.\n\
+         script:\n{script}"
+    );
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("not-converged"),
+        "the failure must say the declared state was not reached, so it is \
+         distinguishable from a command error: {stderr}"
+    );
+}
+
+#[test]
+fn a_command_that_genuinely_converges_still_passes() {
+    // The gate must be passable, or it trains people to delete it. Here the
+    // command actually produces the condition the check tests.
+    let dir = tempfile::tempdir().unwrap();
+    let marker = dir.path().join("done");
+    let script = forjar::resources::task::apply_script(&task(
+        &format!("touch {}", marker.display()),
+        Some(&format!("test -f {}", marker.display())),
+    ));
+
+    let out = run(&script);
+    assert!(
+        out.status.success(),
+        "a task that reaches its declared state must converge.\nstderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(marker.exists());
+}
+
+#[test]
+fn a_failing_command_is_still_reported_as_a_command_failure() {
+    // The two failures must stay distinguishable. A command that errors should
+    // NOT be relabelled as a convergence problem — that would trade one
+    // misleading report for another.
+    let script = forjar::resources::task::apply_script(&task("exit 3", Some("true")));
+    let out = run(&script);
+
+    assert!(!out.status.success(), "a failing command must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("not-converged"),
+        "a command error must not be reported as a convergence failure: {stderr}"
+    );
+}
+
+#[test]
+fn a_task_without_a_completion_check_is_unaffected() {
+    // No check declared means nothing to verify. This must not become a way to
+    // fail tasks that never made the claim in the first place.
+    let script = forjar::resources::task::apply_script(&task("true", None));
+    let out = run(&script);
+    assert!(
+        out.status.success(),
+        "a task with no completion_check must behave as before.\nstderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn the_check_runs_after_the_command_not_before() {
+    // Ordering is the whole point. If the verification ran first it would test
+    // the pre-command state and pass vacuously for any task whose check
+    // happened to hold already — which is exactly the guard semantics being
+    // fixed. Here the command CREATES the condition, so a check evaluated
+    // before it would fail.
+    let dir = tempfile::tempdir().unwrap();
+    let marker = dir.path().join("created-by-the-command");
+    assert!(!marker.exists());
+
+    let script = forjar::resources::task::apply_script(&task(
+        &format!("touch {}", marker.display()),
+        Some(&format!("test -f {}", marker.display())),
+    ));
+    let out = run(&script);
+
+    assert!(
+        out.status.success(),
+        "the verification must run AFTER the command, or a task that creates \
+         its own precondition can never pass.\nstderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}


### PR DESCRIPTION
Closes #254

## The defect

`completion_check` was consulted only as a guard on whether to RUN the command, never re-evaluated afterwards. So `converged` meant *"the command exited 0"*, not *"the resource is in the state it declares"* — and the lock recorded that, so the next `plan` reported `no changes` over a host that had never converged.

**Found in production, not by inspection.** paiml/infra's `lean-toolchain` used `sudo: true`, which made `$HOME=/root`, so the Lean toolchain installed where the runner user could not read it:

```
$ forjar apply -f forjar.yaml -t proof-toolchain --yes
intel: 1 converged, 3 unchanged, 0 failed

$ ssh intel 'command -v lean' ; echo $?
1
```

Every command in that script succeeded. The purpose was not achieved. Nothing noticed.

## The fix

Re-assert the check after the command, and exit non-zero when it still fails — with a message that distinguishes two failures which previously looked identical, except that the second looked like a success:

| | before | after |
|---|---|---|
| the command errored | failure | failure |
| the command ran and achieved nothing | **CONVERGED** | failure, `task=not-converged` |

The check is already written and already cheap; it just ran. Running it once more turns an exit code into a statement about the world.

## Tests

`tests/falsification_task_verifies_completion.rs`, 5 cases, all **executing** the emitted script under bash rather than pattern-matching it. A `script.contains("completion_check")` assertion would pass on a script that never runs the check — the class of test that let this through in the first place.

Beyond the regression, they pin what a careless fix would break:

- a genuinely converging task still passes — or the gate trains people to delete it
- a failing command is still reported as a **command** failure, not relabelled as a convergence problem, trading one misleading report for another
- a task with no `completion_check` is untouched; this must not become a way to fail tasks that never made the claim
- the check runs **after** the command — evaluating it first would pass vacuously for any task whose condition already held, which is exactly the guard semantics being replaced

**Mutation-checked:** reverting the fix fails `a_command_that_succeeds_without_converging_fails` and leaves the other four green, so the regression test isolates the defect rather than the suite catching it incidentally.

## Note on CI

`container_transport` fails on this branch with `Conflict. The container name "/forjar-integration-test" is already in use`. That is **not** from this change — it is the shared-fixture collision #250 fixes with `test_machine_named()`, and `main` does not have that fix yet (`git show main:tests/container_transport.rs | grep -c test_machine_named` -> 0). Everything else passes: **12,994 tests**. It clears once #250 lands.

## Behaviour change

Tasks that were silently not converging will now fail. That is the point — they were never converged, and the lock was recording otherwise.