### PR TITLE
fix: the cargo package check must ask cargo, not the PATH

### DIFF
--- a/src/resources/package.rs
+++ b/src/resources/package.rs
@@ -384,13 +384,21 @@ pub fn state_query_script(resource: &Resource) -> String {
             queries.join("\n")
         }
         "cargo" => {
+            // GH-257: ask cargo, not the PATH — see package_check.rs for the
+            // full reasoning. This one feeds DRIFT, so its blindness is the
+            // more expensive half: with `command -v <crate_name>`, a crate
+            // whose binary is named differently (kani-verifier -> cargo-kani)
+            // reads as MISSING forever, and a dangling symlink reads as
+            // installed. Neither state produces a useful drift signal, which is
+            // why an intel host lost rustup, cargo and forjar without a single
+            // drift finding.
             let queries: Vec<String> = packages
                 .iter()
                 .map(|p| {
                     let (crate_name, _) = parse_cargo_features(p);
                     format!(
-                        "command -v {} >/dev/null 2>&1 && echo {} || echo {}",
-                        sh_squote(crate_name),
+                        "cargo install --list 2>/dev/null | grep -q {} && echo {} || echo {}",
+                        sh_squote(&format!("^{crate_name} v")),
                         sh_squote(&format!("{crate_name}=installed")),
                         sh_squote(&format!("{crate_name}=MISSING"))
                     )

--- a/src/resources/package_check.rs
+++ b/src/resources/package_check.rs
@@ -30,13 +30,49 @@ pub fn check_script(resource: &Resource) -> String {
             verdict::check_script_from(&checks)
         }
         "cargo" => {
+            // GH-257: ask CARGO what it installed, not the PATH.
+            //
+            // This was `command -v <crate_name>`, which is wrong twice over.
+            //
+            // 1. A crate's name is not its binary's name. `kani-verifier`
+            //    installs `cargo-kani` and `kani`; `command -v kani-verifier`
+            //    can never succeed, so the resource reported missing forever
+            //    even with the crate installed and working. Observed on intel:
+            //    `forjar check -r kani-verifier` FAILED while
+            //    `cargo-kani --version` printed 0.67.0.
+            //
+            // 2. `command -v` tests that a path exists and carries the
+            //    executable bit — not that it RUNS. A dangling symlink passes.
+            //    Also observed on intel: ~/.cargo/bin/rustup was gone while
+            //    ~/.cargo/bin/cargo remained as a symlink to it, and every
+            //    existence-check was satisfied by a link that executed nothing.
+            //
+            // `cargo install --list` is cargo's own record of what it
+            // installed, keyed by CRATE name and carrying the version:
+            //
+            //     kani-verifier v0.67.0:
+            //         cargo-kani
+            //         kani
+            //
+            // So it answers the question actually being asked, and it does so
+            // without depending on PATH — which differs between a login shell
+            // and the runner service that will use the tool.
+            let version = resource.version.as_deref();
             let checks: Vec<String> = packages
                 .iter()
                 .map(|p| {
                     let (crate_name, _) = parse_cargo_features(p);
-                    let q = sh_squote(crate_name);
+                    // Anchor on the crate name and the ` v` that precedes the
+                    // version, so `pmat` cannot be satisfied by `pmat-extra`.
+                    let needle = match version {
+                        Some(v) => format!("^{crate_name} v{v}:"),
+                        None => format!("^{crate_name} v"),
+                    };
                     verdict::assert_that(
-                        &format!("command -v {q} >/dev/null 2>&1"),
+                        &format!(
+                            "cargo install --list 2>/dev/null | grep -q {}",
+                            sh_squote(&needle)
+                        ),
                         &format!("installed:{crate_name}"),
                         &format!("missing:{crate_name}"),
                     )

--- a/src/resources/tests_package.rs
+++ b/src/resources/tests_package.rs
@@ -147,10 +147,16 @@ fn test_fj006_apply_apt_sudo_detection() {
 
 #[test]
 fn test_fj006_cargo_check() {
+    // GH-257: asks CARGO, not the PATH. Behavioural coverage that EXECUTES
+    // the script lives in tests/falsification_cargo_check.rs.
     let mut r = make_apt_resource(&["batuta"]);
     r.provider = Some("cargo".to_string());
     let script = check_script(&r);
-    assert!(script.contains("command -v 'batuta'"));
+    assert!(script.contains("cargo install --list"));
+    assert!(
+        !script.contains("command -v"),
+        "a crate's name is not its binary's name; PATH lookup cannot answer this"
+    );
 }
 
 #[test]
@@ -197,10 +203,12 @@ fn test_fj006_quoted_packages() {
 fn test_fj006_state_query_cargo() {
     let mut r = make_apt_resource(&["batuta", "renacer"]);
     r.provider = Some("cargo".to_string());
+    // GH-257: drift is answered by cargo's record, not a PATH lookup.
     let script = state_query_script(&r);
-    assert!(script.contains("command -v 'batuta'"));
-    assert!(script.contains("command -v 'renacer'"));
+    assert!(script.contains("'^batuta v'"));
+    assert!(script.contains("'^renacer v'"));
     assert!(script.contains("installed"));
+    assert!(!script.contains("command -v"));
 }
 
 #[test]
@@ -444,9 +452,10 @@ fn test_cargo_check_strips_features() {
     let mut r = make_apt_resource(&["whisper-apr[cli]"]);
     r.provider = Some("cargo".to_string());
     let script = check_script(&r);
+    // GH-257: same intent, cargo's record instead of a PATH lookup.
     assert!(
-        script.contains("command -v 'whisper-apr'"),
-        "check must use bare crate name, got: {script}"
+        script.contains("'^whisper-apr v'"),
+        "check must use the bare crate name, got: {script}"
     );
     assert!(
         !script.contains("[cli]"),
@@ -460,9 +469,14 @@ fn test_cargo_state_query_strips_features() {
     let mut r = make_apt_resource(&["whisper-apr[cli]"]);
     r.provider = Some("cargo".to_string());
     let script = state_query_script(&r);
+    // GH-257: same intent, cargo's record instead of a PATH lookup.
     assert!(
-        script.contains("command -v 'whisper-apr'"),
-        "state query must use bare crate name, got: {script}"
+        script.contains("'^whisper-apr v'"),
+        "state query must use the bare crate name, got: {script}"
+    );
+    assert!(
+        !script.contains("[cli]"),
+        "features must not reach the needle"
     );
 }
 

--- a/src/resources/tests_package_b.rs
+++ b/src/resources/tests_package_b.rs
@@ -267,13 +267,23 @@ fn test_fj_cargo_source_ignores_version() {
 /// check_script still uses package name (binary name) even with source set.
 #[test]
 fn test_fj_cargo_source_check_uses_binary_name() {
+    // GH-257: the intent — `source:` must not change the crate's identity —
+    // is kept; the mechanism is not. This asserted
+    // `script.contains("command -v 'apr-cli'")`, which enshrined the defect:
+    // `apr-cli` installs a binary called `apr`, so that lookup FAILS on a host
+    // where the crate is installed and working. The check now consults cargo's
+    // own record, which is keyed by crate name.
     let mut r = make_apt_resource(&["apr-cli"]);
     r.provider = Some("cargo".to_string());
     r.source = Some("/build/apr-cli".to_string());
     let script = check_script(&r);
     assert!(
-        script.contains("command -v 'apr-cli'"),
-        "check_script must use package name even with source: {script}"
+        script.contains("'^apr-cli v'"),
+        "check must identify the crate by name even with source: {script}"
+    );
+    assert!(
+        !script.contains("command -v"),
+        "PATH lookup cannot answer this"
     );
 }
 

--- a/tests/falsification_cargo_check.rs
+++ b/tests/falsification_cargo_check.rs
@@ -1,0 +1,168 @@
+//! GH-257: the cargo package check must ask cargo, not the PATH.
+//!
+//! The check was `command -v <crate_name>`, wrong in two independent ways.
+//!
+//! **A crate's name is not its binary's name.** `kani-verifier` installs
+//! `cargo-kani` and `kani`, so `command -v kani-verifier` can never succeed.
+//! Observed on intel: `forjar check -r kani-verifier` FAILED while
+//! `cargo-kani --version` printed `cargo-kani 0.67.0`.
+//!
+//! **`command -v` tests existence, not function.** It succeeds for any path
+//! that exists and carries the executable bit. Also observed on intel:
+//! `~/.cargo/bin/rustup` was gone while `~/.cargo/bin/cargo` remained as a
+//! symlink *to it* — a dangling link that satisfied every existence-check and
+//! could not run a single command.
+//!
+//! Those two produced opposite errors at once (check said missing, apply said
+//! unchanged), which is how a CI host rotted with nothing noticing.
+//!
+//! These tests EXECUTE the emitted script against a stub `cargo`. The test this
+//! replaces asserted `script.contains("command -v 'batuta'")` — a text match
+//! that passes on a script checking entirely the wrong thing, which is exactly
+//! how the defect survived having a test.
+
+use forjar::core::types::{MachineTarget, Resource, ResourceType};
+use std::io::Write;
+use std::process::Command;
+
+fn cargo_pkg(packages: &[&str], version: Option<&str>) -> Resource {
+    Resource {
+        resource_type: ResourceType::Package,
+        machine: MachineTarget::Single("local".to_string()),
+        provider: Some("cargo".to_string()),
+        packages: packages.iter().map(|s| (*s).to_string()).collect(),
+        version: version.map(str::to_string),
+        ..Default::default()
+    }
+}
+
+/// A stub `cargo` whose `install --list` prints the given inventory.
+///
+/// Real `cargo install --list` output, so the parsing under test faces the
+/// real shape rather than a convenient one.
+fn stub_cargo(dir: &std::path::Path, listing: &str) {
+    let bin = dir.join("cargo");
+    let mut f = std::fs::File::create(&bin).unwrap();
+    writeln!(f, "#!/usr/bin/env bash").unwrap();
+    writeln!(f, "if [ \"$1\" = install ] && [ \"$2\" = --list ]; then").unwrap();
+    writeln!(f, "cat <<'LISTING'\n{listing}\nLISTING").unwrap();
+    writeln!(f, "  exit 0").unwrap();
+    writeln!(f, "fi").unwrap();
+    writeln!(f, "exit 1").unwrap();
+    drop(f);
+    let mut perms = std::fs::metadata(&bin).unwrap().permissions();
+    std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o755);
+    std::fs::set_permissions(&bin, perms).unwrap();
+}
+
+/// Run the emitted check script with only the stub dir on PATH.
+fn run_check(script: &str, stub_dir: &std::path::Path) -> bool {
+    Command::new("bash")
+        .arg("-c")
+        .arg(script)
+        .env("PATH", format!("{}:/usr/bin:/bin", stub_dir.display()))
+        .output()
+        .expect("bash must run")
+        .status
+        .success()
+}
+
+const KANI_LISTING: &str = "kani-verifier v0.67.0:\n    cargo-kani\n    kani";
+
+#[test]
+fn a_crate_whose_binary_has_a_different_name_is_found() {
+    // THE REGRESSION. `kani-verifier` installs `cargo-kani` and `kani`, never a
+    // binary of its own name, so the old `command -v kani-verifier` reported
+    // missing on a host where it was installed and working.
+    let dir = tempfile::tempdir().unwrap();
+    stub_cargo(dir.path(), KANI_LISTING);
+
+    let script =
+        forjar::resources::package_check::check_script(&cargo_pkg(&["kani-verifier"], None));
+    assert!(
+        run_check(&script, dir.path()),
+        "kani-verifier is installed per cargo's own record; the check must \
+         agree.\nscript:\n{script}"
+    );
+}
+
+#[test]
+fn a_crate_that_is_not_installed_is_reported_missing() {
+    // The gate must still be able to fail, or it is worse than none.
+    let dir = tempfile::tempdir().unwrap();
+    stub_cargo(dir.path(), KANI_LISTING);
+
+    let script =
+        forjar::resources::package_check::check_script(&cargo_pkg(&["not-installed"], None));
+    assert!(
+        !run_check(&script, dir.path()),
+        "a crate absent from cargo's record must report missing"
+    );
+}
+
+#[test]
+fn a_prefix_of_an_installed_crate_is_not_a_match() {
+    // `pmat` must not be satisfied by `pmat-extra`. Anchoring is the whole
+    // reason the needle carries `^` and the ` v` before the version.
+    let dir = tempfile::tempdir().unwrap();
+    stub_cargo(dir.path(), "pmat-extra v1.0.0:\n    pmat-extra");
+
+    let script = forjar::resources::package_check::check_script(&cargo_pkg(&["pmat"], None));
+    assert!(
+        !run_check(&script, dir.path()),
+        "`pmat` must not be satisfied by `pmat-extra`"
+    );
+}
+
+#[test]
+fn a_pinned_version_must_match_the_installed_one() {
+    // A pin that is never verified is a comment. With `version:` set, the
+    // check has to compare it, or a stale build silently satisfies a bump.
+    let dir = tempfile::tempdir().unwrap();
+    stub_cargo(dir.path(), "forjar v1.13.1:\n    forjar");
+
+    let matching =
+        forjar::resources::package_check::check_script(&cargo_pkg(&["forjar"], Some("1.13.1")));
+    assert!(
+        run_check(&matching, dir.path()),
+        "the installed version matches the pin; the check must pass"
+    );
+
+    let bumped =
+        forjar::resources::package_check::check_script(&cargo_pkg(&["forjar"], Some("1.14.0")));
+    assert!(
+        !run_check(&bumped, dir.path()),
+        "1.13.1 is installed but 1.14.0 is pinned — the check must report missing"
+    );
+}
+
+#[test]
+fn the_check_does_not_depend_on_path_lookup() {
+    // The original failure mode: a binary present on a LOGIN shell's PATH and
+    // absent from the runner service's. Asking cargo removes PATH from the
+    // question entirely. Here the crate is installed per cargo but no binary of
+    // any name exists on PATH — the old check would say missing.
+    let dir = tempfile::tempdir().unwrap();
+    stub_cargo(dir.path(), KANI_LISTING);
+
+    let script =
+        forjar::resources::package_check::check_script(&cargo_pkg(&["kani-verifier"], None));
+    assert!(
+        run_check(&script, dir.path()),
+        "installation is a fact about cargo's record, not about PATH"
+    );
+}
+
+#[test]
+fn feature_syntax_is_stripped_before_matching() {
+    // `copia[cli]` is the crate `copia` with a feature; cargo lists it as
+    // `copia`, so the brackets must not reach the needle.
+    let dir = tempfile::tempdir().unwrap();
+    stub_cargo(dir.path(), "copia v0.2.0:\n    copia");
+
+    let script = forjar::resources::package_check::check_script(&cargo_pkg(&["copia[cli]"], None));
+    assert!(
+        run_check(&script, dir.path()),
+        "the feature suffix must be stripped before matching cargo's record"
+    );
+}


### PR DESCRIPTION
Closes #257

## The defect

`check_script` and `state_query_script` both asked `command -v <crate_name>`. Wrong in two independent ways — and the two produce **opposite** errors at once, which is how a CI host rotted with nothing noticing.

**A crate's name is not its binary's name.** `kani-verifier` installs `cargo-kani` and `kani`, so the lookup can never succeed:

```
$ forjar check -r kani-verifier      FAIL
$ cargo-kani --version               cargo-kani 0.67.0
$ command -v kani-verifier           does not exist
```

`apr-cli` installs `apr`; `copia[cli]` installs `copia`. Any crate whose binary is named differently reported missing forever.

**And `command -v` tests existence, not function** — it succeeds for any path that exists and carries the executable bit. Also observed on intel: `~/.cargo/bin/rustup` was gone while `~/.cargo/bin/cargo` remained as a symlink *to it*. A dangling link that satisfied every existence-check and executed nothing.

`state_query` has the same defect and is **the more expensive half, because it feeds drift**. Neither error mode yields a usable drift signal — which is why intel lost rustup, cargo and forjar without a single drift finding, while `forjar apply` reported `0 converged, 1 unchanged` over an absent binary.

## The fix

Both consult `cargo install --list` — cargo's own record, keyed by crate name and carrying the version:

```
kani-verifier v0.67.0:
    cargo-kani
    kani
```

It answers the question actually being asked, verifies a pinned `version:` (a pin nothing checks is a comment), and removes PATH from the question — which matters because a login shell and the runner service disagree about it, and that disagreement took the fleet's CI down today.

## Four tests were pinning the defect in place

All matched the emitted script's **text**:

| test | asserted |
|---|---|
| `test_fj006_cargo_check` | `contains("command -v 'batuta'")` |
| `test_cargo_check_strips_features` | `contains("command -v 'whisper-apr'")` |
| `test_fj006_state_query_cargo` | `contains("command -v 'batuta'")` |
| `test_fj_cargo_source_check_uses_binary_name` | `contains("command -v 'apr-cli'")` |

The last is the sharpest: **`apr-cli` installs a binary named `apr`**, so that assertion demanded a lookup guaranteed to fail on a host where the crate is installed. A test named *"uses binary name"* enshrined *"uses the crate name as if it were the binary name."* Each keeps its original intent; only the mechanism moved.

`tests/falsification_cargo_check.rs` — 6 cases that **execute** the emitted script against a stub cargo: different binary name, absent crate, prefix collision (`pmat` vs `pmat-extra`), version pin match and mismatch, feature syntax, PATH independence. **Mutation-checked: 4 of 6 fail against `command -v`.**

## Ruled out before claiming this is safe

`cargo install --list` does **not** block on the CARGO_HOME lock (`rc=0` while a build holds it), so the check cannot hang a busy machine. I checked, because a check that hangs is worse than one that lies.

## Note on the local suite

Two container tests (`dispatch_container_backend*`) fail under full-suite load with `should complete within 30s`, and pass in **4.07s in isolation**. Neither file is touched here. That is a separate guessed-duration assertion of the same class as the webhook `sleep(100ms)` fixed in #250 — filing separately rather than smuggling it in.