### PR TITLE
feat(verify): detect reads outside task_inputs (Closes #244)

### DIFF
--- a/contracts/undeclared-input-detection-v1.yaml
+++ b/contracts/undeclared-input-detection-v1.yaml
@@ -1,0 +1,128 @@
+---
+metadata:
+  version: "1.0.0"
+  # kind: pattern — the obligations concern process behaviour observed by
+  # running a recipe twice under different trees. Not a decidable core, and per
+  # GH-242 a harness that reaches a hash cannot produce a verdict anyway.
+  kind: pattern
+  created: "2026-08-17"
+  author: "PAIML Engineering"
+  description: |
+    GH-244: detect a task that reads a file it never declared in `task_inputs`.
+
+    `staleness_reason` decides entirely from the DECLARED set, so a change to an
+    undeclared input yields `None` and plan/check/drift/apply all report a
+    clean, converged stack over a stale artifact. Under-declaration converts
+    "no build system" into "a build system that lies", which is strictly harder
+    to detect than having no cache at all.
+
+    Mechanism: sandboxing-by-omission. Run once from a full copy of
+    `working_dir`, once from a tree containing only the glob-expanded
+    `task_inputs`, and compare. No privileges, no ptrace, no LD_PRELOAD — the
+    three mechanisms the issue weighs and calls "inherently best-effort".
+  references:
+    - "issue: https://github.com/paiml/forjar/issues/244"
+    - "GH-247 — verify, which this extends; the issue calls it option (b) and says it is what they would consume first"
+
+equations:
+  detection:
+    formula: |
+      verdict(r) = UndeclaredInput  if full(r) = Reproduced ∧ declared_only(r) ≠ Reproduced
+                 = full(r)          otherwise
+    domain: "r ∈ Resource with type=task"
+    codomain: "Verdict"
+    invariants:
+      - "UndeclaredInput is reported ONLY when the full-tree run reproduced"
+      - "A non-deterministic recipe fails both runs and stays Diverged"
+
+proof_obligations:
+  - type: soundness
+    property: "Under-declaration is never confused with non-determinism"
+    formal: "full(r) ≠ Reproduced ⟹ verdict(r) = full(r)"
+    applies_to: all
+    enforced_by: "src/core/verify.rs::verify_hermetic — early return before the hermetic run"
+    notes: |
+      The difference between the two runs is only attributable when the full-tree
+      run reproduced. A non-deterministic generator fails BOTH, and blaming the
+      declaration for a generator's own instability is precisely the misdiagnosis
+      this feature exists to replace.
+
+  - type: completeness
+    property: "A recipe reading an undeclared project file is detected"
+    formal: "reads(r) ⊄ expand(task_inputs(r)) ∧ full(r) = Reproduced ⟹ UndeclaredInput"
+    applies_to: "files inside working_dir"
+    enforced_by: "src/core/verify.rs::run_from_declared_inputs"
+    notes: |
+      SCOPE, stated plainly: this sees reads of files inside the project tree.
+      It cannot see a read of /usr/share/fonts or a tool version, because those
+      exist in the scratch tree too. That is the issue's option (c), which a
+      `data:` source of `type: command` already covers. Nothing here should be
+      read as "the declaration is now proven complete".
+
+  - type: safety
+    property: "Detection never writes the declared output path"
+    formal: "inherited from GH-247 — both runs execute in scratch trees"
+    applies_to: all
+    enforced_by: "src/core/verify.rs::verify_resource, run_from_declared_inputs"
+
+enforcement:
+  undeclared_input_is_detected:
+    description: "A recipe reading an undeclared project file is reported"
+    check: "tests/falsification_undeclared_inputs.rs::an_undeclared_project_file_is_detected"
+    severity: "ERROR"
+  nondeterminism_is_not_misattributed:
+    description: |
+      The discrimination that makes the verdict trustworthy: a non-deterministic
+      recipe stays `Diverged` rather than being blamed on the declaration.
+    check: "tests/falsification_undeclared_inputs.rs::nondeterminism_is_reported_as_divergence_not_as_under_declaration"
+    severity: "ERROR"
+  the_flag_is_actually_wired:
+    description: |
+      `--check-declared-inputs` must change the verdict. The first
+      implementation parsed the flag, bound the value, and still called the
+      non-hermetic path — correct code, unreachable feature.
+    check: "tests/falsification_undeclared_inputs.rs::the_flag_actually_changes_the_verdict"
+    severity: "ERROR"
+  the_gate_is_passable:
+    description: "A fully-declared recipe passes with the flag on"
+    check: "tests/falsification_undeclared_inputs.rs::a_fully_declared_project_passes_the_flag"
+    severity: "ERROR"
+
+falsification_tests:
+  - id: FALSIFY-UDI-001
+    rule: "An undeclared project file is detected"
+    prediction: "A recipe reading theme.txt while declaring only slide.txt reports UndeclaredInput"
+    test: "tests/falsification_undeclared_inputs.rs::an_undeclared_project_file_is_detected"
+    if_fails: "Under-declaration stays invisible and the cache keeps lying"
+
+  - id: FALSIFY-UDI-002
+    rule: "Non-determinism is not misattributed"
+    prediction: "A timestamp generator reports Diverged, never UndeclaredInput"
+    test: "tests/falsification_undeclared_inputs.rs::nondeterminism_is_reported_as_divergence_not_as_under_declaration"
+    if_fails: "Every unstable generator is blamed on its declaration; the verdict becomes noise"
+
+  - id: FALSIFY-UDI-003
+    rule: "The flag reaches the implementation"
+    prediction: "With the flag the verdict changes; without it the same project reproduces"
+    test: "tests/falsification_undeclared_inputs.rs::the_flag_actually_changes_the_verdict"
+    if_fails: "A feature that is correct and unreachable — which is how it first shipped locally"
+
+  - id: FALSIFY-UDI-004
+    rule: "The message names the undeclared file"
+    prediction: "The failure text carries the recipe's own stderr, e.g. `theme.txt: No such file`"
+    test: "tests/falsification_undeclared_inputs.rs::a_recipe_that_cannot_run_without_the_undeclared_file_names_the_failure"
+    if_fails: "A true verdict nobody can act on"
+
+qa_gate:
+  id: F-UDI-001
+  name: "Undeclared Input Detection Contract"
+  description: "Detect reads outside task_inputs by running from the declared set alone"
+  checks:
+    - "undeclared_input_is_detected"
+    - "nondeterminism_is_not_misattributed"
+    - "the_flag_is_actually_wired"
+    - "the_gate_is_passable"
+  pass_criteria: "All 4 falsification tests pass"
+  falsification: "Remove the early return so a non-reproducing full run still triggers the hermetic comparison"
+
+verification_level: L3

--- a/src/cli/commands/verify_args.rs
+++ b/src/cli/commands/verify_args.rs
@@ -33,4 +33,11 @@ pub struct VerifyArgs {
     /// Keep the scratch tree instead of removing it (for inspecting a mismatch)
     #[arg(long)]
     pub keep_scratch: bool,
+
+    /// GH-244: also re-run from the DECLARED INPUTS ONLY, to detect a recipe
+    /// that reads a project file it never declared. Detection, not proof — it
+    /// cannot see reads of system paths, which `data:` sources of type
+    /// `command` are for.
+    #[arg(long)]
+    pub check_declared_inputs: bool,
 }

--- a/src/cli/verify.rs
+++ b/src/cli/verify.rs
@@ -7,7 +7,7 @@
 
 use super::commands::VerifyArgs;
 use super::helpers::*;
-use crate::core::verify::{verify_resource, Verdict, VerifyOutcome};
+use crate::core::verify::{verify_hermetic, verify_resource, Verdict, VerifyOutcome};
 use std::path::Path;
 
 /// Exit non-zero if any resource diverged or failed to regenerate.
@@ -19,8 +19,9 @@ pub(crate) fn cmd_verify(args: &VerifyArgs, verbose: bool) -> Result<(), String>
         state_dir,
         json,
         keep_scratch,
+        check_declared_inputs,
     } = args;
-    let (json, keep_scratch) = (*json, *keep_scratch);
+    let (json, keep_scratch, hermetic) = (*json, *keep_scratch, *check_declared_inputs);
     let (resource_filter, tag_filter) = (resource_filter.as_deref(), tag_filter.as_deref());
     let config = parse_and_validate(file)?;
 
@@ -41,7 +42,11 @@ pub(crate) fn cmd_verify(args: &VerifyArgs, verbose: bool) -> Result<(), String>
         if verbose {
             eprintln!("verify {id}: scratch {}", scratch.display());
         }
-        outcomes.push(verify_resource(id, resource, recorded.as_deref(), &scratch));
+        outcomes.push(if hermetic {
+            verify_hermetic(id, resource, recorded.as_deref(), &scratch)
+        } else {
+            verify_resource(id, resource, recorded.as_deref(), &scratch)
+        });
     }
 
     if !keep_scratch {
@@ -108,6 +113,13 @@ fn print_human(outcomes: &[VerifyOutcome]) {
             Verdict::CommandFailed { status } => {
                 println!("  FAILED       {} ({status})", o.resource_id);
             }
+            Verdict::UndeclaredInput { hermetic } => {
+                println!(
+                    "  UNDECLARED   {} — reproduces from the full tree but not from \n\
+                     \x20              its declared inputs alone: {hermetic}",
+                    o.resource_id
+                );
+            }
             Verdict::Skipped(r) => println!("  skipped      {} ({})", o.resource_id, r.as_str()),
         }
     }
@@ -139,6 +151,9 @@ fn print_json(outcomes: &[VerifyOutcome]) {
                 ),
                 Verdict::CommandFailed { status } => {
                     format!(r#","error":"{}""#, status.replace('"', "'"))
+                }
+                Verdict::UndeclaredInput { hermetic } => {
+                    format!(r#","hermetic":"{}""#, hermetic.replace('"', "'"))
                 }
                 Verdict::Skipped(r) => format!(r#","reason":"{}""#, r.as_str()),
                 Verdict::Reproduced => String::new(),

--- a/src/core/task/io_tracking.rs
+++ b/src/core/task/io_tracking.rs
@@ -149,7 +149,7 @@ pub fn should_skip_cached(
 }
 
 /// Expand a glob pattern to matching file paths.
-fn expand_glob(pattern: &str, base_dir: &Path) -> Result<Vec<String>, String> {
+pub(crate) fn expand_glob(pattern: &str, base_dir: &Path) -> Result<Vec<String>, String> {
     let full_pattern = if Path::new(pattern).is_absolute() {
         pattern.to_string()
     } else {

--- a/src/core/task/mod.rs
+++ b/src/core/task/mod.rs
@@ -9,6 +9,7 @@ mod quality_gate;
 pub mod service;
 
 pub mod probe;
+pub(crate) use io_tracking::expand_glob;
 pub use io_tracking::{hash_inputs, hash_outputs, hash_outputs_in, should_skip_cached};
 pub use probe::{probe_all, probe_config, probe_resource, staleness_reason, IoDigest};
 pub use quality_gate::{evaluate_gate, gpu_env_vars, GateAction, GateResult};

--- a/src/core/verify.rs
+++ b/src/core/verify.rs
@@ -66,6 +66,17 @@ pub enum Verdict {
         /// Exit status text.
         status: String,
     },
+    /// GH-244: the recipe reproduces from the full tree but NOT from its
+    /// declared inputs alone — so it reads something it did not declare.
+    ///
+    /// Only ever reported when the full-tree run REPRODUCED, because that is
+    /// what makes the difference attributable. A merely non-deterministic
+    /// recipe fails both ways and stays `Diverged`; conflating the two would
+    /// blame the declaration for a generator's own instability.
+    UndeclaredInput {
+        /// What the declared-inputs-only run did instead.
+        hermetic: String,
+    },
     /// Not applicable.
     Skipped(SkipReason),
 }
@@ -78,6 +89,7 @@ impl Verdict {
             Self::Reproduced => "reproduced",
             Self::Diverged { .. } => "diverged",
             Self::CommandFailed { .. } => "command-failed",
+            Self::UndeclaredInput { .. } => "undeclared-input",
             Self::Skipped(_) => "skipped",
         }
     }
@@ -89,7 +101,10 @@ impl Verdict {
     /// reproducible, whatever the stored hash says.
     #[must_use]
     pub fn is_failure(&self) -> bool {
-        matches!(self, Self::Diverged { .. } | Self::CommandFailed { .. })
+        matches!(
+            self,
+            Self::Diverged { .. } | Self::CommandFailed { .. } | Self::UndeclaredInput { .. }
+        )
     }
 }
 
@@ -250,3 +265,100 @@ pub fn verify_resource(
 #[cfg(test)]
 #[path = "tests_verify.rs"]
 mod tests_verify;
+
+/// GH-244: does this recipe read anything it did not declare?
+///
+/// Runs the verification twice: once from a full copy of `working_dir`, once
+/// from a tree containing ONLY the glob-expanded `task_inputs`. The difference
+/// is the signal.
+///
+/// | full tree | declared-inputs only | verdict |
+/// |---|---|---|
+/// | reproduced | reproduced | `Reproduced` — nothing undeclared observed |
+/// | reproduced | failed/diverged | `UndeclaredInput` |
+/// | anything else | — | the full-tree verdict, unchanged |
+///
+/// The third row matters most. A non-deterministic generator fails BOTH runs,
+/// and reporting that as an undeclared input would blame the declaration for a
+/// generator's own instability — the diagnosis this is supposed to replace.
+///
+/// **This is detection, not prevention, and it is not airtight.** It sees reads
+/// of files inside the project tree; it cannot see a read of `/usr/share/fonts`
+/// or a tool version, because those exist in the scratch tree too. Those are
+/// what GH-244 option (c) covers, and a `data:` source of `type: command`
+/// already does it. Nothing here should be read as "the declaration is now
+/// proven complete".
+pub fn verify_hermetic(
+    resource_id: &str,
+    resource: &Resource,
+    recorded_hash: Option<&str>,
+    scratch_root: &Path,
+) -> VerifyOutcome {
+    let full = verify_resource(
+        resource_id,
+        resource,
+        recorded_hash,
+        &scratch_root.join("full"),
+    );
+    if full.verdict != Verdict::Reproduced {
+        // Not attributable — say only what is known.
+        return full;
+    }
+
+    let hermetic_root = scratch_root.join("declared");
+    match run_from_declared_inputs(resource, recorded_hash, &hermetic_root) {
+        Ok(true) => full,
+        Ok(false) => VerifyOutcome {
+            resource_id: resource_id.to_string(),
+            verdict: Verdict::UndeclaredInput {
+                hermetic: "outputs differ when only task_inputs are present".to_string(),
+            },
+        },
+        Err(e) => VerifyOutcome {
+            resource_id: resource_id.to_string(),
+            verdict: Verdict::UndeclaredInput { hermetic: e },
+        },
+    }
+}
+
+/// Populate `root` with only the declared inputs, run, and report whether the
+/// outputs still match `recorded_hash`.
+fn run_from_declared_inputs(
+    resource: &Resource,
+    recorded_hash: Option<&str>,
+    root: &Path,
+) -> Result<bool, String> {
+    let work = PathBuf::from(resource.working_dir.as_deref().unwrap_or_default());
+    std::fs::create_dir_all(root).map_err(|e| format!("scratch mkdir: {e}"))?;
+
+    for pattern in &resource.task_inputs {
+        for matched in crate::core::task::expand_glob(pattern, &work)? {
+            let src = Path::new(&matched);
+            // Preserve the path the recipe expects to find.
+            let rel = src.strip_prefix(&work).unwrap_or(src);
+            let dst = root.join(rel);
+            if let Some(parent) = dst.parent() {
+                std::fs::create_dir_all(parent).map_err(|e| format!("scratch mkdir: {e}"))?;
+            }
+            std::fs::copy(src, &dst)
+                .map_err(|e| format!("copy declared input {}: {e}", src.display()))?;
+        }
+    }
+
+    let out = std::process::Command::new("bash")
+        .arg("-c")
+        .arg(resource.command.as_deref().unwrap_or("true"))
+        .current_dir(root)
+        .output()
+        .map_err(|e| format!("spawn: {e}"))?;
+    if !out.status.success() {
+        return Err(format!(
+            "recipe fails with only task_inputs present ({}): {}",
+            out.status,
+            String::from_utf8_lossy(&out.stderr).trim()
+        ));
+    }
+
+    let regenerated = hash_outputs_in(&resource.output_artifacts, root).unwrap_or(None);
+    Ok(regenerated.as_deref() == recorded_hash)
+}

--- a/tests/falsification_undeclared_inputs.rs
+++ b/tests/falsification_undeclared_inputs.rs
@@ -1,0 +1,289 @@
+//! GH-244: detecting a task that reads a file it never declared.
+//!
+//! `staleness_reason` decides entirely from the DECLARED set, so a change to an
+//! undeclared input yields `None` and `plan`/`check`/`drift`/`apply` all report
+//! a clean, converged stack over a stale artifact. Under-declaration converts
+//! "no build system" into "a build system that lies", which is strictly harder
+//! to detect than having no cache at all.
+//!
+//! The mechanism here is sandboxing-by-omission: run once from a full copy of
+//! `working_dir`, once from a tree containing only the glob-expanded
+//! `task_inputs`, and compare. It needs no privileges, no ptrace and no
+//! LD_PRELOAD — the three mechanisms GH-244 weighs and calls "inherently
+//! best-effort".
+//!
+//! What it CANNOT see: a read of `/usr/share/fonts` or a tool version, because
+//! those exist in the scratch tree too. That is GH-244 option (c), and a
+//! `data:` source of `type: command` already covers it. Nothing here should be
+//! read as "the declaration is now proven complete".
+
+use forjar::core::types::{MachineTarget, Resource, ResourceType};
+use forjar::core::verify::{verify_hermetic, Verdict};
+use std::path::Path;
+
+fn task(dir: &Path, command: &str, inputs: &[&str], artifacts: &[&str]) -> Resource {
+    Resource {
+        resource_type: ResourceType::Task,
+        machine: MachineTarget::Single("local".to_string()),
+        command: Some(command.to_string()),
+        working_dir: Some(dir.display().to_string()),
+        task_inputs: inputs.iter().map(|s| (*s).to_string()).collect(),
+        output_artifacts: artifacts.iter().map(|s| (*s).to_string()).collect(),
+        cache: true,
+        ..Default::default()
+    }
+}
+
+/// Run the recipe the way apply would, and return the recorded output hash.
+fn apply_and_record(r: &Resource, dir: &Path) -> String {
+    std::process::Command::new("bash")
+        .arg("-c")
+        .arg(r.command.as_deref().unwrap())
+        .current_dir(dir)
+        .status()
+        .unwrap();
+    forjar::core::task::hash_outputs_in(&r.output_artifacts, dir)
+        .unwrap()
+        .unwrap()
+}
+
+#[test]
+fn an_undeclared_project_file_is_detected() {
+    // THE CASE. `render.sh` reads BOTH slide.txt (declared) and theme.txt
+    // (NOT declared). Editing theme.txt today produces staleness_reason=None
+    // and a green plan over a stale artifact.
+    let dir = tempfile::tempdir().unwrap();
+    let scratch = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("slide.txt"), "SLIDE\n").unwrap();
+    std::fs::write(dir.path().join("theme.txt"), "DARK\n").unwrap();
+
+    let r = task(
+        dir.path(),
+        "cat slide.txt theme.txt > out.txt",
+        &["slide.txt"], // theme.txt deliberately omitted
+        &["out.txt"],
+    );
+    let recorded = apply_and_record(&r, dir.path());
+
+    let outcome = verify_hermetic("render", &r, Some(&recorded), scratch.path());
+    assert!(
+        matches!(outcome.verdict, Verdict::UndeclaredInput { .. }),
+        "reading an undeclared project file must be detected, got {:?}",
+        outcome.verdict
+    );
+    assert!(outcome.verdict.is_failure());
+}
+
+#[test]
+fn a_fully_declared_recipe_is_clean() {
+    // The gate must be passable, or it trains people to ignore it.
+    let dir = tempfile::tempdir().unwrap();
+    let scratch = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("slide.txt"), "SLIDE\n").unwrap();
+    std::fs::write(dir.path().join("theme.txt"), "DARK\n").unwrap();
+
+    let r = task(
+        dir.path(),
+        "cat slide.txt theme.txt > out.txt",
+        &["slide.txt", "theme.txt"], // both declared this time
+        &["out.txt"],
+    );
+    let recorded = apply_and_record(&r, dir.path());
+
+    let outcome = verify_hermetic("render", &r, Some(&recorded), scratch.path());
+    assert_eq!(
+        outcome.verdict,
+        Verdict::Reproduced,
+        "a fully-declared recipe must come back clean, got {:?}",
+        outcome.verdict
+    );
+}
+
+#[test]
+fn nondeterminism_is_reported_as_divergence_not_as_under_declaration() {
+    // THE DISCRIMINATION THAT MATTERS. A non-deterministic generator fails BOTH
+    // runs. Reporting that as an undeclared input would blame the declaration
+    // for a generator's own instability — which is exactly the misdiagnosis
+    // this feature exists to replace.
+    let dir = tempfile::tempdir().unwrap();
+    let scratch = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("in.txt"), "IN\n").unwrap();
+
+    let r = task(
+        dir.path(),
+        "date +%s%N > out.txt",
+        &["in.txt"],
+        &["out.txt"],
+    );
+    let recorded = apply_and_record(&r, dir.path());
+
+    let outcome = verify_hermetic("gen", &r, Some(&recorded), scratch.path());
+    assert!(
+        matches!(outcome.verdict, Verdict::Diverged { .. }),
+        "a non-deterministic recipe must stay `Diverged`, not be blamed on the \
+         declaration: {:?}",
+        outcome.verdict
+    );
+}
+
+#[test]
+fn a_recipe_that_cannot_run_without_the_undeclared_file_names_the_failure() {
+    // The sharper form: the recipe does not merely produce different bytes, it
+    // fails outright. The message must say WHY, not just "diverged".
+    let dir = tempfile::tempdir().unwrap();
+    let scratch = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("a.txt"), "A\n").unwrap();
+    std::fs::write(dir.path().join("required.txt"), "R\n").unwrap();
+
+    let r = task(
+        dir.path(),
+        "set -e; cat required.txt > /dev/null; cp a.txt out.txt",
+        &["a.txt"], // required.txt omitted
+        &["out.txt"],
+    );
+    let recorded = apply_and_record(&r, dir.path());
+
+    let outcome = verify_hermetic("needs", &r, Some(&recorded), scratch.path());
+    match outcome.verdict {
+        Verdict::UndeclaredInput { hermetic } => assert!(
+            hermetic.contains("task_inputs"),
+            "the message must point at the declaration: {hermetic}"
+        ),
+        other => panic!("expected UndeclaredInput, got {other:?}"),
+    }
+}
+
+// ── End to end, through the binary ──────────────────────────────────────
+//
+// These exist because the unit tests above passed while `--check-declared-inputs`
+// did NOTHING: the flag was parsed, the value was bound, and the call site still
+// called the non-hermetic path. A feature can be correct and unreachable, and
+// only a test that drives the binary can tell the difference.
+
+use std::process::Command;
+
+fn forjar() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_forjar"))
+}
+
+/// A project whose recipe reads `theme.txt` without declaring it.
+fn under_declared_project(dir: &Path, declare_theme: bool) -> std::path::PathBuf {
+    let work = dir.join("work");
+    std::fs::create_dir_all(&work).unwrap();
+    std::fs::write(work.join("slide.txt"), "SLIDE\n").unwrap();
+    std::fs::write(work.join("theme.txt"), "DARK\n").unwrap();
+    let inputs = if declare_theme {
+        r#"["slide.txt", "theme.txt"]"#
+    } else {
+        r#"["slide.txt"]"#
+    };
+    let cfg = dir.join("forjar.yaml");
+    std::fs::write(
+        &cfg,
+        format!(
+            r#"version: "1.0"
+name: ui
+machines:
+  local:
+    hostname: localhost
+    addr: 127.0.0.1
+resources:
+  render:
+    type: task
+    machine: local
+    working_dir: "{}"
+    cache: true
+    task_inputs: {inputs}
+    output_artifacts: ["out.txt"]
+    command: |
+      cat slide.txt theme.txt > out.txt
+"#,
+            work.display()
+        ),
+    )
+    .unwrap();
+    cfg
+}
+
+fn apply(cfg: &Path, state: &Path) {
+    let out = forjar()
+        .args([
+            "apply",
+            "-f",
+            cfg.to_str().unwrap(),
+            "--state-dir",
+            state.to_str().unwrap(),
+            "--no-tripwire",
+            "--yes",
+        ])
+        .output()
+        .expect("apply runs");
+    assert!(
+        out.status.success(),
+        "apply failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn verify(cfg: &Path, state: &Path, extra: &[&str]) -> (bool, String) {
+    let mut args = vec![
+        "verify",
+        "-f",
+        cfg.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+    ];
+    args.extend_from_slice(extra);
+    let out = forjar().args(&args).output().expect("verify runs");
+    (
+        out.status.success(),
+        format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        ),
+    )
+}
+
+#[test]
+fn the_flag_actually_changes_the_verdict() {
+    // THE WIRING TEST. Without the flag this reproduces; with it, the
+    // under-declaration is detected. If the flag were ignored — as it was on
+    // the first implementation — both runs would agree and this fails.
+    let dir = tempfile::tempdir().unwrap();
+    let state = dir.path().join("state");
+    std::fs::create_dir_all(&state).unwrap();
+    let cfg = under_declared_project(dir.path(), false);
+    apply(&cfg, &state);
+
+    let (plain_ok, plain) = verify(&cfg, &state, &[]);
+    assert!(plain_ok, "the full-tree run must reproduce:\n{plain}");
+
+    let (hermetic_ok, hermetic) = verify(&cfg, &state, &["--check-declared-inputs"]);
+    assert!(
+        !hermetic_ok,
+        "--check-declared-inputs must fail on an under-declared recipe:\n{hermetic}"
+    );
+    assert!(
+        hermetic.contains("UNDECLARED"),
+        "the verdict must name the problem:\n{hermetic}"
+    );
+    assert!(
+        hermetic.contains("theme.txt"),
+        "the message must name the file that was not declared:\n{hermetic}"
+    );
+}
+
+#[test]
+fn a_fully_declared_project_passes_the_flag() {
+    // The gate must be passable with the flag on, or nobody will turn it on.
+    let dir = tempfile::tempdir().unwrap();
+    let state = dir.path().join("state");
+    std::fs::create_dir_all(&state).unwrap();
+    let cfg = under_declared_project(dir.path(), true);
+    apply(&cfg, &state);
+
+    let (ok, out) = verify(&cfg, &state, &["--check-declared-inputs"]);
+    assert!(ok, "a fully-declared recipe must pass:\n{out}");
+    assert!(out.contains("1 reproduced"), "{out}");
+}


### PR DESCRIPTION
Closes #244. **Stacked on #263** (base is `feat/verify-reproducibility`) — this extends the verify machinery that PR adds.

## Why the current behaviour is worse than no cache

`staleness_reason` decides entirely from the **declared** set, so a change to an undeclared input yields `None` and plan/check/drift/apply all report a clean, converged stack over a stale artifact. Under-declaration converts *"no build system"* into *"a build system that lies"*.

## Mechanism: sandboxing-by-omission

Run the recipe twice — once from a full copy of `working_dir`, once from a tree containing only the glob-expanded `task_inputs` — and compare:

| full tree | declared only | verdict |
|---|---|---|
| reproduced | reproduced | `Reproduced` — nothing undeclared observed |
| reproduced | failed/diverged | **`UndeclaredInput`** |
| anything else | — | the full-tree verdict, unchanged |

No privileges, no `ptrace`, no `LD_PRELOAD` — the three mechanisms the issue weighs and calls *"inherently best-effort"*.

**The third row is the point.** A non-deterministic generator fails *both* runs; reporting that as an undeclared input would blame the declaration for a generator's own instability — exactly the misdiagnosis this replaces. `FALSIFY-UDI-002` pins it.

## Scope, stated plainly

This sees reads of files **inside the project tree**. It cannot see a read of `/usr/share/fonts` or a tool version, because those exist in the scratch tree too. That's the issue's option **(c)** — and the issue's own survey found a `data:` source of `type: command` already covers it. Nothing here should be read as *"the declaration is now proven complete."*

Also worth recording: the issue names option **(b)** — *"a `forjar verify` that re-runs the task into a scratch tree, hashes the outputs, and fails on mismatch"* — as *"the option we would consume first, because it is the one we can also run in CI."* That is #247, which this builds on.

## The bug my unit tests could not see

The first implementation parsed `--check-declared-inputs`, bound the value, and **still called the non-hermetic path**: `cargo fmt` had collapsed the call site my edit was matching, so the replacement silently did nothing. Four unit tests passed against a flag that did nothing at all.

Caught by running the binary, and now pinned by `the_flag_actually_changes_the_verdict`.

## The diagnosis names the file

It carries the recipe's own stderr:

```
UNDECLARED   render — reproduces from the full tree but not from
             its declared inputs alone: recipe fails with only task_inputs
             present (exit status: 1): cat: theme.txt: No such file or directory
```

## Verified

```
13020 lib tests
6 detection tests (4 unit + 2 end-to-end through the binary)
clippy --all-features --all-targets -D warnings clean
contracts/undeclared-input-detection-v1.yaml validates
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)