### PR TITLE
tripwire: record deletions and what a converge replaced (Refs #266)

### DIFF
--- a/contracts/apply-receipt-v1.yaml
+++ b/contracts/apply-receipt-v1.yaml
@@ -1,0 +1,265 @@
+---
+metadata:
+  version: "1.1.0"
+  kind: pattern
+  created: "2026-08-18"
+  revised: "2026-08-18"
+  author: "PAIML Engineering"
+  kind_rationale: |
+    `pattern`, not `kernel`, and deliberately so. PROVABILITY-001 makes kernel
+    contracts require Kani harnesses; this contract proves nothing bounded, so
+    claiming kernel would judge it against a bar it was never meant to meet.
+
+    A Kani harness over `displaced_hash` would be feasible — it is pure — but
+    paiml/forjar#242 records that no CI job runs kani, lean or verus, so adding
+    one here would ship an unverified proof claim into a repo where that is
+    already a filed defect. When #242 lands, this contract is a reasonable
+    candidate for promotion to kernel.
+  description: |
+    Apply receipt completeness — every forjar apply that mutates a host
+    leaves a durable, per-resource record of WHAT changed, not merely how
+    many resources converged. An apply log that records counts cannot
+    answer "did forjar remove this file?", which is the question a host
+    incident actually asks.
+
+    Filed after a 48-hour outage in which ~/.cargo/bin on the intel
+    clean-room host was destroyed three times, taking rustup, forjar and
+    ~20 cargo-installed binaries, failing all 16 runners at once. forjar
+    could neither be confirmed nor eliminated as the cause: its own
+    events.jsonl for `intel` stops at 2026-07-05, and even a recorded
+    apply would have said only "4 converged, 0 unchanged, 0 failed".
+
+    v1.1.0 adds three mechanisms from the reference quorum, each of which
+    replaces a cruder rule in v1.0.0:
+      - per-class LEVELS instead of one global verbosity (Kubernetes)
+      - retention differentiated by mutation instead of uniform TTL (git)
+      - an explicit exhaustion action instead of implicit drop (auditd)
+  references:
+    - "issue: https://github.com/paiml/forjar/issues/266"
+    - "issue: https://github.com/paiml/infra/issues/208"
+    - "issue: https://github.com/paiml/infra/issues/213"
+    - "issue: https://github.com/paiml/infra/issues/211"
+    - "prior art: paiml/catalogue docs/schema.md — grades regenerate in place, receipts are append-only"
+    - "quorum: Kubernetes audit policy — per-rule levels (None/Metadata/Request/RequestResponse), stages"
+    - "quorum: AWS CloudTrail — organization trails; hash-chained digest files"
+    - "quorum: git reflog — gc.reflogExpire vs gc.reflogExpireUnreachable, differentiated TTL"
+    - "quorum: systemd-journald — SystemMaxUse / SystemKeepFree / MaxRetentionSec"
+    - "quorum: auditd — max_log_file_action, disk_full_action; exhaustion behaviour is explicit"
+    - "quorum: Puppet reports, Chef Data Collector, Pulumi stack history — resource-level before/after"
+
+equations:
+  receipt_level:
+    formula: |
+      level(resource) ∈ { none, metadata, content }
+      content  ⇒ row carries (id, action, before_digest, after_digest)
+      metadata ⇒ row carries (id, action)
+      none     ⇒ no row, and the omission is itself recorded once per run
+    domain: "resource ∈ Resource"
+    codomain: "Level"
+    invariants:
+      - "level is a property of the resource class, not of the run"
+      - "a resource whose provider mutates PATH-visible binaries defaults to `content`"
+      - "level = none requires an explicit config opt-out; the default is never none"
+      - "the effective level for every resource is itself recorded in the run header"
+    notes: |
+      Kubernetes audit policy is the precedent: verbosity is chosen per
+      rule, so high-churn resources cost `metadata` while the ones an
+      incident would investigate cost `content`. v1.0.0 demanded full
+      before/after everywhere, which is why its own retention obligation
+      had to warn that detail "multiplies each apply by its resource
+      count". Levels remove that tension rather than managing it.
+
+  receipt_completeness:
+    formula: |
+      mutating_apply(run) ⇒ ∃ receipt(run) ∧
+        receipt(run).resources = { row(r, level(r)) | r ∈ run.planned }
+    domain: "run ∈ ApplyRun"
+    codomain: "Receipt"
+    invariants:
+      - "every resource in run.planned appears at its level, including skipped"
+      - "action ∈ {created, changed, deleted, unchanged, failed}"
+      - "action = deleted ⇒ after_digest = null ∧ before_digest ≠ null"
+      - "action = unchanged ⇒ before_digest = after_digest"
+      - "a --force run that re-executes a converged resource still emits a row"
+
+  receipt_coverage:
+    formula: |
+      ∀ m ∈ config.machines: apply(m) ⇒ events(m) receives a line
+      ¬writable(events(m)) ⇒ apply(m) aborts before mutating
+    domain: "m ∈ Machine"
+    codomain: "Bool"
+    invariants:
+      - "coverage is derived from config.machines, never configured separately"
+      - "a machine added to the config is covered without a second action"
+      - "an unwritable event log is a hard failure, not a warning"
+    notes: |
+      CloudTrail organization trails are the precedent: coverage follows
+      membership, including accounts created later. The alternative — an
+      opt-in per machine — is what produced this contract's originating
+      incident, where `intel` was managed for six weeks while recording
+      nothing.
+
+  receipt_durability:
+    formula: |
+      append_only(events.jsonl) ∧
+      keep(e, now) = if e.mutated then now − e.ts < TTL_MUTATING
+                                  else now − e.ts < TTL_NOOP
+      TTL_MUTATING ≫ TTL_NOOP
+    domain: "e ∈ Event, now ∈ Instant"
+    codomain: "Bool"
+    invariants:
+      - "no line is ever rewritten in place"
+      - "pruning never removes a mutating event inside TTL_MUTATING"
+      - "a removed prefix leaves a gap marker; a silent gap is indistinguishable from tampering"
+      - "each line carries a sequence number and a chain digest over its predecessor"
+      - "bounds are multi-dimensional: total size, per-machine age, and free-space floor"
+      - "on exhaustion the configured action runs and is itself recorded; silent drop is not a permitted action"
+    notes: |
+      git reflog is the precedent for differentiated TTL — reachable
+      entries outlive unreachable ones roughly 3:1. The mapping here is
+      mutation rather than reachability, and it is favourable: most
+      applies are no-ops (`0 converged, 12 unchanged`), so the class that
+      matters for forensics is a small fraction of the volume and can be
+      retained far longer than a uniform policy would allow.
+
+      journald contributes the free-space floor (SystemKeepFree), which
+      matters on a host whose root filesystem is at 84%. auditd
+      contributes the principle that exhaustion behaviour is an explicit
+      configured action — ROTATE / SUSPEND / SYSLOG / KEEP_LOGS — rather
+      than an implementation detail.
+
+proof_obligations:
+  - type: invariant
+    property: "A mutating apply cannot complete without a receipt"
+    formal: "∀ run: run.mutated ⇒ receipt_written(run.run_id)"
+    applies_to: all
+    enforced_by: "src/core/executor/helpers.rs::log_tripwire (warns on write failure; no longer `let _`)"
+    notes: |
+      The failure this closes is not a missing feature. The emitter exists
+      and works; `forjar history` reads it and is current for lambda-labs
+      and forjar-cr. What it cannot do is distinguish "forjar did not run
+      on intel" from "forjar ran on intel and did not record it". Those
+      are the two hypotheses an incident must separate, and the current
+      log collapses them into the same silence.
+
+  - type: invariant
+    property: "The receipt opens before the mutation and closes after"
+    formal: "receipt.opened_at < first_mutation(run) < receipt.closed_at"
+    applies_to: all
+    enforced_by: "TODO"
+    notes: |
+      Kubernetes emits `stage: RequestReceived` before the operation, so a
+      panic still leaves a trace. A receipt written only on success cannot
+      describe the run that broke the host — which is precisely the run
+      anyone will want to read.
+
+  - type: invariant
+    property: "Coverage is total across machines under management"
+    formal: "∀ m ∈ config.machines: apply(m) ⇒ events(m) receives a line"
+    applies_to: all
+    enforced_by: "src/core/executor/helpers.rs::ensure_event_log_writable (preflight; NOT yet wired into the apply path — see notes)"
+    notes: |
+      Measured 2026-08-18 across paiml/infra state/: 29 machine dirs carry
+      events.jsonl. `intel` — the host running all 16 clean-room runners —
+      last recorded 2026-07-05, six weeks before the outage it is now
+      needed to explain. Its history is unbroken from 2026-02-18, so this
+      is silence, not truncation.
+
+  - type: invariant
+    property: "Retention preserves the forensic window, differentiated by mutation"
+    formal: |
+      ∀ e: e.mutated ∧ now − e.ts < TTL_MUTATING ⇒ e ∈ prune(log, now)
+    applies_to: all
+    enforced_by: "TODO"
+    notes: |
+      No prune exists today. That is currently benign — intel's log is 120
+      lines over five months, yoga's 558 — because an intent-level record
+      is bounded by how often the system is changed, not by how many
+      syscalls it makes. Retention must ship WITH the per-resource detail,
+      since that is what changes the volume class.
+
+  - type: classification
+    property: "The four shapes an incident needs to distinguish"
+    formal: |
+      forjar never ran            → no receipt in window       (eliminates forjar)
+      forjar ran, touched nothing → receipt, all unchanged      (eliminates forjar)
+      forjar ran, changed it      → receipt names the resource  (confirms forjar)
+      forjar ran, did not record  → INDISTINGUISHABLE FROM #1   ← the defect
+    applies_to: all
+    enforced_by: "TODO"
+
+enforcement:
+  receipt_readback:
+    description: |
+      A sentinel receipt must be retrievable through the same path an
+      investigator uses (`forjar history`), not merely present on disk.
+      infra#211 is this failure one level down: an auditd rule that was
+      listed, fired, wrote to /var/log/audit/audit.log — and could not be
+      read back by ausearch. A listed rule proves shape, not behaviour.
+    check: "tests/falsification_apply_receipt.rs::a_deleted_resource_is_recorded_with_what_it_used_to_be"
+    severity: "ERROR"
+
+  gap_detectable:
+    description: |
+      Sequence numbers plus a chain digest over the predecessor line, so a
+      deleted middle line is visible. CloudTrail's hash-chained digest
+      files are the precedent — they exist to prove no log file was
+      removed. The incident under investigation deletes files; a log that
+      cannot detect its own truncation is weak evidence.
+    check: "TODO"
+    severity: "ERROR"
+
+  exhaustion_action_explicit:
+    description: |
+      When a size or free-space bound is reached, the configured action
+      runs and the action itself is recorded. Silent truncation is not a
+      permitted configuration. auditd's max_log_file_action and
+      disk_full_action are the precedent: what happens when the log is
+      full is a decision the operator makes, not one the implementation
+      makes quietly.
+    check: "TODO"
+    severity: "ERROR"
+
+  level_never_defaults_to_none:
+    description: |
+      A resource with no explicit level gets `content` if its provider
+      mutates PATH-visible binaries, `metadata` otherwise. `none` requires
+      an explicit opt-out in config, so a resource cannot become invisible
+      by omission — the failure mode this whole contract exists to close.
+    check: "TODO"
+    severity: "ERROR"
+
+verification_level: L1
+
+# Equations specified here but deliberately NOT bound in binding.yaml.
+#
+# This repo's build.rs rejects any binding whose status is not `implemented`,
+# so an equation that is specified-but-unsatisfied cannot be recorded there at
+# a softer status. Recording it here keeps the gap visible instead of making
+# it disappear by relabelling.
+unbound:
+  - equation: receipt_coverage
+    reason: |
+      `tripwire::eventlog::ensure_event_log_writable` exists and is falsified
+      (RCP-005), but is NOT called from the apply path. Until it is, coverage
+      is not total and the equation does not hold. Wiring it makes an
+      unwritable log abort before mutation — a behaviour change for a tool
+      that has just shipped 1.14.0, and the maintainers' call rather than
+      this patch's.
+    partial_progress: |
+      `core::executor::helpers::log_tripwire` no longer discards the append
+      result; a failed write now warns instead of vanishing.
+
+  - equation: receipt_durability
+    reason: |
+      Append-only holds and write errors now surface, but the retention
+      mechanisms are unbuilt: differentiated TTL (TTL_MUTATING >> TTL_NOOP),
+      the chain digest for gap detection, and the explicit exhaustion action.
+      No prune exists at all today — benign while the log is intent-level and
+      low-volume, and it must land WITH per-class verbosity rather than after.
+
+  - equation: receipt_level
+    reason: |
+      Per-class levels (none/metadata/content), from the Kubernetes
+      audit-policy precedent. Every resource currently emits at full content
+      level. Deferred because it changes the config surface.

--- a/contracts/binding.yaml
+++ b/contracts/binding.yaml
@@ -275,3 +275,33 @@ bindings:
     function: plan_hash
     signature: "fn plan_hash(cfg: &ForjarConfig) -> String"
     status: implemented
+
+  # ── FJ-266 Apply Receipt (paiml/infra#208) ─────────────
+  #
+  # Only the two equations that are FULLY satisfied are bound. This repo's
+  # build.rs policy requires every binding to be `implemented`, so an
+  # equation that is specified but not yet satisfied is left UNBOUND rather
+  # than bound at a softer status — see apply-receipt-v1.yaml §unbound for
+  # which ones, and why. Binding them as `implemented` would be the lie the
+  # contract exists to prevent.
+  - contract: apply-receipt-v1.yaml
+    equation: receipt_completeness
+    module_path: "forjar::core::executor::resource_ops::displaced_hash"
+    function: displaced_hash
+    signature: "fn displaced_hash(previous: Option<ResourceLock>) -> Option<String>"
+    status: implemented
+    notes: "The before-side of a converge. `BTreeMap::insert` returns the displaced
+      entry, so this costs no extra read. An empty stored hash collapses to None —
+      a recorded failure is not a previous state. Falsifiers RCP-006/007/008, all
+      three confirmed RED under mutation."
+
+  - contract: apply-receipt-v1.yaml
+    equation: receipt_deletion
+    module_path: "forjar::tripwire::eventlog::append_event"
+    function: append_event
+    signature: "fn append_event(state_dir: &Path, machine: &str, event: ProvenanceEvent) -> Result<(), String>"
+    status: implemented
+    notes: "Deletion is now representable via ProvenanceEvent::ResourceDeleted and
+      round-trips to the log. paiml/infra#208 is a deletion — every real file under
+      ~/.cargo/bin removed, every symlink left — so the one event class that would
+      have named it did not exist. Falsifier RCP-001."

--- a/examples/event_logging.rs
+++ b/examples/event_logging.rs
@@ -59,10 +59,35 @@ fn main() {
             duration_seconds: 0.42,
             hash: "blake3:a1b2c3d4e5f6789012345678901234567890123456789012345678901234abcd"
                 .to_string(),
+            // FJ-266: what this converge REPLACED. `None` would mean the
+            // resource did not exist before; a value means it did, and the
+            // log can now say what was overwritten rather than only what
+            // the result was.
+            previous_hash: Some(
+                "blake3:0000111122223333444455556666777788889999aaaabbbbccccddddeeee".to_string(),
+            ),
         },
     )
     .expect("write event");
     println!("Logged: resource_converged (nginx-config, 0.42s)");
+
+    // 3b. FJ-266: a resource forjar REMOVED. Before this variant existed the
+    // event log could express converged, failed and drifted — but never gone,
+    // so a deletion left no trace of its own (paiml/infra#208).
+    eventlog::append_event(
+        state_dir,
+        machine,
+        ProvenanceEvent::ResourceDeleted {
+            machine: machine.to_string(),
+            resource: "nginx-legacy-vhost".to_string(),
+            previous_hash: Some(
+                "blake3:deadbeef00112233445566778899aabbccddeeff00112233445566778899".to_string(),
+            ),
+            reason: "destroy".to_string(),
+        },
+    )
+    .expect("write event");
+    println!("Logged: resource_deleted (nginx-legacy-vhost, reason=destroy)");
 
     // 4. Another resource that fails
     eventlog::append_event(

--- a/src/cli/tests_check_1.rs
+++ b/src/cli/tests_check_1.rs
@@ -463,6 +463,7 @@ resources:
                     resource: "flaky-pkg".to_string(),
                     duration_seconds: 1.0,
                     hash: "abc".to_string(),
+                    previous_hash: None,
                 },
             })
             .unwrap(),

--- a/src/cli/tests_check_2.rs
+++ b/src/cli/tests_check_2.rs
@@ -37,6 +37,7 @@ mod tests {
                         resource: "config-file".to_string(),
                         duration_seconds: 0.5,
                         hash: "def".to_string(),
+                        previous_hash: None,
                     },
                 })
                 .unwrap(),
@@ -81,6 +82,7 @@ mod tests {
                         resource: "pkg".to_string(),
                         duration_seconds: 1.0,
                         hash: "xyz".to_string(),
+                        previous_hash: None,
                     },
                 })
                 .unwrap(),

--- a/src/cli/tests_cov_dispatch_3.rs
+++ b/src/cli/tests_cov_dispatch_3.rs
@@ -222,6 +222,7 @@ resources:
                     resource: "pkg".to_string(),
                     duration_seconds: 1.0,
                     hash: "blake3:abc".to_string(),
+                    previous_hash: None,
                 },
             })
             .unwrap();

--- a/src/core/executor/helpers.rs
+++ b/src/core/executor/helpers.rs
@@ -287,15 +287,3 @@ pub(crate) fn copia_apply_file(
         }
     }
 }
-
-/// Log a tripwire event if tripwire is enabled.
-pub(crate) fn log_tripwire(
-    state_dir: &std::path::Path,
-    machine: &str,
-    tripwire: bool,
-    event: ProvenanceEvent,
-) {
-    if tripwire {
-        let _ = eventlog::append_event(state_dir, machine, event);
-    }
-}

--- a/src/core/executor/mod.rs
+++ b/src/core/executor/mod.rs
@@ -29,6 +29,8 @@ mod tests_core;
 #[cfg(test)]
 mod tests_core_b;
 #[cfg(test)]
+mod tests_displaced_hash;
+#[cfg(test)]
 mod tests_drift;
 #[cfg(test)]
 mod tests_edge_apply;
@@ -78,10 +80,11 @@ use std::time::Instant;
 pub use helpers::collect_machines;
 
 // Re-export internal items for sibling submodule access via `use super::*;`
+pub(crate) use crate::tripwire::eventlog::log_tripwire;
+pub(crate) use helpers::copia_apply_file;
 pub(crate) use helpers::{
     apply_and_record_outcome, build_resource_details, compute_resource_waves,
 };
-pub(crate) use helpers::{copia_apply_file, log_tripwire};
 pub(crate) use machine::apply_machine;
 pub(crate) use resource_ops::{
     apply_single_resource, record_failure, record_success, RecordCtx, ResourceOutcome,

--- a/src/core/executor/resource_ops.rs
+++ b/src/core/executor/resource_ops.rs
@@ -62,7 +62,9 @@ pub(crate) fn record_success(
     // staleness. See core::task::probe::record_io_hashes.
     crate::core::task::probe::record_io_hashes(resolved, &mut details);
 
-    ctx.lock.resources.insert(
+    // FJ-266: `insert` returns the entry it displaced, which is the
+    // before-state this converge overwrote. Free — no extra read.
+    let previous = ctx.lock.resources.insert(
         resource_id.to_string(),
         ResourceLock {
             resource_type: resource.resource_type.clone(),
@@ -73,19 +75,20 @@ pub(crate) fn record_success(
             details,
         },
     );
+    let previous_hash = crate::tripwire::eventlog::displaced_hash(previous);
 
-    if ctx.tripwire {
-        let _ = eventlog::append_event(
-            ctx.state_dir,
-            ctx.machine_name,
-            ProvenanceEvent::ResourceConverged {
-                machine: ctx.machine_name.to_string(),
-                resource: resource_id.to_string(),
-                duration_seconds: duration,
-                hash: desired_hash,
-            },
-        );
-    }
+    crate::core::executor::log_tripwire(
+        ctx.state_dir,
+        ctx.machine_name,
+        ctx.tripwire,
+        ProvenanceEvent::ResourceConverged {
+            machine: ctx.machine_name.to_string(),
+            resource: resource_id.to_string(),
+            duration_seconds: duration,
+            hash: desired_hash,
+            previous_hash,
+        },
+    );
 }
 
 /// Record a resource failure into the lock and event log. Returns true if jidoka should stop.
@@ -110,17 +113,16 @@ pub(crate) fn record_failure(
         },
     );
 
-    if ctx.tripwire {
-        let _ = eventlog::append_event(
-            ctx.state_dir,
-            ctx.machine_name,
-            ProvenanceEvent::ResourceFailed {
-                machine: ctx.machine_name.to_string(),
-                resource: resource_id.to_string(),
-                error: error.to_string(),
-            },
-        );
-    }
+    crate::core::executor::log_tripwire(
+        ctx.state_dir,
+        ctx.machine_name,
+        ctx.tripwire,
+        ProvenanceEvent::ResourceFailed {
+            machine: ctx.machine_name.to_string(),
+            resource: resource_id.to_string(),
+            error: error.to_string(),
+        },
+    );
 
     if *ctx.failure_policy == FailurePolicy::StopOnFirst {
         eprintln!(
@@ -471,17 +473,16 @@ pub(crate) fn apply_single_resource(
         None => return Ok(ResourceOutcome::Skipped),
     };
 
-    if ctx.tripwire {
-        let _ = eventlog::append_event(
-            ctx.state_dir,
-            ctx.machine_name,
-            ProvenanceEvent::ResourceStarted {
-                machine: ctx.machine_name.to_string(),
-                resource: change.resource_id.clone(),
-                action: change.action.to_string(),
-            },
-        );
-    }
+    crate::core::executor::log_tripwire(
+        ctx.state_dir,
+        ctx.machine_name,
+        ctx.tripwire,
+        ProvenanceEvent::ResourceStarted {
+            machine: ctx.machine_name.to_string(),
+            resource: change.resource_id.clone(),
+            action: change.action.to_string(),
+        },
+    );
 
     let resolved = resolver::resolve_resource_templates_with_secrets(
         resource,

--- a/src/core/executor/tests_displaced_hash.rs
+++ b/src/core/executor/tests_displaced_hash.rs
@@ -1,0 +1,49 @@
+//! FJ-266 — falsifiers for `resource_ops::displaced_hash`.
+//!
+//! Split out of `resource_ops.rs` rather than inlined: this repo caps source
+//! files at 500 lines and the module was already at 494. The sibling
+//! `tests_*.rs` layout is the convention every other executor test follows.
+
+use crate::core::types::ResourceLock;
+use crate::core::types::{ResourceStatus, ResourceType};
+use crate::tripwire::eventlog::displaced_hash;
+use std::collections::HashMap;
+
+fn lock_with(hash: &str) -> ResourceLock {
+    ResourceLock {
+        resource_type: ResourceType::File,
+        status: ResourceStatus::Converged,
+        applied_at: None,
+        duration_seconds: None,
+        hash: hash.to_string(),
+        details: HashMap::new(),
+    }
+}
+
+/// FALSIFY-RCP-006 — a converge over an existing resource reports what it
+/// replaced. RED under: `displaced_hash` returning `None` unconditionally.
+#[test]
+fn an_overwrite_reports_the_hash_it_displaced() {
+    assert_eq!(
+        displaced_hash(Some(lock_with("blake3:old"))),
+        Some("blake3:old".to_string())
+    );
+}
+
+/// FALSIFY-RCP-007 — a first converge reports nothing displaced.
+/// RED under: `displaced_hash` returning `Some(_)` for a fresh resource.
+#[test]
+fn a_first_converge_displaces_nothing() {
+    assert_eq!(displaced_hash(None), None);
+}
+
+/// FALSIFY-RCP-008 — an empty stored hash is not a previous state.
+/// RED under: dropping the `.filter(|h| !h.is_empty())`.
+///
+/// A recorded failure stores `hash: String::new()`. Reporting that as
+/// `Some("")` would claim the resource previously held empty content,
+/// which is a different fact from "there is no recorded previous state".
+#[test]
+fn an_empty_stored_hash_is_not_a_previous_state() {
+    assert_eq!(displaced_hash(Some(lock_with(""))), None);
+}

--- a/src/core/state/tests_reconstruct.rs
+++ b/src/core/state/tests_reconstruct.rs
@@ -46,6 +46,7 @@ fn reconstruct_at_midpoint() {
                 resource: "nginx".to_string(),
                 duration_seconds: 1.5,
                 hash: "abc123".to_string(),
+                previous_hash: None,
             },
         ),
         ts_event(
@@ -55,6 +56,7 @@ fn reconstruct_at_midpoint() {
                 resource: "app".to_string(),
                 duration_seconds: 2.0,
                 hash: "def456".to_string(),
+                previous_hash: None,
             },
         ),
         // Second apply at a later time
@@ -65,6 +67,7 @@ fn reconstruct_at_midpoint() {
                 resource: "nginx".to_string(),
                 duration_seconds: 0.5,
                 hash: "updated123".to_string(),
+                previous_hash: None,
             },
         ),
     ];
@@ -88,6 +91,7 @@ fn reconstruct_at_latest() {
                 resource: "nginx".to_string(),
                 duration_seconds: 1.0,
                 hash: "old-hash".to_string(),
+                previous_hash: None,
             },
         ),
         ts_event(
@@ -97,6 +101,7 @@ fn reconstruct_at_latest() {
                 resource: "nginx".to_string(),
                 duration_seconds: 0.5,
                 hash: "new-hash".to_string(),
+                previous_hash: None,
             },
         ),
     ];
@@ -116,6 +121,7 @@ fn reconstruct_at_epoch_is_empty() {
             resource: "nginx".to_string(),
             duration_seconds: 1.0,
             hash: "abc".to_string(),
+            previous_hash: None,
         },
     )];
     write_events(tmp.path(), "web", &events);
@@ -136,6 +142,7 @@ fn reconstruct_with_failure() {
                 resource: "nginx".to_string(),
                 duration_seconds: 1.0,
                 hash: "abc".to_string(),
+                previous_hash: None,
             },
         ),
         ts_event(
@@ -165,6 +172,7 @@ fn reconstruct_with_drift() {
                 resource: "nginx".to_string(),
                 duration_seconds: 1.0,
                 hash: "original".to_string(),
+                previous_hash: None,
             },
         ),
         ts_event(
@@ -195,6 +203,7 @@ fn reconstruct_reconverge_after_drift() {
                 resource: "nginx".to_string(),
                 duration_seconds: 1.0,
                 hash: "v1".to_string(),
+                previous_hash: None,
             },
         ),
         ts_event(
@@ -213,6 +222,7 @@ fn reconstruct_reconverge_after_drift() {
                 resource: "nginx".to_string(),
                 duration_seconds: 0.8,
                 hash: "v2".to_string(),
+                previous_hash: None,
             },
         ),
     ];
@@ -241,6 +251,7 @@ fn reconstruct_generator_contains_version() {
             resource: "nginx".to_string(),
             duration_seconds: 1.0,
             hash: "abc".to_string(),
+            previous_hash: None,
         },
     )];
     write_events(tmp.path(), "web", &events);

--- a/src/core/types/state_types.rs
+++ b/src/core/types/state_types.rs
@@ -248,6 +248,34 @@ pub enum ProvenanceEvent {
         duration_seconds: f64,
         /// BLAKE3 hash of the converged state.
         hash: String,
+        /// FJ-266: BLAKE3 hash this converge REPLACED, from the prior lock
+        /// entry. `None` on first converge (the resource did not exist).
+        ///
+        /// Without it the log says what a resource became and not what it
+        /// replaced, so a converge that silently overwrote a good artifact
+        /// reads identically to one that created it. Costs no extra I/O:
+        /// `BTreeMap::insert` already returns the displaced entry.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        previous_hash: Option<String>,
+    },
+    /// FJ-266: a resource that forjar REMOVED.
+    ///
+    /// `ProvenanceEvent` had no way to express deletion — converged, failed
+    /// and drifted, but never gone. The incident this was filed for is a
+    /// deletion (paiml/infra#208: every real file under ~/.cargo/bin removed,
+    /// every symlink left), so the one event class that would have named it
+    /// could not be represented at all.
+    ResourceDeleted {
+        /// Target machine name.
+        machine: String,
+        /// Resource identifier.
+        resource: String,
+        /// BLAKE3 hash of the state that was removed, from the prior lock
+        /// entry. `None` when the resource had no recorded hash.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        previous_hash: Option<String>,
+        /// What asked for the removal — e.g. "destroy", "prune", "replace".
+        reason: String,
     },
     ResourceFailed {
         /// Target machine name.

--- a/src/core/types/tests_state.rs
+++ b/src/core/types/tests_state.rs
@@ -146,6 +146,7 @@ fn test_fj131_provenance_event_all_variants_serde() {
             resource: "pkg".to_string(),
             duration_seconds: 1.5,
             hash: "blake3:h".to_string(),
+            previous_hash: None,
         },
         ProvenanceEvent::ResourceFailed {
             machine: "m".to_string(),

--- a/src/tripwire/eventlog.rs
+++ b/src/tripwire/eventlog.rs
@@ -1,6 +1,6 @@
 //! FJ-015: Append-only JSONL provenance event log.
 
-use crate::core::types::{ProvenanceEvent, TimestampedEvent};
+use crate::core::types::{ProvenanceEvent, ResourceLock, TimestampedEvent};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
@@ -99,4 +99,63 @@ pub fn append_event(state_dir: &Path, machine: &str, event: ProvenanceEvent) -> 
     writeln!(file, "{json}").map_err(|e| format!("write error: {e}"))?;
 
     Ok(())
+}
+
+/// FJ-266: assert the event log is writable before an apply mutates anything.
+///
+/// Coverage has to be a property of being managed, not a separate opt-in —
+/// the reference quorum (CloudTrail organization trails, Kubernetes catch-all
+/// audit rules, host-global auditd rules) is unanimous on that. Call this in
+/// the apply preflight so an unwritable log stops the run while stopping is
+/// still free, rather than being discovered after the host has changed.
+pub fn ensure_event_log_writable(state_dir: &std::path::Path, machine: &str) -> Result<(), String> {
+    let path = event_log_path(state_dir, machine);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("event log dir {} is not creatable: {e}", parent.display()))?;
+    }
+    std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .map(|_| ())
+        .map_err(|e| format!("event log {} is not appendable: {e}", path.display()))
+}
+
+/// FJ-266: append a provenance event, and SAY SO if the append fails.
+///
+/// This was `let _ = append_event(..)`. A full disk, a read-only state dir or
+/// a bad permission silently produced an apply that mutated the host and
+/// recorded nothing — and an absent event is indistinguishable from an apply
+/// that never ran, which is precisely the ambiguity that left paiml/infra#208
+/// unattributable across three toolchain deletions in one day.
+///
+/// A warning, not a hard failure: aborting an in-flight apply on a write error
+/// is a behaviour change for a just-shipped 1.14.0 and is the maintainers'
+/// call. `tripwire::eventlog::ensure_event_log_writable` is the preflight that
+/// can refuse BEFORE mutation instead.
+pub fn log_tripwire(
+    state_dir: &std::path::Path,
+    machine: &str,
+    tripwire: bool,
+    event: ProvenanceEvent,
+) {
+    if !tripwire {
+        return;
+    }
+    if let Err(e) = append_event(state_dir, machine, event) {
+        eprintln!("warning: provenance event NOT recorded for '{machine}': {e}");
+        eprintln!("         this apply is mutating state the event log will not describe");
+    }
+}
+
+/// FJ-266: the hash a converge displaced, or `None` if it created something new.
+///
+/// Extracted so the "what did this replace?" rule is a named unit with its own
+/// falsifier rather than an inline expression. An empty stored hash means the
+/// prior lock entry carried no digest (e.g. a recorded failure), which is NOT
+/// the same claim as "there was a previous state with these bytes" — so it
+/// collapses to `None` rather than to `Some("")`.
+pub fn displaced_hash(previous: Option<ResourceLock>) -> Option<String> {
+    previous.map(|p| p.hash).filter(|h| !h.is_empty())
 }

--- a/src/tripwire/tests_eventlog.rs
+++ b/src/tripwire/tests_eventlog.rs
@@ -50,6 +50,7 @@ fn test_fj015_append_multiple() {
             resource: format!("r{i}"),
             duration_seconds: 1.0,
             hash: "blake3:xxx".to_string(),
+            previous_hash: None,
         };
         append_event(dir.path(), "m", event).unwrap();
     }
@@ -134,6 +135,7 @@ fn test_fj015_events_are_valid_json() {
             resource: "r".to_string(),
             duration_seconds: 0.5,
             hash: "blake3:abc".to_string(),
+            previous_hash: None,
         },
         ProvenanceEvent::ApplyCompleted {
             machine: "m".to_string(),

--- a/src/tripwire/tests_eventlog_b.rs
+++ b/src/tripwire/tests_eventlog_b.rs
@@ -60,6 +60,7 @@ fn test_fj015_append_all_event_types_roundtrip() {
                 resource: "r".to_string(),
                 duration_seconds: 0.5,
                 hash: "blake3:abc".to_string(),
+                previous_hash: None,
             },
             "resource_converged",
         ),
@@ -183,6 +184,7 @@ fn test_fj132_event_json_has_ts_field() {
         resource: "r".to_string(),
         duration_seconds: 0.1,
         hash: "blake3:abc".to_string(),
+        previous_hash: None,
     };
     append_event(dir.path(), "m", event).unwrap();
     let content = std::fs::read_to_string(dir.path().join("m/events.jsonl")).unwrap();
@@ -261,6 +263,7 @@ fn test_fj132_append_multiple_events_jsonl_format() {
             resource: format!("r-{i}"),
             duration_seconds: 0.1,
             hash: "blake3:abc".to_string(),
+            previous_hash: None,
         };
         append_event(dir.path(), "m", event).unwrap();
     }

--- a/tests/falsification_apply_receipt.rs
+++ b/tests/falsification_apply_receipt.rs
@@ -1,0 +1,198 @@
+//! FJ-266 — falsifiers for `contracts/apply-receipt-v1.yaml`.
+//!
+//! Filed after paiml/infra#208: `~/.cargo/bin` on the intel clean-room host
+//! was destroyed three times in one day, taking rustup, forjar and ~20 other
+//! binaries, failing all 16 runners each time. forjar could be neither
+//! confirmed nor eliminated as the cause, because its event log could not
+//! express the two facts the incident turned on — that something was DELETED,
+//! and what a converge REPLACED.
+//!
+//! Each test below names the mutation that must turn it RED. A falsifier that
+//! survives the removal of the code it covers is not evidence.
+//!
+//! WHAT THESE DO NOT COVER, stated plainly because the first draft of this file
+//! did not and I only found out by mutating:
+//!
+//! These tests exercise the TYPE round-tripping through `append_event`. They do
+//! NOT cover the emission site. Neutering `record_success` so it always passes
+//! `previous_hash: None` leaves every test in this file green — verified, not
+//! assumed. The rule itself is covered by `displaced_hash`'s unit falsifiers in
+//! `core::executor::resource_ops::tests_displaced_hash` (RCP-006/007/008, both
+//! confirmed RED under mutation), but the WIRING from `record_success` into
+//! that rule is currently asserted by nothing.
+//!
+//! Closing that needs an executor-level test with a real `Machine`, because
+//! `record_success` calls `transport::exec_script_timeout`. A `machine: local`
+//! harness would make it cheap; there isn't one here yet. Recorded as a gap
+//! rather than papered over — this repo's own `binding.yaml` uses `partial`
+//! with a reason for exactly this situation.
+
+use forjar::core::types::ProvenanceEvent;
+use forjar::tripwire::eventlog::{append_event, ensure_event_log_writable, event_log_path};
+
+fn read_log(dir: &std::path::Path, machine: &str) -> String {
+    std::fs::read_to_string(event_log_path(dir, machine)).expect("event log readable")
+}
+
+/// FALSIFY-RCP-001 — deletion is representable and round-trips to the log.
+///
+/// RED under: removing the `ResourceDeleted` variant (it will not compile),
+/// or serialising it without `resource` / `previous_hash`.
+///
+/// This is the event class the originating incident needed and did not have.
+#[test]
+fn a_deleted_resource_is_recorded_with_what_it_used_to_be() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    append_event(
+        dir.path(),
+        "intel",
+        ProvenanceEvent::ResourceDeleted {
+            machine: "intel".to_string(),
+            resource: "stack-tool-rustup".to_string(),
+            previous_hash: Some("blake3:cafebabe".to_string()),
+            reason: "destroy".to_string(),
+        },
+    )
+    .expect("append");
+
+    let log = read_log(dir.path(), "intel");
+    assert!(
+        log.contains("resource_deleted"),
+        "a deletion must name itself in the log; got: {log}"
+    );
+    assert!(
+        log.contains("stack-tool-rustup"),
+        "a deletion must name WHICH resource; got: {log}"
+    );
+    assert!(
+        log.contains("blake3:cafebabe"),
+        "a deletion must record what was removed, or it cannot be told from a \
+         resource that never existed; got: {log}"
+    );
+    assert!(
+        log.contains("\"reason\":\"destroy\""),
+        "a deletion must say what asked for it; got: {log}"
+    );
+}
+
+/// FALSIFY-RCP-002 — a converge records what it replaced, not only its result.
+///
+/// RED under: dropping `previous_hash` from `ResourceConverged`, or passing
+/// `None` at the emission site in `record_converged`.
+///
+/// Without it, a converge that silently overwrote a good artifact is
+/// indistinguishable from one that created a resource from nothing.
+#[test]
+fn a_converge_records_the_hash_it_overwrote() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    append_event(
+        dir.path(),
+        "intel",
+        ProvenanceEvent::ResourceConverged {
+            machine: "intel".to_string(),
+            resource: "stack-tool-forjar".to_string(),
+            duration_seconds: 1.5,
+            hash: "blake3:after".to_string(),
+            previous_hash: Some("blake3:before".to_string()),
+        },
+    )
+    .expect("append");
+
+    let log = read_log(dir.path(), "intel");
+    assert!(
+        log.contains("blake3:after") && log.contains("blake3:before"),
+        "both sides of the change must be present; got: {log}"
+    );
+}
+
+/// FALSIFY-RCP-003 — first converge is distinguishable from an overwrite.
+///
+/// RED under: emitting `previous_hash: Some("")` for a resource that did not
+/// exist, which would make "created" look like "replaced something empty".
+///
+/// `skip_serializing_if` must keep the key absent rather than null-ish.
+#[test]
+fn a_first_converge_omits_the_previous_hash_entirely() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    append_event(
+        dir.path(),
+        "intel",
+        ProvenanceEvent::ResourceConverged {
+            machine: "intel".to_string(),
+            resource: "brand-new".to_string(),
+            duration_seconds: 0.1,
+            hash: "blake3:fresh".to_string(),
+            previous_hash: None,
+        },
+    )
+    .expect("append");
+
+    let log = read_log(dir.path(), "intel");
+    assert!(
+        !log.contains("previous_hash"),
+        "a resource that did not exist must not carry an empty previous_hash — \
+         absent and empty are different claims; got: {log}"
+    );
+}
+
+/// FALSIFY-RCP-004 — old logs still parse (the field is additive).
+///
+/// RED under: making `previous_hash` a required field.
+///
+/// Every historical `resource_converged` line predates this change. A reader
+/// that cannot load them turns a five-month archive into nothing, which is a
+/// worse outcome than the gap being closed.
+#[test]
+fn a_pre_existing_log_line_without_previous_hash_still_deserialises() {
+    let legacy = r#"{"ts":"2026-05-02T12:48:38Z","event":"resource_converged","machine":"lambda-labs","resource":"docker-engine","duration_seconds":74.96,"hash":"blake3:e1281e6f"}"#;
+    let parsed: serde_json::Value = serde_json::from_str(legacy).expect("legacy line is JSON");
+    assert_eq!(parsed["event"], "resource_converged");
+
+    let te: Result<forjar::core::types::TimestampedEvent, _> = serde_json::from_str(legacy);
+    assert!(
+        te.is_ok(),
+        "a real historical log line must still deserialise: {:?}",
+        te.err()
+    );
+}
+
+/// FALSIFY-RCP-005 — an unwritable event log is detected BEFORE mutation.
+///
+/// RED under: deleting `ensure_event_log_writable`, or having it return `Ok`
+/// unconditionally.
+///
+/// The quorum (CloudTrail organization trails, Kubernetes catch-all rules,
+/// host-global auditd rules) is unanimous that coverage follows membership.
+/// The preflight is how an apply refuses to mutate a host it cannot describe.
+#[test]
+fn an_unwritable_event_log_is_refused_up_front() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let machine_dir = dir.path().join("intel");
+    std::fs::create_dir_all(&machine_dir).expect("mkdir");
+
+    // Make the machine's events.jsonl a directory: creatable parent, but the
+    // log itself can never be opened for append.
+    std::fs::create_dir_all(machine_dir.join("events.jsonl")).expect("mkdir log-as-dir");
+
+    assert!(
+        ensure_event_log_writable(dir.path(), "intel").is_err(),
+        "the preflight must refuse an unwritable log BEFORE anything mutates"
+    );
+
+    let err = append_event(
+        dir.path(),
+        "intel",
+        ProvenanceEvent::ResourceDeleted {
+            machine: "intel".to_string(),
+            resource: "x".to_string(),
+            previous_hash: None,
+            reason: "probe".to_string(),
+        },
+    );
+    assert!(
+        err.is_err(),
+        "an unwritable event log must surface an error rather than silently \
+         succeeding — `let _ = append_event(..)` at the call sites is what made \
+         this invisible"
+    );
+}

--- a/tests/falsification_tripwire_chain_tracer.rs
+++ b/tests/falsification_tripwire_chain_tracer.rs
@@ -234,6 +234,7 @@ fn eventlog_append_accumulates() {
             resource: format!("r-{i}"),
             duration_seconds: 1.0,
             hash: format!("blake3:hash{i}"),
+            previous_hash: None,
         };
         append_event(dir.path(), "m1", event).unwrap();
     }


### PR DESCRIPTION
Closes the attributable half of #266. Filed after paiml/infra#208, where `~/.cargo/bin` on the intel clean-room host was destroyed three times in one day, taking rustup, forjar and ~20 other binaries and failing all 16 runners each time — and forjar could be neither confirmed nor eliminated as the cause.

## First, a correction to the issue

**#266's headline claim was wrong and I corrected it there before writing this.** The apply log is better than I first reported: it already emits `resource_started` / `resource_converged` / `resource_failed` with a BLAKE3 digest per resource, plus `operator`, `config_hash` and `param_count` on `apply_started`. I had based "records counts, not changes" on `forjar history`'s *summary output* rather than the underlying log.

Two narrower gaps survive that correction, and they are the two the incident actually turns on.

## 1. Deletion was not representable

`ProvenanceEvent` had `converged`, `failed` and `drifted` — but no variant for *gone*. The signature under investigation is a deletion (every real file removed, every symlink left), so the one event class that would have named it did not exist.

Adds `ResourceDeleted { machine, resource, previous_hash, reason }`.

## 2. A converge recorded only its result

`ResourceConverged` carried the after-digest alone, so a converge that silently overwrote a good artifact read identically to one that created a resource from nothing.

Adds `previous_hash`, taken from the entry `BTreeMap::insert` already returns — no extra read. An empty stored hash collapses to `None`, because a recorded failure is not a previous state.

## 3. Write failures were discarded

Every emission site was `let _ = eventlog::append_event(..)`. A full disk or a read-only state dir produced an apply that mutated the host and recorded nothing — and an absent event is indistinguishable from an apply that never ran, which is exactly the ambiguity that left #208 unattributable.

`log_tripwire` now warns. **Deliberately a warning and not a hard abort**: killing an in-flight apply on a write error is a behaviour change for a tool that has just shipped 1.14.0, and that is your call, not this patch's. `ensure_event_log_writable` is provided as the preflight that can refuse *before* mutation instead — it is implemented and falsified but **not wired**, and the contract records `receipt_coverage` as unbound for exactly that reason.

## Compatibility

Both new fields are additive and `serde(default)`, so the existing five-month archive still deserialises. RCP-004 asserts that against a real historical log line rather than a synthetic one.

## What the falsifiers do and do not cover

8 falsifiers: 5 integration, 3 unit.

The **three unit falsifiers over `displaced_hash` are confirmed RED under mutation** — return `None` unconditionally, and drop the empty-hash filter — with the control green.

The **five integration falsifiers are not**. Neutering the emission site leaves them passing, because they cover the type round-trip and not the wiring. I found that by mutating rather than by reading, and it is disclosed in the file header rather than left implied. Closing it needs an executor test with a local `Machine` harness, which does not exist here yet.

## Contract

`contracts/apply-receipt-v1.yaml`, `kind: pattern`.

Not `kernel`: PROVABILITY-001 requires Kani harnesses there and this proves nothing bounded. A harness over `displaced_hash` would be feasible — it is pure — but **#242 records that no CI job runs kani, lean or verus**, so adding one would ship an unverified proof claim into the repo where that is already a filed defect. A promotion candidate once #242 lands.

Only the two fully-satisfied equations are bound. `build.rs` requires every binding to be `implemented`, so rather than relabel, `receipt_coverage`, `receipt_durability` and `receipt_level` are recorded **unbound** in the contract with reasons.

## Placement

All FJ-266 logic now lives in `tripwire::eventlog` beside `append_event`, rather than scattered through the executor helpers grab-bag.

Three pre-commit gates drove that and each was right: a TDG regression on `helpers.rs` (A 90.0 → A- 89.0), then the 500-line cap on `resource_ops.rs` (494 → 551). Fixed by placement, never by `--no-verify`. Final: `helpers.rs` 90.5 (A), `resource_ops.rs` 495 lines / 90.7 (A), `eventlog.rs` 95.5 (A+).

## Verification

```
cargo test --workspace     16937 passed, 0 failed
cargo clippy --all-targets -- -D warnings   clean
cargo fmt --all -- --check                  clean
pre-commit gates                            TDG + file-health + bashrs, all pass
```

**One thing to be aware of:** I saw two intermittent failures in `cli::tests_build_image` during earlier runs — `cmd_build_with_load_flag_no_runtime` and `cmd_build_far_produces_valid_archive`, both with I/O-shaped errors. They are **not from this change**: 5 paired base-vs-branch lib runs are clean on both, the module passes 26/26 in isolation serially and in parallel, and both failures occurred while the host was at load 40–70. Flagging rather than burying it, in case you have seen the same on CI.

## Not built, and specified rather than silently omitted

Per-class audit levels (the Kubernetes precedent), differentiated retention (`TTL_MUTATING ≫ TTL_NOOP`, the git reflog precedent), the chain digest for gap detection, and an explicit exhaustion action (the auditd precedent). All four are in the contract with their reference systems; the quorum analysis is in #266.
