### PR TITLE
fix(moved): the rule rejected the feature's only correct usage

### DIFF
--- a/src/core/parser/mod.rs
+++ b/src/core/parser/mod.rs
@@ -296,17 +296,11 @@ pub fn parse_and_validate_opts(path: &Path, deny_unknown: bool) -> Result<Forjar
     // set. validate_config ran before expansion, so a `to` that lands on a
     // recipe-expanded key (e.g. `recipe_id/foo`) would otherwise pass and then
     // silently clobber that expanded resource's converged lock.
-    let post_errors = crate::core::planner::moved::validate_moved_targets(&config);
-    if !post_errors.is_empty() {
-        return Err(format!(
-            "validation errors:\n{}",
-            post_errors
-                .iter()
-                .map(|e| format!("  - {e}"))
-                .collect::<Vec<_>>()
-                .join("\n")
-        ));
-    }
+    // #165's post-expansion `moved.to` collision re-check is gone with the
+    // config-time check it duplicated: `to` naming a declared resource is the
+    // required shape of a rename, not a collision. The genuinely destructive
+    // case — the LOCK already holding `to` — is detected in `rename_lock`,
+    // which has the state this function does not.
 
     Ok(config)
 }

--- a/src/core/planner/moved.rs
+++ b/src/core/planner/moved.rs
@@ -3,9 +3,13 @@
 //! `moved` entries declaratively rename resource keys in lock state so a
 //! rename does not show up as destroy+create in the plan. They must be applied
 //! as an atomic permutation: chained (`a→b`, `b→c`) or colliding (`x→z`,
-//! `y→z`) moves must never silently overwrite existing lock state. Colliding /
-//! chained moves are rejected at validate time; `apply_moved_blocks` then
-//! resolves the remaining entries in a single pass into a fresh map.
+//! `y→z`) moves must never silently overwrite existing lock state.
+//!
+//! What is decidable WHERE matters here, and getting it wrong made the feature
+//! unusable. From config alone you can decide: `from == to`, duplicate `from`,
+//! duplicate `to`, and chains. You CANNOT decide whether a rename would clobber
+//! converged state — that is a fact about the lock. A `to` that names a declared
+//! resource is the REQUIRED shape of a rename, not a collision.
 
 use crate::core::parser::ValidationError;
 use crate::core::types::*;
@@ -59,6 +63,34 @@ fn rename_lock(moved: &[MovedEntry], lock: &StateLock, machine: &str) -> StateLo
             }
             None => id.clone(),
         };
+        // THE REAL COLLISION, and the only place it is decidable.
+        //
+        // Validation cannot see this: `moved: a → b` with `b` also declared in
+        // config is the CANONICAL rename and perfectly safe when the lock holds
+        // no `b`. It is destructive only when the lock holds BOTH — which is
+        // state, not config. The old config-time check could not tell those
+        // apart and so rejected every correct use of the feature.
+        //
+        // Losing an entry here would silently discard a resource's converged
+        // state, so it is loud and it keeps the MOVED entry (the declared
+        // intent) rather than whichever happened to be iterated last.
+        if let Some(existing) = new_lock.resources.get(&new_key) {
+            let moved_in = rename.contains_key(id.as_str());
+            eprintln!(
+                "warning: moved target '{new_key}' on {machine} already holds state \
+                 (hash {}); {} entry kept. Remove the stale resource or pick a \
+                 different target — two resources cannot share one state key.",
+                &existing.hash.chars().take(12).collect::<String>(),
+                if moved_in {
+                    "the moved"
+                } else {
+                    "the existing"
+                }
+            );
+            if !moved_in {
+                continue;
+            }
+        }
         new_lock.resources.insert(new_key, rl.clone());
     }
     new_lock
@@ -105,12 +137,23 @@ pub(crate) fn validate_moved_blocks(config: &ForjarConfig, errors: &mut Vec<Vali
                 "moved block has colliding 'to: {to}' — two moves target the same resource id"
             )));
         }
-        // Collision with a managed resource whose own state we'd clobber. A
-        // `to` that is itself being moved away (`to` ∈ froms) is a chain, not
-        // a destructive collision, and is reported separately below.
-        if managed_collision(to, &config.resources, &froms) {
-            errors.push(managed_collision_err(to));
-        }
+        // NO config-time "collides with an existing resource" check here.
+        //
+        // It used to reject `to` whenever the config declared a resource by
+        // that name — which is the CANONICAL usage and the only correct one:
+        // after a rename the resource IS declared under its new name, and a
+        // `to` that is not declared would point the rename at nothing.
+        //
+        // The stated concern ("would overwrite its converged state") is a claim
+        // about the LOCK, and config-contains-`to` cannot decide it:
+        //
+        //   canonical rename   config has `to`: YES   lock has `to`: no   safe
+        //   genuine clobber    config has `to`: YES   lock has `to`: YES  destructive
+        //
+        // True in both, so it discriminated nothing and forbade the feature's
+        // only working shape — paiml/forjar-cookbook recipes/34-moved-blocks.yaml
+        // (the documented example) failed validation. The real collision is
+        // detected against the lock in `rename_lock`, which has it.
         // Chained move: this entry's `to` is some other entry's `from`.
         if to != from && froms.contains(to) {
             errors.push(err(format!(
@@ -122,54 +165,14 @@ pub(crate) fn validate_moved_blocks(config: &ForjarConfig, errors: &mut Vec<Vali
     }
 }
 
-/// #165: Re-check `moved.to` collisions against the POST-expansion resource
-/// set so a `to` that lands on a recipe-expanded key is rejected too.
-///
-/// [`validate_moved_blocks`] runs at validate time, before `expand_recipes` /
-/// `expand_resources` insert namespaced keys (`recipe_id/foo`). A `moved.to`
-/// equal to such a key would pass validation and then clobber the expanded
-/// resource's converged lock. This runs against the fully expanded
-/// `config.resources` and reports any collision (deduped per `to`).
-pub(crate) fn validate_moved_targets(config: &ForjarConfig) -> Vec<ValidationError> {
-    let moved = &config.moved;
-    if moved.is_empty() {
-        return Vec::new();
-    }
-
-    let froms: std::collections::HashSet<&str> = moved.iter().map(|m| m.from.as_str()).collect();
-    let mut errors = Vec::new();
-    let mut reported: std::collections::HashSet<&str> = std::collections::HashSet::new();
-
-    for entry in moved {
-        let to = entry.to.as_str();
-        if reported.contains(to) {
-            continue;
-        }
-        if managed_collision(to, &config.resources, &froms) {
-            reported.insert(to);
-            errors.push(managed_collision_err(to));
-        }
-    }
-    errors
-}
-
-/// True when `to` would rename onto a managed resource and overwrite its
-/// converged state. A `to` that is itself being moved away (`to` ∈ `froms`)
-/// is a chain, not a destructive collision.
-fn managed_collision(
-    to: &str,
-    resources: &indexmap::IndexMap<String, Resource>,
-    froms: &std::collections::HashSet<&str>,
-) -> bool {
-    resources.contains_key(to) && !froms.contains(to)
-}
-
-fn managed_collision_err(to: &str) -> ValidationError {
-    err(format!(
-        "moved 'to: {to}' collides with existing resource '{to}' — \
-         renaming onto a managed resource would overwrite its converged state"
-    ))
-}
+// #165's `validate_moved_targets` is removed: it re-ran the config-time
+// collision check against the POST-expansion resource set, so a `moved.to`
+// landing on a recipe-expanded key (`recipe_id/foo`) was rejected too.
+//
+// It went with the check it duplicated. The premise — that `to` naming a
+// declared resource is destructive — is false; that is the required shape of a
+// rename, expanded keys included. Such a `to` is destructive only when the LOCK
+// already holds the key, which `rename_lock` now detects with the state in hand.
 
 fn err(message: String) -> ValidationError {
     ValidationError { message }
@@ -329,18 +332,28 @@ mod tests {
     }
 
     #[test]
-    fn validate_rejects_to_colliding_with_managed_resource() {
-        // `to: existing` where `existing` is a real managed resource → would
-        // overwrite its converged state.
+    fn validate_accepts_to_naming_the_renamed_resource() {
+        // INVERTED from what this test used to assert.
+        //
+        // It required an error when `to` named a declared resource — which is
+        // the REQUIRED shape of a rename: after `old → existing`, the resource
+        // IS declared as `existing`. A `to` that is not declared would point
+        // the rename at nothing and the resource would be destroyed.
+        //
+        // The old error claimed the rename "would overwrite its converged
+        // state", which is a fact about the LOCK. Config-contains-`to` is true
+        // both when the lock holds `to` (destructive) and when it does not
+        // (the normal rename), so it decided nothing and forbade the feature's
+        // only working shape. forjar's own cookbook example
+        // (recipes/34-moved-blocks.yaml) failed validation because of it.
         let yaml = format!(
             "{HEADER}resources:\n  existing:\n    type: file\n    path: /tmp/e\n    content: x\n\
              moved:\n  - from: old\n    to: existing\n"
         );
         let errs = errors_for(&yaml);
         assert!(
-            errs.iter()
-                .any(|m| m.contains("collides with existing resource 'existing'")),
-            "expected managed-collision error, got {errs:?}"
+            errs.is_empty(),
+            "the canonical rename must validate, got {errs:?}"
         );
     }
 
@@ -408,16 +421,17 @@ mod tests {
     }
 
     #[test]
-    fn validate_rejects_to_colliding_with_recipe_expanded_key() {
-        // `to: setup/config-file` only EXISTS after recipe expansion. Before
-        // #165 the pre-expansion collision check missed it; now the parser
-        // re-checks against the post-expansion resource set and rejects it.
+    fn validate_accepts_to_naming_a_recipe_expanded_key() {
+        // Same inversion, post-expansion (#165). `to: setup/config-file` names
+        // a key that exists only after recipe expansion — which is exactly what
+        // renaming a recipe-produced resource looks like, not a collision.
         let result =
             parse_and_validate_with_recipe("moved:\n  - from: old\n    to: setup/config-file\n");
-        let err = result.expect_err("collision with expanded recipe key must be rejected");
         assert!(
-            err.contains("collides with existing resource 'setup/config-file'"),
-            "expected post-expansion managed-collision error, got: {err}"
+            result.is_ok(),
+            "a rename onto an expanded key must validate; the destructive case \
+             (the LOCK already holding it) is caught in rename_lock: {:?}",
+            result.err()
         );
     }
 

--- a/tests/falsification_moved_allows_the_canonical_rename.rs
+++ b/tests/falsification_moved_allows_the_canonical_rename.rs
@@ -1,0 +1,126 @@
+//! A `moved` block whose `to` is the renamed resource must VALIDATE.
+//!
+//! THE BUG.
+//!
+//! `moved` exists to rename a resource without a destroy+create cycle. The
+//! canonical usage — the only usage, really — is:
+//!
+//!     moved:
+//!       - from: webserver-pkg
+//!         to:   nginx-web
+//!     resources:
+//!       nginx-web: { ... }        # the SAME resource, under its new name
+//!
+//! The `to` target MUST be declared in config; otherwise the rename points at
+//! nothing and the resource would be destroyed. That is how OpenTofu/Terraform
+//! `moved` blocks work and how forjar's own cookbook documents them
+//! (paiml/forjar-cookbook recipes/34-moved-blocks.yaml).
+//!
+//! `validate_moved_blocks` rejected exactly that:
+//!
+//!     moved 'to: nginx-web' collides with existing resource 'nginx-web' —
+//!     renaming onto a managed resource would overwrite its converged state
+//!
+//! WHY THE CHECK CANNOT WORK WHERE IT SITS.
+//!
+//! "Overwrite its converged state" is a claim about the LOCK. The check tests
+//! `config.resources`. Those differ precisely where it matters:
+//!
+//!     canonical rename   config has `to`: YES   lock has `to`: no    safe
+//!     genuine clobber    config has `to`: YES   lock has `to`: YES   destructive
+//!
+//! Config-contains-`to` is true in BOTH, so it cannot discriminate — and since
+//! the safe case is the normal case, the rule rejects every correct use of the
+//! feature. It is a proxy standing in for the thing it means to test, which is
+//! the same shape as `mountpoint -q` standing in for "the declared filesystem
+//! is mounted".
+//!
+//! The real collision is detectable only against the lock, which validation
+//! does not have. `apply_moved_blocks` does, and defends there.
+//!
+//! The rule WAS tested — by two tests asserting it rejects the canonical
+//! rename (`validate_rejects_to_colliding_with_managed_resource` and its
+//! post-expansion twin from #165). They passed for as long as the rule existed
+//! and encoded its premise as the expected result, which is how a rule
+//! forbidding its feature's only correct usage shipped in 1.15.0. Both are now
+//! inverted. A test can only guard behaviour someone questioned first.
+
+use forjar::core::parser::validate_config;
+
+fn cfg(moved: &str, resources: &str) -> String {
+    format!(
+        r#"version: "1.0"
+name: t
+machines:
+  m: {{ hostname: h, addr: 127.0.0.1 }}
+{moved}
+resources:
+{resources}
+"#
+    )
+}
+
+#[test]
+fn the_canonical_rename_validates() {
+    // THE REGRESSION. This is the documented pattern and the cookbook's own
+    // recipe 34. It must not be an error.
+    let yaml = cfg(
+        "moved:\n  - from: webserver-pkg\n    to: nginx-web\n",
+        "  nginx-web:\n    type: file\n    machine: m\n    path: /tmp/x\n    content: \"y\"\n",
+    );
+    let config: forjar::core::types::ForjarConfig =
+        serde_yaml_ng::from_str(&yaml).expect("fixture must parse");
+    let errors = validate_config(&config);
+    assert!(
+        errors.is_empty(),
+        "the canonical moved-block rename must validate — `to` is REQUIRED to be \
+         a declared resource, or the rename points at nothing.\nerrors: {:?}",
+        errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn a_no_op_move_is_still_rejected() {
+    // The gate must keep catching what it legitimately caught.
+    let yaml = cfg(
+        "moved:\n  - from: same\n    to: same\n",
+        "  same:\n    type: file\n    machine: m\n    path: /tmp/x\n    content: \"y\"\n",
+    );
+    let config: forjar::core::types::ForjarConfig =
+        serde_yaml_ng::from_str(&yaml).expect("fixture must parse");
+    assert!(
+        !validate_config(&config).is_empty(),
+        "from == to is a no-op and must still be rejected"
+    );
+}
+
+#[test]
+fn two_moves_onto_one_target_are_still_rejected() {
+    // x→z and y→z would clobber in the lock regardless of config, and that IS
+    // decidable from config alone. It must keep failing.
+    let yaml = cfg(
+        "moved:\n  - from: a\n    to: z\n  - from: b\n    to: z\n",
+        "  z:\n    type: file\n    machine: m\n    path: /tmp/x\n    content: \"y\"\n",
+    );
+    let config: forjar::core::types::ForjarConfig =
+        serde_yaml_ng::from_str(&yaml).expect("fixture must parse");
+    assert!(
+        !validate_config(&config).is_empty(),
+        "two moves onto one target must still be rejected"
+    );
+}
+
+#[test]
+fn a_chain_is_still_rejected() {
+    // a→b, b→c is order-dependent and must stay an error.
+    let yaml = cfg(
+        "moved:\n  - from: a\n    to: b\n  - from: b\n    to: c\n",
+        "  c:\n    type: file\n    machine: m\n    path: /tmp/x\n    content: \"y\"\n",
+    );
+    let config: forjar::core::types::ForjarConfig =
+        serde_yaml_ng::from_str(&yaml).expect("fixture must parse");
+    assert!(
+        !validate_config(&config).is_empty(),
+        "chained moves must still be rejected"
+    );
+}


### PR DESCRIPTION
`moved` blocks rename a resource without a destroy+create cycle. The canonical — and only — usage is:

```yaml
moved:
  - from: webserver-pkg
    to:   nginx-web
resources:
  nginx-web: { ... }        # the SAME resource, under its new name
```

`to` **must** be declared, or the rename points at nothing and the resource is destroyed. `validate_moved_blocks` rejected exactly that:

```
moved 'to: nginx-web' collides with existing resource 'nginx-web' —
renaming onto a managed resource would overwrite its converged state
```

## Why the check could not work where it sat

*"Overwrite its converged state"* is a claim about the **lock**. The check tested **`config.resources`**. Those differ precisely where it matters:

| | config has `to` | lock has `to` | |
|---|---|---|---|
| canonical rename | **yes** | no | safe |
| genuine clobber | **yes** | **yes** | destructive |

Config-contains-`to` is true in **both**, so it discriminated nothing — and since the safe case is the *normal* case, the rule forbade every correct use of the feature. A proxy standing in for the thing it means to test: the same shape as `mountpoint -q` standing in for *"the declared filesystem is mounted"*.

## Found from the consuming side

`paiml/forjar-cookbook`'s `validate-recipes` job fails on `recipes/34-moved-blocks.yaml` — **forjar's own documented example of the feature** — at 97/98 recipes passing.

## The fix

- Config-time check removed.
- The real collision (the lock already holding `to`) is detected in `rename_lock`, which has the state and is where the clobber would actually occur. It now reports loudly and keeps the **moved** entry — the declared intent — rather than whichever key happened to be iterated last.
- `validate_moved_targets` (#165) went with it: it re-ran the same check post-expansion, so a `to` landing on a recipe-expanded key was rejected too. Same false premise, wider blast radius.

What validation *can* decide from config alone is unchanged and still enforced: `from == to`, duplicate `from`, duplicate `to`, and chains. All three have controls in the new test file.

## Two tests asserted the wrong behaviour

`validate_rejects_to_colliding_with_managed_resource` and its post-expansion twin **required** the error. They passed for as long as the rule existed and encoded its premise as the expected result. Both are inverted here.

I initially reported this rule as having *no* test coverage. That was wrong — it had two, and they are precisely why it survived. A test can only guard behaviour someone questioned first.

## Verification

`core::planner::moved` 12/12, new falsification suite 4/4, `cargo test --lib` 12,943 passing. fmt, clippy `-D warnings`, all quality gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)