### PR TITLE
fix(validate): load the config before dispatching to sub-checks

### DIFF
--- a/src/cli/dispatch_validate_b.rs
+++ b/src/cli/dispatch_validate_b.rs
@@ -207,13 +207,16 @@ pub(crate) fn dispatch_validate(args: ValidateArgs) -> Result<(), String> {
     // a schema version that was never consulted.
     super::inert_flags::reject_inert_flag("--schema-version", _schema_version.is_some())?;
 
-    // FJ-2500 / GH-272: unknown fields are errors. This used to be an inline
-    // copy of the check here, which is exactly how validate and every other
-    // verb came to disagree about whether the same file was valid — two
-    // implementations, one of them permissive. `parse_and_validate` now denies
-    // by default, so the check lives in ONE place and validate inherits it
-    // rather than reimplementing it. The flag is kept for backward compat.
+    // FJ-2500 / GH-272: unknown fields are errors. This was an inline copy of
+    // the check, which is how validate and every other verb came to disagree
+    // about whether the same file was valid. `parse_and_validate` now denies,
+    // so validate inherits the rule instead of reimplementing it — and loading
+    // here, BEFORE dispatch, covers every sub-check rather than only the ones
+    // that happen to load the config themselves. `--check-recipe-purity` reads
+    // raw YAML by design (purity keys are not typed fields) and so consulted
+    // no validation at all; it was the inline copy that had been masking that.
     let _ = deny_unknown_fields; // always true for validate
+    crate::core::parser::parse_and_validate(&file)?;
 
     // FJ-2503: --deep runs all deep checks in a single aggregated pass
     if deep {

--- a/tests/falsification_unknown_field_is_rejected_everywhere.rs
+++ b/tests/falsification_unknown_field_is_rejected_everywhere.rs
@@ -198,6 +198,34 @@ fn codegen_rejects_the_unknown_field_too() {
     );
 }
 
+/// `validate --check-recipe-purity` reads the raw YAML directly, because purity
+/// keys like `sandbox` are not typed resource fields. That made it the one path
+/// where an unknown field could still slip through after validate's inline
+/// check was consolidated into the parser — and it did: consolidating turned
+/// `pure_is_unreachable_because_sandbox_is_not_a_resource_field` red, because
+/// the purity classifier happily read a `sandbox:` key out of a config nothing
+/// had validated. A third bypass, found only because the second fix removed the
+/// thing that had been masking it.
+#[test]
+fn the_recipe_purity_path_rejects_the_unknown_field_too() {
+    let dir = tempfile::tempdir().unwrap();
+    let cfg = config_with_typo(dir.path());
+    let out = forjar()
+        .args([
+            "validate",
+            "-f",
+            cfg.to_str().unwrap(),
+            "--check-recipe-purity",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "the purity path classified a config nothing had validated. stdout:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}
+
 /// The counter-case. Without this, every assertion above would also pass if the
 /// commands had simply been broken for all mount configs.
 #[test]


### PR DESCRIPTION
Follow-up to #274, which merged with `coverage` red. **That failure was correct** — it pointed at a real third bypass, and main is currently red on it.

## What the failure was telling us

Consolidating validate's inline unknown-field check turned `pure_is_unreachable_because_sandbox_is_not_a_resource_field` red.

`--check-recipe-purity` goes through `extract_purity`, which reads raw YAML via `serde_yaml_ng::from_str` into an untyped `Value` — it *has* to, because purity keys like `sandbox` are deliberately not typed resource fields. So it consulted **no validation at all**. validate's inline copy had been the only thing standing in front of it.

That's the lesson worth keeping: **deleting a duplicate is how you find out what the duplicate was load-bearing for.**

With the inline check gone, `validate --check-recipe-purity` on a config declaring `sandbox: {}` stopped erroring and reported `Recipe purity: Pure (0)` — a level that test documents as unreachable.

## The fix

Load through `parse_and_validate` **before validate dispatches**, not inside the purity path. That covers every sub-check — including any added later that also reads the file itself — rather than patching only the one that happened to be caught. It also keeps `validate_store_purity.rs` free of a cross-module reference it doesn't need.

## Coverage

`the_recipe_purity_path_rejects_the_unknown_field_too` added, so the bypass cannot reopen silently. **Six verbs now assert one verdict** — validate, plan, apply, codegen, recipe-purity, and a correctly-spelled counter-case proving the suite cannot pass by the verbs simply being broken.

## Unrelated flakiness noted

`core::webhook_server::tests::server_rejects_bad_path` fails intermittently under parallel execution and blocked this push twice before passing. Diagnosed and filed as #276 rather than papered over — the readiness probe binds the port it is waiting for, stealing it from the server, and `free_port()` is TOCTOU. Not touched here; it needs a signature change to fix properly.

Refs #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)