### PR TITLE
fix(purifier): stop discarding every SC1* finding — the gate was blind to syntax errors (#285)

### DIFF
--- a/src/core/purifier.rs
+++ b/src/core/purifier.rs
@@ -18,13 +18,29 @@ use bashrs::linter::{lint_shell, LintResult, Severity};
 /// in generated scripts (e.g., SC2162 for `read` without `-r`).
 pub fn validate_script(script: &str) -> Result<(), String> {
     let result = lint_shell(script);
-    // SC1xxx (syntax) rules excluded: bashrs has false positives on generated
-    // scripts (SC1035 on `in` in quoted strings, SC1020 on `]` in heredocs).
-    // SC2xxx (semantic) rules are retained.
+    // SC1xxx (SYNTAX) rules were excluded here for a long time, with the note:
+    // "bashrs has false positives on generated scripts (SC1035 on `in` in quoted
+    // strings, SC1020 on `]` in heredocs)". Both of those were real, and both
+    // are the quote-blindness class fixed upstream — SC1035/SC1020 by bashrs
+    // 6.67.0 (GH-226, which resolves quoting once and hands the shell-syntax
+    // rules a source where literal text is inert filler), SC1028/SC1078 by
+    // 6.68.0 (paiml/bashrs#243, #245).
+    //
+    // Excluding them cost more than it saved. SC1xxx is the SYNTAX-error family,
+    // which is precisely what a gate over GENERATED shell most wants to catch —
+    // forjar was blind to malformed output of its own making. The SC2135/SC2136
+    // pair in #281 was caught only because it happened to land in SC2*; the same
+    // defect under an SC1 code would have shipped silently.
+    //
+    // Measured before removing (forjar#285), against every resource this fleet
+    // declares: 437 resources x 3 phases = 1,311 generated scripts, emitted with
+    // `forjar codegen` from all nine machine YAMLs and linted at Error severity.
+    // SC1* findings: ZERO. That sweep did NOT apply `strip_data_payloads`, so it
+    // is stricter than this call site, which lints the sanitised script.
     let errors: Vec<_> = result
         .diagnostics
         .iter()
-        .filter(|d| d.severity == Severity::Error && !d.code.starts_with("SC1"))
+        .filter(|d| d.severity == Severity::Error)
         .collect();
     if errors.is_empty() {
         Ok(())
@@ -91,4 +107,67 @@ pub fn purify_script(script: &str) -> Result<String, String> {
     validate_script(&purified)?;
 
     Ok(purified)
+}
+
+#[cfg(test)]
+mod sc1_gate_tests {
+    use super::*;
+
+    /// The SC1xxx family must be LIVE, not filtered away.
+    ///
+    /// forjar#285: this gate excluded every `SC1*` finding for a long time,
+    /// which made it blind to the syntax-error family — precisely what a gate
+    /// over GENERATED shell most wants to catch. A test that only asserted the
+    /// good cases pass would go green with the family switched back off, so
+    /// this one requires a real syntax error to be REJECTED.
+    #[test]
+    fn a_real_syntax_error_is_rejected() {
+        // Unterminated double-quoted string: SC1078, an SC1* code.
+        let broken = "echo \"this string never closes\n";
+        let err = validate_script(broken).expect_err(
+            "a script with an unterminated string was accepted — the SC1 family is filtered again",
+        );
+        assert!(
+            err.contains("SC1"),
+            "rejected, but not by an SC1 rule: {err}"
+        );
+    }
+
+    /// Guard the guard: the shapes that JUSTIFIED the exclusion must still pass,
+    /// or re-enabling the family trades a blind spot for a false positive that
+    /// aborts `forjar apply` fleet-wide.
+    ///
+    /// Both are named in the original comment: SC1035 on `in` inside a quoted
+    /// string, SC1020 on `]` inside a heredoc. Both are the quote-blindness
+    /// class fixed by bashrs 6.67.0 (GH-226) and 6.68.0.
+    #[test]
+    fn the_false_positives_that_justified_the_exclusion_are_gone() {
+        let quoted_in = "grep \"^Diff in\" \"$f\"\necho \"select a in b\"\n";
+        assert!(
+            validate_script(quoted_in).is_ok(),
+            "SC1035-shape false positive is back: `in` inside a quoted string"
+        );
+
+        let bracket_in_heredoc =
+            "cat > /tmp/x <<'PAYLOAD'\nsome text with ] a bracket\nand [ 0-9 ] regex-ish\nPAYLOAD\n";
+        assert!(
+            validate_script(bracket_in_heredoc).is_ok(),
+            "SC1020-shape false positive is back: `]` inside a heredoc"
+        );
+    }
+
+    /// The generated shape that #281 was about must still pass — a folded YAML
+    /// scalar inlined into a check script.
+    #[test]
+    fn a_folded_condition_check_script_still_passes() {
+        let script = crate::resources::verdict::single(
+            "sh -c 'for u in a b; do test -n \"$u\"; done; exit 0'",
+            "forjar=converged",
+            "forjar=diverged",
+        );
+        assert!(
+            validate_script(&script).is_ok(),
+            "forjar generates a check script its own gate rejects"
+        );
+    }
 }


### PR DESCRIPTION
Closes #285.

The I8 gate filtered out the **entire SC1xxx family**, with the note:

> SC1xxx (syntax) rules excluded: bashrs has false positives on generated scripts (SC1035 on `in` in quoted strings, SC1020 on `]` in heredocs).

Both were real. Both are the quote-blindness class, and both are fixed upstream — SC1035/SC1020 by bashrs 6.67.0 (GH-226, which resolves quoting once and hands the shell-syntax rules a source where literal text is inert filler), SC1028/SC1078 by 6.68.0 ([paiml/bashrs#243](https://github.com/paiml/bashrs/issues/243), #245).

**The exclusion cost more than it saved.** `SC1xxx` is the *syntax-error* family, which is exactly what a gate over **generated** shell most wants to catch: forjar was blind to malformed output of its own making. The SC2135/SC2136 pair fixed in #281 was caught only because it happened to land in `SC2*` — the same defect under an `SC1` code would have shipped silently and aborted a resource in the field with no explanation.

## Measured before removing

Over every resource this fleet declares — not a sample, and not the test suite:

```
437 resources × 3 phases = 1,311 generated scripts
emitted with `forjar codegen` from all nine machine YAMLs
linted at Error severity

SC1* findings: ZERO
```

That sweep did **not** apply `strip_data_payloads`, so it is *stricter* than this call site, which lints the sanitised script. `forjar plan` across all nine machines also reports **0 I8 violations** with the family live.

## Three tests, and the first is the one that matters

`a_real_syntax_error_is_rejected` requires a script with a genuine syntax error to be **rejected**. A test that only asserted the good cases pass would go green with the family switched back off — verified by injection:

```
a script with an unterminated string was accepted — the SC1 family is filtered again
```

The other two pin the shapes that justified the exclusion (`in` inside a quoted string, `]` inside a heredoc) plus the folded-scalar check script from #281, so re-enabling cannot trade a blind spot for a false positive that aborts apply fleet-wide.

12,988 tests pass; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLii4JZqyTauqbQWwUg7uf