### PR TITLE
fix(comply): pin an effort level on the repo-local dogfood skill (CB-1650)

### DIFF
--- a/.claude/skills/dogfood/SKILL.md
+++ b/.claude/skills/dogfood/SKILL.md
@@ -1,6 +1,7 @@
 ---
 allowed-tools: Bash(cargo:*), Bash(forjar:*), Bash(pmat:*), Bash(gh:*), Bash(git:*), Bash(find:*), Bash(head:*), Bash(tail:*), Bash(wc:*), Bash(grep:*), Bash(diff:*), Bash(timeout:*), Bash(jq:*), Bash(python3:*), Bash(echo:*), Bash(cat:*), Bash(rm:*), Bash(mktemp:*), Bash(mkdir:*), Bash(sh:*), Bash(bashrs:*), Read, Glob, Grep, Agent
 description: Dogfood forjar — rebuild, install, exercise every command, prove the C1–C10 claims and contracts against a sandboxed stack, check quality, file bugs
+effort: high
 ---
 
 # Forjar CLI Exhaustive QA — Contract-First Dogfood


### PR DESCRIPTION
One of the four `pmat comply check` failures that make the pre-release dogfood protocol return **NO-GO** for forjar 1.16.0. This is the one that is genuinely forjar’s to fix.

```
✗ CB-1650: Skill Effort Pinned: 1 skill(s) without a valid effort pin (MACS F4)
  - .claude/skills/dogfood/SKILL.md: no `effort:` in frontmatter
```
after:
```
✓ CB-1650: Skill Effort Pinned: 1 skill(s) pin a model-level effort
```

`high` because the skill is an exhaustive contract-first QA pass over every CLI command, not a lint.

**Worth noting:** the check names a **repo-local** path. There is also `~/.claude/skills/dogfood/SKILL.md` — a different and much larger skill — and editing that one would have left CB-1650 red while looking like a fix.

## The other three, for the record

| failure | status |
|---|---|
| **CB-400** | lints pmat’s own auto-generated `.git/hooks/pre-commit` — untracked, marked DO NOT EDIT, regenerated by pmat. Filed as [pmat#1049](https://github.com/paiml/paiml-mcp-agent-toolkit/issues/1049) |
| **CB-200** | real debt: 50 functions below grade A, with a dated ceiling in `.pmat/cb200-baseline.json` |
| **Version Currency** | pmat is 25 versions behind — a separate upgrade |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLii4JZqyTauqbQWwUg7uf