### PR TITLE
fix(release): macOS builds never added the target, so x86_64 darwin shipped nothing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,6 +167,25 @@ jobs:
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          # ADD THE TARGET. The Linux branch below already does this; macOS did
+          # not, and it only mattered once `macos-latest` became ARM: with an
+          # aarch64 host, aarch64-apple-darwin is NATIVE and builds fine, while
+          # x86_64-apple-darwin has no std and dies with
+          #   error[E0463]: can't find crate for `core`
+          # That is what happened on v1.17.0 — 5 of 6 targets built, and the
+          # release shipped without an x86_64 macOS binary while `create-release`
+          # reported success and `checksums`/`dist-artifacts` silently skipped.
+          #
+          # NOT `|| true`. The Linux branch swallows failure that way, so a
+          # missing target there would surface later as this same inscrutable
+          # `core` error rather than at the point of cause. A target that cannot
+          # be installed must fail here, loudly.
+          export PATH="$HOME/.cargo/bin:$PATH"
+          rustup target add "${{ matrix.target }}"
+          rustup target list --installed | grep -qx "${{ matrix.target }}" || {
+            echo "::error::rustup reported success but ${{ matrix.target }} is not installed"
+            exit 1
+          }
 
       - name: Install target prerequisites (Linux)
         if: contains(matrix.target, 'linux')


### PR DESCRIPTION
Closes #303.

v1.17.0's `Release` run failed on `x86_64-apple-darwin`:

```
error[E0463]: can't find crate for `core`
```

The Linux branch runs `rustup target add`. **The macOS branch didn't.** Harmless while `macos-latest` was x86_64; now it's ARM, so `aarch64-apple-darwin` is native and fine while `x86_64-apple-darwin` has no std. Latent defect, activated by GitHub changing the runner architecture — not by anything in this repo.

**It almost passed for fine.** `create-release` reported success, five of six binaries attached, and `checksums`/`dist-artifacts` *skipped* rather than failed — so the Release looks populated and the only signal is one red job inside it. Same shape as paiml/copia#58 earlier today.

crates.io is unaffected; forjar 1.17.0 is live.

**Not `|| true`.** The Linux branch swallows a failed target add that way, which is precisely why this surfaced as an inscrutable `core` error deep in libc rather than at the point of cause. The step also asserts `rustup target list --installed` contains the target — "rustup exited 0" is not "the target is there".

Two follow-ups noted in #303 and deliberately not bundled here: the Linux branch's own `|| true`, and the fact that `checksums`/`dist-artifacts` skipping on a partial matrix failure lets a release publish with no checksums and nothing says so at the release level.