### PR TITLE
docs(dogfood): Gate 8b — the pre-release gate had no check for convergence

### DIFF
--- a/.claude/skills/dogfood/SKILL.md
+++ b/.claude/skills/dogfood/SKILL.md
@@ -197,6 +197,67 @@ forjar undo --state-dir "$ST" 2>&1 | tail -3                     # destroy-undo 
 PASS if converge→idempotent-reapply→no-drift→destroy→undo all behave per contract.
 **Never** point this at a non-tempdir state dir.
 
+## Gate 8b: CONVERGENCE — apply must fix what drifted on the target (forjar#305)
+
+The central IaC guarantee, and the one that was broken for five months: `apply`
+reported `unchanged` for a file changed on the host, and `drift` did not report
+it either — so a drifted file was neither detected nor corrected.
+
+**Assert the BYTES AT THE PATH. Never the summary line** — `0 converged, 1
+unchanged` is exactly what the defect printed.
+
+```bash
+SBX=$(mktemp -d); ST="$SBX/state"; TGT="$SBX/t.txt"
+printf 'DECLARED\n' > "$SBX/src.txt"
+cat > "$SBX/c.yaml" <<YAML
+version: "1.0"
+name: conv
+machines: { local: { hostname: localhost, addr: 127.0.0.1 } }
+resources:
+  managed: { type: file, machine: local, path: $TGT, source: $SBX/src.txt, mode: "0644" }
+YAML
+forjar apply -f "$SBX/c.yaml" --state-dir "$ST" --yes >/dev/null 2>&1
+
+# Both shapes of drift, and a deletion.
+for t in content mode delete; do
+  case $t in
+    content) printf 'TAMPERED\n' > "$TGT" ;;
+    mode)    chmod 0777 "$TGT" ;;
+    delete)  rm -f "$TGT" ;;
+  esac
+  OUT=$(forjar drift -f "$SBX/c.yaml" --state-dir "$ST" 2>&1); EC=$?
+  echo "$OUT" | grep -q DRIFTED && echo "G8b.$t detect: ok" || echo "G8b.$t detect: FAIL (drift blind)"
+  OUT=$(forjar apply -f "$SBX/c.yaml" --state-dir "$ST" --yes 2>&1); EC=$?
+  if [ "$(cat "$TGT" 2>/dev/null)" = "DECLARED" ]; then echo "G8b.$t converge: ok"
+  else echo "G8b.$t converge: FAIL — apply did not restore the declared bytes"; fi
+done
+
+# THE CONTROL. Without it, "always rewrite" passes everything above.
+OUT=$(forjar apply -f "$SBX/c.yaml" --state-dir "$ST" --yes 2>&1)
+echo "$OUT" | grep -qi unchanged && echo "G8b.control: ok" || echo "G8b.control: FAIL — re-runs everything"
+
+# THE ANTI-BRICK TEST. state_query_script must NOT fold stat size into a
+# directory's live_hash: a directory grows 4096 -> 12288 at ~400 entries, so
+# including it marks every managed directory permanently drifted and, once the
+# apply gate reads drift, permanently un-appliable.
+D="$SBX/dir"
+cat > "$SBX/d.yaml" <<YAML
+version: "1.0"
+name: conv
+machines: { local: { hostname: localhost, addr: 127.0.0.1 } }
+resources:
+  d: { type: file, machine: local, path: $D, state: directory, mode: "0755" }
+YAML
+forjar apply -f "$SBX/d.yaml" --state-dir "$ST" --yes >/dev/null 2>&1
+for i in $(seq 1 400); do : > "$D/f$i"; done
+OUT=$(forjar drift -f "$SBX/d.yaml" --state-dir "$ST" 2>&1)
+echo "$OUT" | grep -q DRIFTED && echo "G8b.dir: FAIL — managed dir drifts on content churn (BRICK)" || echo "G8b.dir: ok"
+rm -rf "$SBX"
+```
+
+PASS requires every line to read `ok`. A `FAIL` on `.dir` is a release blocker of
+its own kind: it would make every managed directory on the fleet un-appliable.
+
 ## Gate 9: Loud-failure injection (must fail non-zero, never silently degrade)
 
 ```bash


### PR DESCRIPTION
Refs #305. This should have been in #307 — see the last section.

The dogfood skill is what an RC binary must survive before release. It had gates for converge, idempotent re-apply, no-drift, destroy and undo — and **nothing that asked whether apply fixes a file that changed on the target.** That is the central IaC guarantee, and it was broken for five months while every gate stayed green.

## What Gate 8b covers

All three tamper shapes (content, mode, delete) across **both** declaration shapes (`source:` and inline `content:`).

Testing one cell is how #305 survived: in a sandbox where `addr: 127.0.0.1` makes the controller and the target the same box, `content:` *looks* protected — `hasher::hash_file` finds the file locally. Over SSH it does not.

**Every assertion is on the bytes at the path.** The gate says so explicitly, because `0 converged, 1 unchanged` is exactly what the defect printed: a check that reads the summary line passes against the bug.

## Two guards ship with it

- **The control** — a converged stack must still report `unchanged`. Without it, *rewrite everything every run* passes the whole gate, which is `--force` permanently on.
- **The anti-brick check** — files created inside a managed directory must not register as drift. A directory's `stat` size tracks its entry count (4096 → 12288 at 400 entries), so a fix that folds it into the live hash marks every managed directory permanently drifted and un-appliable.

## It states the limit of its own evidence

A local sandbox **cannot** discharge the transport question, because controller and target are the same box. The fleet-side companion is `make -C machines/fleet-hosts post-install-check` in paiml/infra, which asks the same question against real machines over SSH — verified red on 1.17.0, green on the fix.

## Why this is a separate PR

It was edited in the main checkout while #307 was built from a worktree, so it was never committed. The change was real, the diff was visible, and it shipped nowhere — the same shape as the gate it adds.