### PR TITLE
fix(apply,drift): Drifted is an observation, not an off switch

### DIFF
--- a/contracts/apply-converges-observed-drift-v1.yaml
+++ b/contracts/apply-converges-observed-drift-v1.yaml
@@ -54,12 +54,45 @@ equations:
 
   apply_reads_what_drift_reads:
     formula: |
-      pre_apply_findings(config, state_dir, m) = detect_drift_full(lock_m, m, config.resources)
+      resolved      = resolve_all(config.resources, config.params, config.machines, config.secrets)
+      pre_apply_findings(config, state_dir, m) = detect_drift_full(lock_m, m, resolved)
     domain: "config ∈ ForjarConfig, state_dir ∈ Path, m ∈ Machine"
     codomain: "Vec<DriftFinding>"
     invariants:
       - "apply and `forjar drift` answer the same question with the same detector"
+      - "AND with the same arguments — both pass TEMPLATE-RESOLVED resources"
       - "Two shipped surfaces never disagree about whether a resource has drifted"
+    notes: |
+      CORRECTED (forjar#310). This equation was written as
+      `detect_drift_full(lock_m, m, config.resources)` — RAW, unresolved — which
+      is what the code did and what made every `{{params.*}}`-bearing resource
+      report permanent false drift and be rewritten on every apply.
+
+      So the contract ENCODED THE DEFECT while the two invariants printed
+      directly beneath it said the opposite. A guard that states the bug as its
+      specification cannot fail on the bug; fixing the code without fixing this
+      line would have re-armed the trap on the next refactor.
+
+      `cli/drift.rs` has resolved since PMAT-197 and carries the reason:
+      "resources MUST be template-resolved before they are compared against live
+      machine state." Same detector, same arguments — the second half is the
+      half that was missing.
+
+  observation_is_bounded:
+    formula: |
+      ∀ q ∈ state_queries(apply_path): duration(q) ≤ DRIFT_QUERY_TIMEOUT_SECS
+    domain: "q a state_query_script execution over any transport"
+    codomain: "Duration"
+    invariants:
+      - "No transport call on the apply path is unbounded"
+      - "One unresponsive machine cannot prevent healthy machines from converging"
+    notes: |
+      forjar#310. `check_nonfile_drift` used bare `transport::exec_script` (no
+      timeout) while the identical query at `executor/resource_ops.rs:46` has
+      always used `exec_script_timeout`. Unbounded reporting is survivable — a
+      human can Ctrl-C it. #307 moved it onto the APPLY path, where a host that
+      accepts a connection and then stalls hangs the whole run: measured at 0
+      bytes of output with every healthy machine left unconverged.
 
   observed_drift_plans_update:
     formula: |

--- a/src/cli/apply.rs
+++ b/src/cli/apply.rs
@@ -370,6 +370,7 @@ fn check_pre_apply_drift(
     state_dir: &Path,
     machine_filter: Option<&str>,
     force: bool,
+    dry_run: bool,
     verbose: bool,
 ) -> Result<(), String> {
     if !config.policy.tripwire || force {
@@ -393,8 +394,31 @@ fn check_pre_apply_drift(
         // `detect_drift_full` is what `forjar drift` calls (cli/drift.rs), and
         // it needs the resolved resources so template-bearing paths compare
         // against what was actually deployed. (forjar#305.)
+        // PMAT-197, REGRESSED BY #307 AND FIXED AGAIN HERE (forjar#310).
+        //
+        // This passed `&config.resources` — RAW, unresolved. cli/drift.rs has
+        // carried the fix and the reason since PMAT-197: "resources MUST be
+        // template-resolved before they are compared against live machine
+        // state. Passing raw cfg.resources made every {{params.*}}-bearing
+        // resource report permanent false drift."
+        //
+        // The comment three lines above this one already said the code "needs
+        // the resolved resources so template-bearing paths compare against what
+        // was actually deployed". The comment was right and the code did not do
+        // it — so every templated resource was falsely drifted on every apply,
+        // rewritten every run, and templated `task` commands re-executed every
+        // time. 156 fleet resources are template-bearing.
+        //
+        // Resolving here also makes apply and `forjar drift` ask the SAME
+        // question, which was the entire point of switching to detect_drift_full.
+        let resolved = crate::core::resolver::resolve_all(
+            &config.resources,
+            &config.params,
+            &config.machines,
+            &config.secrets,
+        );
         let findings = match config.machines.get(machine_name.as_str()) {
-            Some(m) => crate::tripwire::drift::detect_drift_full(lock, m, &config.resources),
+            Some(m) => crate::tripwire::drift::detect_drift_full(lock, m, &resolved),
             None => crate::tripwire::drift::detect_drift(lock),
         };
         if !findings.is_empty() {
@@ -413,12 +437,26 @@ fn check_pre_apply_drift(
                     rl.status = types::ResourceStatus::Drifted;
                 }
             }
-            // A failure to persist must not be silent: the apply would then
-            // proceed against a lock that still says Converged and would
-            // report "unchanged" over the very drift just printed.
-            crate::core::state::save_lock(state_dir, &updated).map_err(|e| {
-                format!("observed {} drifted resource(s) on {machine_name} but could not record it in the lock: {e}", findings.len())
-            })?;
+            // A DRY RUN MUST NOT WRITE THE LOCK. #307 persisted here
+            // unconditionally, so `apply --dry-run` — documented as making no
+            // changes — mutated state, and that write was itself what silenced
+            // `forjar drift` afterwards (forjar#310). The findings are still
+            // PRINTED above, which is the whole job of a dry run.
+            if dry_run {
+                if verbose {
+                    eprintln!(
+                        "  (dry run: {} drifted resource(s) on {machine_name} NOT recorded in the lock)",
+                        findings.len()
+                    );
+                }
+            } else {
+                // A failure to persist must not be silent: the apply would then
+                // proceed against a lock that still says Converged and would
+                // report "unchanged" over the very drift just printed.
+                crate::core::state::save_lock(state_dir, &updated).map_err(|e| {
+                    format!("observed {} drifted resource(s) on {machine_name} but could not record it in the lock: {e}", findings.len())
+                })?;
+            }
         }
     }
     if total_drift > 0 && verbose {
@@ -442,7 +480,7 @@ fn apply_pre_validate(
     verbose: bool,
 ) -> Result<(), String> {
     super::apply_gates::check_state_integrity(state_dir, verbose)?;
-    check_pre_apply_drift(config, state_dir, machine_filter, force, verbose)?;
+    check_pre_apply_drift(config, state_dir, machine_filter, force, dry_run, verbose)?;
 
     // FJ-335: Confirm destructive actions
     if confirm_destructive && !dry_run && !yes {

--- a/src/core/codegen/tests_coverage.rs
+++ b/src/core/codegen/tests_coverage.rs
@@ -188,7 +188,7 @@ fn test_codegen_docker_with_ports_and_env() {
     );
     let query = state_query_script(&r).unwrap();
     assert!(
-        query.contains("docker inspect 'webapp'"),
+        query.contains("docker inspect") && query.contains("'webapp'"),
         "state_query must inspect container: {query}"
     );
 }

--- a/src/resources/docker.rs
+++ b/src/resources/docker.rs
@@ -85,8 +85,32 @@ pub fn apply_script(resource: &Resource) -> String {
 pub fn state_query_script(resource: &Resource) -> String {
     let name = resource.name.as_deref().unwrap_or("unknown");
     let n = sh_squote(name);
+    // DECLARED INTENT ONLY — NOT `docker inspect`'s full output.
+    //
+    // This hashed the ENTIRE inspect document, which contains State.StartedAt,
+    // State.FinishedAt and State.Status. Measured on intel, the same container
+    // twice, 12 seconds apart:
+    //
+    //     inspect sha t0: 52eea127b4b425dd
+    //     inspect sha t1: c1e3029d2739ffa3
+    //
+    // So a docker resource's live_hash was PERMANENTLY volatile — always
+    // "drifted". That was harmless while only `forjar drift` read it. #307 made
+    // the apply gate read it too, and forjar's docker apply is
+    // `docker stop; docker rm; docker run` — so EVERY apply tore down and
+    // recreated every container. For machines/intel/forjar.yaml's `ci-registry`
+    // that is paiml/infra#285, the 2026-08-24 fleet-wide CI outage, converted
+    // into a guaranteed recurrence. (forjar#310.)
+    //
+    // A container's identity here is what the resource DECLARES: image, ports,
+    // mounts, restart policy, env — plus whether it is running at all. How long
+    // it has been up is not drift. Same principle as the directory-`size`
+    // exclusion in file.rs: an observable that moves on its own is not evidence
+    // of divergence from intent.
+    let fmt = "{{.Config.Image}}|{{.Image}}|{{.HostConfig.RestartPolicy.Name}}|{{range $p,$c := .HostConfig.PortBindings}}{{$p}}->{{range $c}}{{.HostPort}}{{end}},{{end}}|{{range .Mounts}}{{.Type}}:{{.Name}}:{{.Source}}:{{.Destination}},{{end}}|{{range .Config.Env}}{{.}},{{end}}|running={{.State.Running}}";
     format!(
-        "docker inspect {n} 2>/dev/null && echo {} || echo {}",
+        "docker inspect --format {} {n} 2>/dev/null && echo {} || echo {}",
+        sh_squote(fmt),
         sh_squote(&format!("container={name}")),
         sh_squote(&format!("container=MISSING:{name}"))
     )

--- a/src/resources/tests_docker.rs
+++ b/src/resources/tests_docker.rs
@@ -183,7 +183,12 @@ fn test_fj030_apply_stopped() {
 fn test_fj030_state_query() {
     let r = make_docker_resource("web", "nginx:latest");
     let script = state_query_script(&r);
-    assert!(script.contains("docker inspect 'web'"));
+    // Targets the right container. NOT `contains("docker inspect 'web'")` —
+    // the observable now carries a `--format` between the verb and the name
+    // (forjar#310), and an assertion on that exact substring was testing the
+    // command's spelling rather than what it observes.
+    assert!(script.contains("docker inspect"));
+    assert!(script.contains("'web'"));
     assert!(script.contains("container=MISSING:web"));
 }
 
@@ -270,7 +275,7 @@ fn test_fj030_no_name_defaults_to_unknown() {
     let apply = apply_script(&r);
     assert!(apply.contains("--name 'unknown'"));
     let query = state_query_script(&r);
-    assert!(query.contains("docker inspect 'unknown'"));
+    assert!(query.contains("docker inspect") && query.contains("'unknown'"));
 }
 
 #[test]
@@ -306,4 +311,61 @@ fn test_fj030_absent_no_run_no_pull() {
     let script = apply_script(&r);
     assert!(!script.contains("docker pull"));
     assert!(!script.contains("docker run"));
+}
+
+// ── forjar#310: the observable must not move on its own ──────────────────────
+
+/// A docker resource's drift observable must contain DECLARED INTENT ONLY.
+///
+/// It used to hash the whole `docker inspect` document, which carries
+/// `State.StartedAt`, `State.FinishedAt` and `State.Status`. Measured on a real
+/// host, the same container twice 12 seconds apart, produced two different
+/// digests — so a docker resource was PERMANENTLY "drifted".
+///
+/// That was survivable while only `forjar drift` read it. forjar#307 made the
+/// apply gate read it too, and the docker apply path is
+/// `docker stop; docker rm; docker run` — so every apply tore down and
+/// recreated every container. On the paiml fleet that is the `ci-registry`
+/// resource, i.e. paiml/infra#285, the fleet-wide CI outage, made recurring.
+///
+/// This asserts on the OBSERVABLE'S CONTENT rather than running docker,
+/// because the failure is that a *field* is present, and a field's presence is
+/// exactly what a text assertion can legitimately check.
+#[test]
+fn state_query_excludes_fields_that_change_on_their_own() {
+    let r = make_docker_resource("web", "nginx:latest");
+    let q = state_query_script(&r);
+    for volatile in [
+        "StartedAt",
+        "FinishedAt",
+        "State.Status",
+        "State.Health",
+        "RestartCount",
+        "Pid",
+    ] {
+        assert!(
+            !q.contains(volatile),
+            "docker observable contains `{volatile}`, which moves without any \
+             change of intent — every apply would recreate the container:\n{q}"
+        );
+    }
+    // The control. An observable that captures NOTHING would pass the loop
+    // above and is the more dangerous failure: it can never see a real change.
+    for declared in [
+        "Config.Image",
+        "RestartPolicy",
+        "PortBindings",
+        "Mounts",
+        "Config.Env",
+    ] {
+        assert!(
+            q.contains(declared),
+            "docker observable is missing declared intent `{declared}` — it \
+             could not detect a real divergence:\n{q}"
+        );
+    }
+    assert!(
+        q.contains("State.Running"),
+        "the observable must still notice a container that stopped:\n{q}"
+    );
 }

--- a/src/resources/tests_docker_b.rs
+++ b/src/resources/tests_docker_b.rs
@@ -291,7 +291,7 @@ fn test_docker_state_query_with_network() {
     r.restart = Some("on-failure:5".to_string());
     let query = state_query_script(&r);
     assert!(
-        query.contains("docker inspect 'api'"),
+        query.contains("docker inspect") && query.contains("'api'"),
         "state_query must inspect container: {query}"
     );
     assert!(

--- a/src/tripwire/drift/mod.rs
+++ b/src/tripwire/drift/mod.rs
@@ -66,7 +66,11 @@ fn hash_remote_content(
     // use `hash_string_or_sentinel` to stay inside the contract.
     if out.stdout.trim() == "__DIR__" {
         let ls_script = format!("ls -la '{path}'");
-        match crate::transport::exec_script(machine, &ls_script) {
+        match crate::transport::exec_script_timeout(
+            machine,
+            &ls_script,
+            Some(DRIFT_QUERY_TIMEOUT_SECS),
+        ) {
             Ok(ls_out) if ls_out.success() => Some(hasher::hash_string_or_sentinel(&ls_out.stdout)),
             _ => None,
         }
@@ -102,7 +106,7 @@ pub fn check_file_drift_via_transport(
     let script = format!(
         "set -euo pipefail\nif [ -d '{path}' ]; then echo '__DIR__'; else cat '{path}'; fi"
     );
-    match crate::transport::exec_script(machine, &script) {
+    match crate::transport::exec_script_timeout(machine, &script, Some(DRIFT_QUERY_TIMEOUT_SECS)) {
         Ok(out) if out.success() => {
             let actual = hash_remote_content(&out, path, machine)?;
             if actual != expected_hash {
@@ -132,6 +136,21 @@ pub fn check_file_drift_via_transport(
 }
 
 /// Check all file-type resources in a lock for drift.
+/// Bound on every transport call the DRIFT DETECTOR makes.
+///
+/// forjar#310. `check_nonfile_drift` used bare `transport::exec_script`, which
+/// has no timeout, while the identical query at its original call site
+/// (`executor/resource_ops.rs:46`) has always used `exec_script_timeout`.
+/// Harmless while drift detection was a reporting command a human ran and could
+/// Ctrl-C. #307 put it on the APPLY path, so one host that accepts a TCP
+/// connection and then stalls hangs `apply` forever — measured: 0 bytes of
+/// output, and every healthy machine in the same run left unconverged.
+///
+/// This fleet has documented wedged-switch and hung-NAS-mount history, so that
+/// is a live shape, not a hypothetical. A state query is a `stat`, a `cat` and
+/// a hash; if it has not answered in this long, the answer is not coming.
+const DRIFT_QUERY_TIMEOUT_SECS: u64 = 60;
+
 /// Uses local filesystem hashing (for local machines without transport context).
 pub fn detect_drift(lock: &StateLock) -> Vec<DriftFinding> {
     detect_drift_impl(lock, None)
@@ -155,7 +174,7 @@ fn check_nonfile_drift(
         Err(_) => return None,
     };
 
-    match crate::transport::exec_script(machine, &query) {
+    match crate::transport::exec_script_timeout(machine, &query, Some(DRIFT_QUERY_TIMEOUT_SECS)) {
         Ok(out) if out.success() => {
             // STRONG contract: query stdout may be empty when state absent.
             let actual_hash = hasher::hash_string_or_sentinel(&out.stdout);
@@ -228,7 +247,27 @@ fn detect_nonfile_drift(
         // covers content, owner, group, mode and existence, so it is strictly
         // stronger than the controller-side bytes-only `content_hash`.
         // (forjar#305.)
-        if rl.status != ResourceStatus::Converged {
+        // `Drifted` IS RE-CHECKED. It means "needs work", not "stop looking".
+        //
+        // This read `!= Converged`, which was correct while nothing ever wrote
+        // `Drifted`. #307 started writing it — and turned the drift tripwire
+        // into a gate that fires ONCE and then reports clean forever over a
+        // still-tampered file:
+        //
+        //     tripwire before        -> 1 (drift detected, correct)
+        //     apply --dry-run        -> lock status becomes `drifted`
+        //     tripwire after         -> 0 (CLEAN) while bytes are still TAMPERED
+        //
+        // That is strictly worse than the #305 blindness it replaced: a gate
+        // that never fired gets distrusted, a gate that fires once and then
+        // lies gets TRUSTED. `--tripwire` is the CI gate. (forjar#310.)
+        //
+        // Failed/Unknown stay excluded: their lock hash records an apply that
+        // did not complete, so it is not a baseline anything can be compared
+        // against. `Drifted` is different — it was written by an apply that
+        // OBSERVED a converged resource move, so the recorded hash is exactly
+        // the baseline drift detection needs.
+        if rl.status != ResourceStatus::Converged && rl.status != ResourceStatus::Drifted {
             continue;
         }
         if should_ignore_drift(id, resources) {
@@ -296,7 +335,7 @@ pub fn check_image_drift(
     let script = format!(
         "docker inspect {container_name} --format '{{{{.Image}}}}' 2>/dev/null || echo 'NOT_RUNNING'"
     );
-    match crate::transport::exec_script(machine, &script) {
+    match crate::transport::exec_script_timeout(machine, &script, Some(DRIFT_QUERY_TIMEOUT_SECS)) {
         Ok(out) if out.success() => {
             let actual = out.stdout.trim().to_string();
             if actual == "NOT_RUNNING" {


### PR DESCRIPTION
Closes #310. The 1.18.0 release gate came back **3/3 NO-GO**. #307's detection half is right and measurably works; its convergence wiring shipped five defects. **Five of the nine must-fixes are here**; the rest stay open in #310 and I am not releasing until they are settled.

## The one that decided the NO-GO: #307 made the tripwire *worse than the bug*

`detect_nonfile_drift` skips any entry whose status != `Converged` — correct while nothing ever wrote `Drifted`. #307 started writing it, so the **first** observation silenced every later one:

```
tripwire before    -> 1   (correct)
apply --dry-run    -> lock status becomes 'drifted'
tripwire after     -> 0   (CLEAN)   while the bytes are still TAMPERED
```

`--tripwire` is the CI gate in six machine Makefiles, `nightly-audit.yml`, and lambda-labs AUD-012b. **A gate that never fired gets distrusted; a gate that fires once and then lies gets trusted.** And the mark is written per-*machine* regardless of `-r`/`-t` scope, so it also silenced the docker/service/package/cron/mount resources 1.17.0 could still see — strictly weaker than the version it replaced.

`Drifted` now means *needs work*, not *stop looking*. `Failed`/`Unknown` stay excluded and the code says why: their hash comes from an apply that did not complete, so it is not a baseline. A `Drifted` entry's hash was written by an apply that *observed* a converged resource move — exactly the baseline drift detection needs.

## A dry run must not write the lock

#307 persisted unconditionally, so `apply --dry-run` mutated state while printing `No changes applied` — and that write is what silenced drift afterwards. Now gated on `!dry_run`; findings are still printed, which is the whole job of a dry run.

## PMAT-197, regressed and fixed again

`check_pre_apply_drift` passed `&config.resources` — **raw**. `cli/drift.rs` has resolved since PMAT-197 and carries the reason: *"Passing raw cfg.resources made every {{params.*}}-bearing resource report permanent false drift."*

So apply and drift asked the same question with **different arguments**: 112 templated paths rewritten and 23 templated task commands re-executed on every apply, fleet-wide. The comment three lines above the defect already said the code *"needs the resolved resources"*. The comment was right; the code did not do it.

## A docker resource's identity is declared intent, not runtime state

The observable hashed the whole `docker inspect` document — `State.StartedAt`, `FinishedAt`, `Status`. Measured on intel, same container, 12s apart:

```
52eea127b4b425dd  ->  c1e3029d2739ffa3
```

Permanently "drifted". Survivable while only `drift` read it; #307 put it on the apply path, and the docker apply is `stop; rm; run` — **every apply tore down every container.** For intel's `ci-registry` that is a registry outage on every post-restart apply, breaking in-flight `docker pull` across 16 runners. (The named volume from paiml/infra#285 means availability, not data loss.)

Now: image, ports, mounts, restart policy, env, running-or-not. Same principle as 1c's directory-`size` exclusion — **an observable that moves on its own is not evidence of divergence from intent.**

## Every transport call on the apply path is bounded

`check_nonfile_drift` used bare `exec_script` (no timeout) while the identical query at `executor/resource_ops.rs:46` has always used `exec_script_timeout`. Unbounded *reporting* is survivable — a human can Ctrl-C. #307 moved it onto **apply**, where a host that connects and then stalls hangs the run: measured 0 bytes of output, every healthy machine left unconverged. This fleet has wedged-switch and hung-NAS history. 60s, and the constant says why.

## The contract encoded the defect

`apply_reads_what_drift_reads` was written as `detect_drift_full(lock_m, m, config.resources)` — the raw-resources bug, **stated as the specification**, directly above two invariants saying the opposite. A guard that specifies the bug cannot fail on it, and fixing the code without this line re-arms the trap on the next refactor. Corrected, plus a new `observation_is_bounded` equation.

## Tests

Four docker tests asserted `contains("docker inspect 'name'")` — the command's *spelling*, not what it observes — and broke on the `--format`. Rewritten to assert the property.

New `state_query_excludes_fields_that_change_on_their_own` checks **both directions**: no volatile field present, *and* declared intent still present — because an observable that captures nothing passes the first half and is the more dangerous failure.

## Verification — three binaries, all reporting `forjar 1.17.0`

| binary | sha | tripwire | lock after dry-run |
|---|---|---|---|
| PREFIX | `0bae92da` | 0 → 0 | unchanged | (blind: #305) |
| #307 | `a31fa2e4` | 1 → **0** | **MUTATED** | (#310) |
| **this** | `d34bb24d` | **1 → 1** | unchanged |

Controls hold: still converges a tampered file, still reports `unchanged` when converged. Docker observable stable across 14s on a live intel container.

**13,115 pass.** The 5 remaining failures (4 hasher should-panic, `build_metrics_current`) are **pre-existing on `origin/main`** — verified by stashing these changes and re-running the suite. fmt and clippy clean.

## Still open in #310 — not fixed here

Symlink write-through; re-baselining `live_hash` from a post-apply observation that did not reach declared state; the apply-path perf regression on a **real SSH** transport (the 35.7× at N=200 is a local-transport floor, never measured over SSH); process-lock ordering.