### PR TITLE
fix(file): `group:` without `owner:` was silently ignored, then reported converged

### DIFF
--- a/src/resources/file.rs
+++ b/src/resources/file.rs
@@ -45,16 +45,27 @@ pub fn check_script(resource: &Resource) -> String {
 /// Append chown/chmod lines for the given resource ownership and mode.
 fn push_ownership_lines(lines: &mut Vec<String>, path: &str, resource: &Resource) {
     let p = sh_squote(path);
-    if let Some(ref owner) = resource.owner {
-        if let Some(ref group) = resource.group {
-            lines.push(format!(
-                "chown {} {}",
-                sh_squote(&format!("{owner}:{group}")),
-                p
-            ));
-        } else {
-            lines.push(format!("chown {} {}", sh_squote(owner), p));
-        }
+    // `group:` WITHOUT `owner:` USED TO BE SILENTLY IGNORED.
+    //
+    // `group` was only ever read inside the `owner` branch, so a resource
+    // declaring group alone emitted no ownership command at all — and the lock
+    // then recorded `group: <declared>` under `status: converged` while the file
+    // on disk kept whatever group it had. A declared attribute that is never
+    // applied and is nonetheless reported as converged is the worst shape a
+    // config tool has: the operator has written down an intent the system has
+    // quietly agreed to ignore. (forjar#310, confirmed 3/3 by the release gate.)
+    match (&resource.owner, &resource.group) {
+        (Some(owner), Some(group)) => lines.push(format!(
+            "chown {} {}",
+            sh_squote(&format!("{owner}:{group}")),
+            p
+        )),
+        (Some(owner), None) => lines.push(format!("chown {} {}", sh_squote(owner), p)),
+        // chgrp, not `chown :group` — chgrp says what is meant, and `chown`
+        // with a leading colon is a portability trap (BSD and GNU disagree
+        // about `:group` vs `.group`, and this fleet has a macOS host).
+        (None, Some(group)) => lines.push(format!("chgrp {} {}", sh_squote(group), p)),
+        (None, None) => {}
     }
     if let Some(ref mode) = resource.mode {
         lines.push(format!("chmod {} {}", sh_squote(mode), p));

--- a/src/resources/tests_file.rs
+++ b/src/resources/tests_file.rs
@@ -346,3 +346,54 @@ fn test_fj007_apply_file_creates_parent_dir() {
         "mkdir must precede the content write in apply script"
     );
 }
+
+/// forjar#310: `group:` declared WITHOUT `owner:` emitted no ownership command
+/// at all, and the lock recorded `group: <declared>` under `converged` anyway.
+///
+/// A declared attribute that is never applied and is still reported converged is
+/// the worst shape available: the operator wrote down an intent the system
+/// quietly agreed to ignore. 58 directory resources on the paiml fleet declare
+/// ownership.
+#[test]
+fn group_without_owner_is_actually_applied() {
+    let mut r = Resource {
+        resource_type: ResourceType::File,
+        machine: MachineTarget::Single("m1".to_string()),
+        path: Some("/etc/thing.conf".to_string()),
+        content: Some("x".to_string()),
+        ..Default::default()
+    };
+    r.group = Some("staff".to_string());
+    r.owner = None;
+    let script = apply_script(&r);
+    assert!(
+        script.contains("chgrp 'staff' '/etc/thing.conf'"),
+        "group declared without owner emitted NO ownership command:\n{script}"
+    );
+
+    // Controls — the three other combinations must be unchanged.
+    r.owner = Some("noah".to_string());
+    let both = apply_script(&r);
+    assert!(
+        both.contains("chown 'noah:staff' '/etc/thing.conf'"),
+        "owner+group regressed:\n{both}"
+    );
+    assert!(
+        !both.contains("chgrp"),
+        "owner+group must use one chown, not chown plus chgrp:\n{both}"
+    );
+
+    r.group = None;
+    let owner_only = apply_script(&r);
+    assert!(
+        owner_only.contains("chown 'noah' '/etc/thing.conf'"),
+        "owner-only regressed:\n{owner_only}"
+    );
+
+    r.owner = None;
+    let neither = apply_script(&r);
+    assert!(
+        !neither.contains("chown") && !neither.contains("chgrp"),
+        "neither declared, but an ownership command was emitted:\n{neither}"
+    );
+}


### PR DESCRIPTION
Refs #310. Confirmed **3/3** by the 1.18.0 release gate's adversarial verifiers.

`group` was only ever read **inside** the `owner` branch:

```rust
if let Some(owner) = resource.owner {
    if let Some(group) = resource.group { chown owner:group }
    else { chown owner }
}
// group alone: nothing emitted
```

So a resource declaring `group:` and not `owner:` emitted **no ownership command at all**. The apply exited 0, `record_success` wrote the lock with `group: <declared>` under `status: converged`, and the file kept whatever group it had — permanently, silently.

**A declared attribute that is never applied and is still reported converged is the worst shape a config tool has.** It isn't that the operator's intent failed; it's that the system quietly agreed to ignore an intent the operator wrote down, and then said yes. **58 directory resources on the paiml fleet declare ownership.**

## Why `chgrp`, not `chown :group`

Two reasons: `chgrp` says what is meant, and a leading colon is a portability trap — BSD and GNU disagree about `:group` vs `.group`, and this fleet has a macOS host.

## The test covers all four combinations

The three that already worked are **controls**: owner+group must still emit one `chown` and *not* also a `chgrp`; owner-only unchanged; neither must emit nothing.

Without those, *"always emit both"* passes the one assertion that matters and breaks the other three.

**Instrument probed** by reverting only `file.rs`:

```
group declared without owner emitted NO ownership command
```

## Note on the wider family

The gate grouped this with *"apply adopts a drifted value into the lock as the new oracle."* The core machinery for that is **already right**: `output_verify::unverified_after_apply` (FJ-2732/PMAT-137) makes `check_script` the permission slip for `Converged`, and it *is* wired on the apply path.

Its own doc comment says the honest thing — *"a WEAK check makes this a no-op rather than a guard."* So the remaining members of that family are **weak per-handler checks, not a missing mechanism**. Tracked in #310. This PR fixes the one that was a plain omission rather than a weak assertion.

**13,116 pass.** The 5 failures are pre-existing on `origin/main`. fmt and `clippy --all-targets -- -D warnings` clean.