### PR TITLE
fix(apply): a REFUSED apply must not write to the state dir first

### DIFF
--- a/src/cli/apply.rs
+++ b/src/cli/apply.rs
@@ -479,6 +479,22 @@ fn apply_pre_validate(
     yes: bool,
     verbose: bool,
 ) -> Result<(), String> {
+    // REFUSE BEFORE WRITING, NOT AFTER.
+    //
+    // Everything below this line can mutate the state dir — `check_pre_apply_drift`
+    // persists `ResourceStatus::Drifted` — but the process lock is not acquired
+    // until the executor runs, much later. So a concurrent apply used to do its
+    // drift pass, rewrite state.lock.yaml and re-seal the `.b3` over the holder's
+    // state, and only then be told the directory was locked. Measured: "error:
+    // state directory is locked by PID N" with the lock file MUTATED by that very
+    // run. (forjar#310.)
+    //
+    // A read-only probe, not an early acquire — see locked_by_other_live_pid for
+    // why. It does not replace the acquire; it only ensures the loser of the race
+    // has not written anything first.
+    if let Some(msg) = crate::core::state::locked_by_other_live_pid(state_dir) {
+        return Err(msg);
+    }
     super::apply_gates::check_state_integrity(state_dir, verbose)?;
     check_pre_apply_drift(config, state_dir, machine_filter, force, dry_run, verbose)?;
 

--- a/src/core/state/mod.rs
+++ b/src/core/state/mod.rs
@@ -256,7 +256,9 @@ pub fn load_apply_report(state_dir: &Path, machine: &str) -> Result<Option<Strin
 // FJ-266: State locking — prevent concurrent applies (see `process_lock`)
 // ============================================================================
 
-pub use process_lock::{acquire_process_lock, force_unlock, release_process_lock};
+pub use process_lock::{
+    acquire_process_lock, force_unlock, locked_by_other_live_pid, release_process_lock,
+};
 #[cfg(test)]
 pub(super) use process_lock::{parse_lock_pid, process_lock_path};
 

--- a/src/core/state/process_lock.rs
+++ b/src/core/state/process_lock.rs
@@ -219,6 +219,44 @@ fn unlink_confirmed_stale_lock(lock_path: &Path) -> Result<ReapOutcome, String> 
 }
 
 /// Release the process lock.
+/// READ-ONLY: is this state dir held by a live process OTHER than ours?
+///
+/// forjar#310. The apply pipeline validates BEFORE it acquires: `apply_pre_validate`
+/// (and therefore `check_pre_apply_drift`, which persists `ResourceStatus::Drifted`)
+/// runs at cli/apply.rs, while `acquire_process_lock` is not reached until
+/// executor/mod.rs. So a second concurrent apply would run the drift check,
+/// WRITE state.lock.yaml and re-seal its `.b3` — over the state belonging to the
+/// run that holds the lock — and only THEN be refused:
+///
+///     error: state directory is locked by PID 1034915
+///     state.lock.yaml: MUTATED by the REFUSED apply
+///
+/// Measured, not inferred.
+///
+/// This is deliberately a READ-ONLY PROBE and not an early acquire.
+/// `acquire_process_lock` uses `create_new` and is not reentrant, so acquiring
+/// here would make the executor's own later acquire fail against our own PID.
+/// Changing that lock's lifetime is a real concurrency change; refusing early on
+/// an observation is not. It also cannot reap a stale lock — that stays the
+/// acquirer's job, so a dead PID does not block the pre-check.
+///
+/// Returns `None` when free, stale, unreadable, or held by US. Not a substitute
+/// for acquiring: between this probe and the acquire another process may win.
+/// It only ensures the LOSER has not written anything first.
+pub fn locked_by_other_live_pid(state_dir: &Path) -> Option<String> {
+    let lock_path = process_lock_path(state_dir);
+    let content = std::fs::read_to_string(&lock_path).ok()?;
+    match classify_lock_owner(&content, is_pid_running) {
+        LockOwner::Live(pid) if pid != std::process::id() => Some(format!(
+            "state directory is locked by PID {} ({}). \
+             If this is stale, run: forjar apply --force-unlock",
+            pid,
+            lock_path.display()
+        )),
+        _ => None,
+    }
+}
+
 pub fn release_process_lock(state_dir: &Path) {
     let lock_path = process_lock_path(state_dir);
     let _ = std::fs::remove_file(&lock_path);

--- a/src/core/state/process_lock/tests.rs
+++ b/src/core/state/process_lock/tests.rs
@@ -316,3 +316,55 @@ fn test_165_reap_reports_live_pid_held() {
     // The live lock must remain untouched.
     assert!(lock_path.exists());
 }
+
+// ── forjar#310: refuse before writing ────────────────────────────────────────
+
+#[test]
+fn locked_by_other_live_pid_reports_a_live_foreign_holder() {
+    let d = tempfile::tempdir().unwrap();
+    // PID 1 exists on every unix and is never us.
+    std::fs::write(process_lock_path(d.path()), "pid: 1\nhost: somewhere\n").unwrap();
+    let v = locked_by_other_live_pid(d.path());
+    assert!(
+        v.is_some_and(|m| m.contains("locked by PID 1")),
+        "a live foreign holder must be reported"
+    );
+}
+
+#[test]
+fn locked_by_other_live_pid_is_silent_for_free_stale_and_self() {
+    let d = tempfile::tempdir().unwrap();
+
+    assert!(
+        locked_by_other_live_pid(d.path()).is_none(),
+        "an unlocked state dir must not be reported as locked"
+    );
+
+    // OUR OWN pid must not block us — otherwise the probe refuses every apply
+    // the moment the lock's lifetime is ever moved earlier.
+    std::fs::write(
+        process_lock_path(d.path()),
+        format!("pid: {}\nhost: self\n", std::process::id()),
+    )
+    .unwrap();
+    assert!(
+        locked_by_other_live_pid(d.path()).is_none(),
+        "our own lock must not refuse us"
+    );
+
+    // Stale (dead PID). Reaping stays the ACQUIRER's job, so a read-only probe
+    // must not block — otherwise a crashed run wedges the state dir against a
+    // check that can never clear it.
+    std::fs::write(process_lock_path(d.path()), "pid: 4294967290\nhost: dead\n").unwrap();
+    assert!(
+        locked_by_other_live_pid(d.path()).is_none(),
+        "a stale lock must not be treated as held — the acquirer reaps it"
+    );
+
+    // Garbage must not invent a verdict in either direction.
+    std::fs::write(process_lock_path(d.path()), "not a lock file at all").unwrap();
+    assert!(
+        locked_by_other_live_pid(d.path()).is_none(),
+        "unparseable lock content must not be reported as a live holder"
+    );
+}


### PR DESCRIPTION
Refs #310 — the last of the gate's structural must-fixes.

The apply pipeline **validates before it acquires**. `apply_pre_validate` — and therefore `check_pre_apply_drift`, which persists `ResourceStatus::Drifted` — runs in `cli/apply.rs`, while `acquire_process_lock` is not reached until `executor/mod.rs:313`.

So a second concurrent apply did its whole drift pass, rewrote `state.lock.yaml` and re-sealed the `.b3` **over the state belonging to the run holding the lock**, and only then was refused. Measured, not inferred:

```
error: state directory is locked by PID 1034915 (st/.forjar.lock)
state.lock: MUTATED by the REFUSED apply
```

**The loser of the race corrupts the winner's state and then reports that it did nothing.**

## A read-only probe, not an early acquire

That distinction is the whole design. `acquire_process_lock` uses `create_new` and is **not reentrant**, so acquiring in pre-validate would make the executor's own later acquire fail against our own PID. Moving that lock's lifetime is a real concurrency change and deserves its own scrutiny; refusing early on an *observation* is not.

The probe also deliberately does **not** reap a stale lock. Reaping stays the acquirer's job — a read-only check that can block but never clear would let one crashed run wedge the state dir permanently.

**It does not close the race**, and doesn't claim to: between probe and acquire another process can still win. It ensures only that the loser hasn't written anything first, which is the actual damage.

## Tests cover the silent cases as carefully as the loud one

A probe that refuses too eagerly is worse than the bug:

| case | expected |
|---|---|
| live **foreign** pid | reported |
| no lock | silent |
| **our own** pid | silent — or the probe refuses every apply the moment the lock lifetime is ever moved earlier |
| **stale** dead pid | silent — the acquirer reaps it |
| garbage content | silent — invent no verdict in either direction |

Verified end-to-end against a held lock: refused apply leaves `state.lock` **UNCHANGED** where the previous build left it **MUTATED** — and the control, a normal apply with no lock held, still converges a tampered file.

**13,118 pass.** The 5 failures are pre-existing on `origin/main`. fmt and `clippy --all-targets -- -D warnings` clean.