### PR TITLE
fix(release): the staging dir is a fixed path on a runner that is not ephemeral

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -253,6 +253,24 @@ jobs:
     if: needs.verify.outputs.has_binaries == 'true'
     runs-on: [self-hosted, clean-room]
     steps:
+      # THE STAGING DIR IS A FIXED PATH ON A RUNNER THAT IS NOT EPHEMERAL.
+      #
+      # `download-artifact` writes into /tmp/release-assets and does NOT clear
+      # it first. On a GitHub-hosted runner /tmp is fresh every job so that is
+      # free; these runners are self-hosted and /tmp persists. The steps below
+      # then glob `*.tar.gz` — so whatever the PREVIOUS release left behind is
+      # swept into this one's checksums and uploaded to this one's tag.
+      #
+      # Measured on v1.18.0: four `forjar-1.17.0-*.tar.gz` assets attached to
+      # the v1.18.0 release, and SHA256SUMS carrying 10 lines instead of 6 —
+      # four of them for a version this release is not.
+      #
+      # Same family as the fleet's standing rule that a self-hosted workspace IS
+      # a cache: any fixed path on these runners holds the last job's output
+      # until something removes it.
+      - name: Clear the staging directory
+        run: rm -rf /tmp/release-assets && mkdir -p /tmp/release-assets
+
       - name: Download all binary artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
@@ -260,10 +278,37 @@ jobs:
           merge-multiple: true
           path: /tmp/release-assets
 
-      - name: Generate SHA256SUMS
+      - name: Refuse to publish anything that is not this release
         working-directory: /tmp/release-assets
         run: |
+          set -euo pipefail
+          ver="${RELEASE_TAG#v}"
+          stray=0
+          for f in *.tar.gz; do
+            case "$f" in
+              forjar-"$ver"-*) ;;
+              *) echo "::error::staging holds $f, which is not $RELEASE_TAG"; stray=1 ;;
+            esac
+          done
+          # A CLEAN DIRECTORY IS NOT PROOF THE CLEAR WORKED — an empty staging
+          # dir would also pass a "no strays" test while publishing nothing. So
+          # assert the denominator too.
+          n=$(ls -1 *.tar.gz 2>/dev/null | wc -l)
+          echo "staging holds $n archive(s) for $RELEASE_TAG"
+          [ "$n" -gt 0 ] || { echo "::error::no archives staged — nothing to publish"; exit 1; }
+          [ "$stray" -eq 0 ] || exit 1
+
+      - name: Generate SHA256SUMS and per-asset sidecars
+        working-directory: /tmp/release-assets
+        run: |
+          set -euo pipefail
           sha256sum *.tar.gz > SHA256SUMS
+          # Per-asset `.sha256` as well, because binary-release.yml produces
+          # them and install.sh falls back to them when SHA256SUMS is missing.
+          # Two producers writing to one release with different conventions is
+          # how v1.18.0 ended up with sidecars for its Linux assets and none for
+          # its macOS ones.
+          for f in *.tar.gz; do sha256sum "$f" > "$f.sha256"; done
           echo "=== SHA256SUMS ==="
           cat SHA256SUMS
 
@@ -273,7 +318,7 @@ jobs:
         working-directory: /tmp/release-assets
         run: |
           gh release upload "$RELEASE_TAG" \
-            *.tar.gz SHA256SUMS \
+            *.tar.gz *.tar.gz.sha256 SHA256SUMS \
             --repo "${{ github.repository }}" \
             --clobber
 

--- a/install.sh
+++ b/install.sh
@@ -138,8 +138,28 @@ verify_checksum() {
   [ -n "$CHECKSUMS" ] || die "failed to download checksums for $TAG"
   EXPECTED=$(echo "$CHECKSUMS" | grep "$ASSET" | awk '{print $1}')
   if [ -z "$EXPECTED" ]; then
-    warn "no checksum found for $ASSET -- skipping verification"
-    return
+    # A CHECKSUM FILE THAT DOES NOT MENTION THIS ASSET IS NOT A PASS.
+    #
+    # This used to `warn ... skipping verification` and INSTALL ANYWAY. The
+    # dangerous case is not a missing SHA256SUMS — that path already dies above.
+    # It is a STALE one: it downloads fine, so the per-asset fallback never
+    # fires, and the grep simply finds nothing.
+    #
+    # forjar v1.18.0 came within one asset of this. Its SHA256SUMS was written
+    # by a run that globbed a reused staging directory, so it carried four
+    # entries for 1.17.0 alongside 1.18.0's. Had the macOS archives been
+    # uploaded by the later run instead of the earlier one, every mac install
+    # would have printed a warning and proceeded unverified.
+    #
+    # Try the per-asset sidecar before giving up, then refuse.
+    CHECKSUMS=$(download "https://github.com/${REPO}/releases/download/${TAG}/${ASSET}.sha256" 2>/dev/null) || CHECKSUMS=""
+    EXPECTED=$(echo "$CHECKSUMS" | grep "$ASSET" | awk '{print $1}')
+  fi
+  if [ -z "$EXPECTED" ]; then
+    # Wording note: do NOT write "for $ASSET" here. bashrs's SC1086 parses that
+    # literal sequence inside a string as a for-loop over an expanded variable
+    # and fails the dist lint gate, which is a required check.
+    die "$TAG publishes no checksum matching asset $ASSET -- refusing to install unverified"
   fi
   ACTUAL=$(compute_checksum "$ARCHIVE")
   if [ "$ACTUAL" != "$EXPECTED" ]; then

--- a/src/cli/dist_generators.rs
+++ b/src/cli/dist_generators.rs
@@ -21,8 +21,28 @@ verify_checksum() {{
   [ -n "$CHECKSUMS" ] || die "failed to download checksums for $TAG"
   EXPECTED=$(echo "$CHECKSUMS" | grep "$ASSET" | awk '{{print $1}}')
   if [ -z "$EXPECTED" ]; then
-    warn "no checksum found for $ASSET -- skipping verification"
-    return
+    # A CHECKSUM FILE THAT DOES NOT MENTION THIS ASSET IS NOT A PASS.
+    #
+    # This used to `warn ... skipping verification` and INSTALL ANYWAY. The
+    # dangerous case is not a missing SHA256SUMS — that path already dies above.
+    # It is a STALE one: it downloads fine, so the per-asset fallback never
+    # fires, and the grep simply finds nothing.
+    #
+    # forjar v1.18.0 came within one asset of this. Its SHA256SUMS was written
+    # by a run that globbed a reused staging directory, so it carried four
+    # entries for 1.17.0 alongside 1.18.0's. Had the macOS archives been
+    # uploaded by the later run instead of the earlier one, every mac install
+    # would have printed a warning and proceeded unverified.
+    #
+    # Try the per-asset sidecar before giving up, then refuse.
+    CHECKSUMS=$(download "https://github.com/${{REPO}}/releases/download/${{TAG}}/${{ASSET}}.sha256" 2>/dev/null) || CHECKSUMS=""
+    EXPECTED=$(echo "$CHECKSUMS" | grep "$ASSET" | awk '{{print $1}}')
+  fi
+  if [ -z "$EXPECTED" ]; then
+    # Wording note: do NOT write "for $ASSET" here. bashrs's SC1086 parses that
+    # literal sequence inside a string as a for-loop over an expanded variable
+    # and fails the dist lint gate, which is a required check.
+    die "$TAG publishes no checksum matching asset $ASSET -- refusing to install unverified"
   fi
   ACTUAL=$(compute_checksum "$ARCHIVE")
   if [ "$ACTUAL" != "$EXPECTED" ]; then


### PR DESCRIPTION
Fixes the two defects visible on the v1.18.0 release, plus a third found while checking whether they mattered.

## 1 — Stray assets: a fixed staging path on a non-ephemeral runner

v1.18.0 carries four `forjar-1.17.0-*.tar.gz` assets, and its `SHA256SUMS` has **10 lines instead of 6** — four of them for a version this release is not.

`release.yml`'s checksums job stages into `/tmp/release-assets`, and `download-artifact` does **not** clear it. On a GitHub-hosted runner `/tmp` is fresh every job; these runners are self-hosted and it persists. So the previous release's tarballs are still there when `sha256sum *.tar.gz` and `gh release upload ... *.tar.gz` glob the directory.

Same family as the standing fleet rule that a self-hosted workspace **is** a cache.

Fixed with a clear step and a guard that refuses any archive whose name doesn't carry this release's version — and asserts a **non-zero count**, because an empty staging dir would otherwise pass a "no strays" check while publishing nothing.

## 2 — Two producers, two conventions

`binary-release.yml` writes per-asset `.sha256`; `release.yml` wrote only a combined `SHA256SUMS`. Both upload to the same release, which is why v1.18.0 has sidecars for Linux and none for macOS. `release.yml` now emits both.

## 3 — Verification degraded to "skipped", and this is the one that matters

`verify_checksum` grepped `SHA256SUMS` for the asset and, on no match:

```sh
warn "no checksum found for $ASSET -- skipping verification"
return        # ...and installed anyway
```

The per-asset fallback only fired when `SHA256SUMS` failed to **download**. A *stale* one downloads perfectly well and the grep simply finds nothing — so the failure mode the fallback existed for was the one it could not reach.

**v1.18.0 came within one asset of this.** Its `SHA256SUMS` was written by the run that globbed the reused staging dir. Had the macOS archives been uploaded by *that* run rather than the earlier clean one, every mac install would have warned and proceeded unverified. I measured it: the darwin entries are present, so nobody was affected — but by ordering, not by design.

It now tries the sidecar, then **refuses**.

## A wording trap, recorded in the code

bashrs `SC1086` parses the literal sequence `for $ASSET` **inside a string** as a for-loop and fails the dist lint gate, which is a required check. The `die` message is phrased around it with a comment saying why.

## Verified

```
dist --verify   sh -n ok · --help ok · bashrs lint (0 errors) · snippets ok
                asset URL structure ok  ->  verify: PASS
dist tests      212 passed, 0 failed   (3 were failing mid-change)
clippy --all-targets -- -D warnings: 0
```

`install.sh` is regenerated from the fixed generator and committed, so the file users fetch matches what `dist --installer` produces.

**Note for whoever regenerates it next:** `./target/release/forjar` in this repo is a **stale binary** — `CARGO_TARGET_DIR` is redirected repo-wide, so `cargo build` doesn't update `./target` and running it silently generates from old code. I hit exactly that and got the pre-fix installer back; caught by grepping the output rather than trusting the command.
