### PR TITLE
refactor: every cognitive-complexity violation in the CLI, by extraction (#321, #323)

### DIFF
--- a/.pmat/baseline.json
+++ b/.pmat/baseline.json
@@ -1,6 +1,6 @@
 {
   "version": "3.32.0",
-  "created_at": "2026-08-28T18:38:41.178351240Z",
+  "created_at": "2026-08-28T20:20:31.311695693Z",
   "git_context": null,
   "files": {
     "./build.rs": {
@@ -1591,76 +1591,76 @@
     },
     "./src/cli/apply_variants.rs": {
       "content_hash": [
-        90,
-        187,
-        15,
-        40,
-        90,
-        219,
-        120,
-        122,
-        253,
-        180,
-        248,
-        119,
-        227,
+        202,
+        18,
+        13,
         243,
-        134,
-        74,
-        165,
-        90,
-        95,
-        44,
-        206,
-        88,
-        62,
-        248,
-        105,
-        129,
-        165,
-        54,
-        109,
+        70,
+        9,
+        26,
+        182,
+        64,
+        12,
+        138,
         108,
-        174,
-        63
+        187,
+        118,
+        163,
+        224,
+        50,
+        94,
+        105,
+        28,
+        3,
+        250,
+        250,
+        194,
+        26,
+        224,
+        245,
+        28,
+        220,
+        52,
+        33,
+        205
       ],
       "score": {
-        "structural_complexity": 16.5,
+        "structural_complexity": 22.6,
         "semantic_complexity": 19.0,
-        "duplication_ratio": 20.0,
+        "duplication_ratio": 17.829912,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 95.5,
+        "total": 99.42991,
         "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./src/cli/apply_variants.rs",
         "penalties_applied": [
           {
-            "source_metric": "StructuralComplexity",
-            "amount": 1.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "Deep nesting: 5 levels"
-          },
-          {
             "source_metric": "Duplication",
             "amount": 5.0,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 42 duplicate code patterns"
+            "issue": "Found 47 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 2.170088,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 10.9%"
           },
           {
             "source_metric": "StructuralComplexity",
-            "amount": 7.5000005,
+            "amount": 2.4,
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cognitive complexity: 40"
+            "issue": "High cognitive complexity: 23"
           },
           {
             "source_metric": "SemanticComplexity",
@@ -2026,84 +2026,76 @@
     },
     "./src/cli/cbom.rs": {
       "content_hash": [
-        48,
-        66,
-        167,
-        246,
-        148,
-        172,
-        147,
-        151,
-        95,
-        61,
-        144,
-        188,
-        151,
-        173,
-        122,
-        123,
-        16,
-        133,
-        188,
-        96,
-        184,
-        242,
-        156,
-        248,
+        87,
+        71,
+        68,
         84,
-        195,
-        82,
-        181,
-        130,
-        219,
-        19,
-        101
+        168,
+        183,
+        201,
+        64,
+        239,
+        141,
+        11,
+        137,
+        24,
+        215,
+        47,
+        86,
+        93,
+        164,
+        160,
+        42,
+        145,
+        43,
+        160,
+        244,
+        167,
+        51,
+        225,
+        72,
+        80,
+        116,
+        124,
+        164
       ],
       "score": {
-        "structural_complexity": 14.0,
+        "structural_complexity": 19.3,
         "semantic_complexity": 20.0,
-        "duplication_ratio": 17.840908,
+        "duplication_ratio": 17.912088,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 91.84091,
-        "grade": "A",
+        "total": 97.21209,
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./src/cli/cbom.rs",
         "penalties_applied": [
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 1.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "Deep nesting: 5 levels"
-          },
           {
             "source_metric": "Duplication",
             "amount": 5.0,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 16 duplicate code patterns"
+            "issue": "Found 18 duplicate code patterns"
           },
           {
             "source_metric": "Duplication",
-            "amount": 2.159091,
+            "amount": 2.087912,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Code duplication: 10.8%"
+            "issue": "Code duplication: 10.4%"
           },
           {
             "source_metric": "StructuralComplexity",
-            "amount": 10.0,
+            "amount": 5.7000003,
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cognitive complexity: 51"
+            "issue": "High cognitive complexity: 34"
           }
         ],
         "critical_defects_count": 0,
@@ -4989,60 +4981,68 @@
     },
     "./src/cli/dispatch_graph.rs": {
       "content_hash": [
+        16,
+        74,
+        249,
+        209,
+        171,
         49,
-        233,
-        250,
-        47,
-        66,
-        1,
-        120,
-        123,
-        93,
-        185,
-        64,
-        161,
-        43,
-        241,
-        23,
-        32,
-        105,
-        9,
-        55,
         95,
-        174,
-        91,
-        99,
-        213,
-        122,
-        177,
-        204,
-        3,
+        12,
+        149,
+        55,
+        249,
+        181,
+        47,
+        115,
+        131,
+        124,
+        43,
+        242,
+        2,
         113,
-        223,
-        9,
-        249
+        28,
+        0,
+        136,
+        82,
+        185,
+        142,
+        102,
+        48,
+        159,
+        38,
+        139,
+        54
       ],
       "score": {
         "structural_complexity": 0.0,
         "semantic_complexity": 15.5,
-        "duplication_ratio": 20.0,
+        "duplication_ratio": 17.209303,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 5.5,
-        "total": 76.0,
-        "grade": "B",
+        "entropy_score": 5.0,
+        "total": 72.709305,
+        "grade": "B-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./src/cli/dispatch_graph.rs",
         "penalties_applied": [
           {
             "source_metric": "Duplication",
-            "amount": 4.5,
+            "amount": 5.0,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 9 duplicate code patterns"
+            "issue": "Found 20 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 2.7906978,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 14.0%"
           },
           {
             "source_metric": "StructuralComplexity",
@@ -5050,7 +5050,7 @@
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cognitive complexity: 69"
+            "issue": "High cognitive complexity: 63"
           },
           {
             "source_metric": "StructuralComplexity",
@@ -5058,7 +5058,7 @@
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cyclomatic complexity: 70"
+            "issue": "High cyclomatic complexity: 64"
           },
           {
             "source_metric": "SemanticComplexity",
@@ -5084,49 +5084,49 @@
     },
     "./src/cli/dispatch_graph_b.rs": {
       "content_hash": [
-        224,
-        245,
-        43,
-        107,
-        74,
-        135,
-        157,
-        161,
-        90,
+        40,
+        35,
+        158,
+        240,
+        246,
         72,
-        25,
-        213,
-        82,
-        68,
-        166,
-        95,
-        54,
-        61,
-        238,
-        190,
+        0,
+        106,
+        208,
+        4,
+        27,
+        220,
+        241,
+        174,
+        50,
+        244,
+        199,
+        89,
+        7,
+        52,
+        124,
+        144,
+        109,
+        88,
+        45,
+        228,
+        138,
         51,
-        19,
-        19,
-        99,
-        159,
-        92,
-        192,
-        153,
-        54,
-        56,
-        105,
-        254
+        173,
+        176,
+        216,
+        188
       ],
       "score": {
-        "structural_complexity": 4.5,
+        "structural_complexity": 21.7,
         "semantic_complexity": 15.5,
-        "duplication_ratio": 17.256859,
+        "duplication_ratio": 17.482517,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 77.25686,
-        "grade": "B",
+        "total": 94.68252,
+        "grade": "A",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./src/cli/dispatch_graph_b.rs",
@@ -5137,31 +5137,23 @@
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 10 duplicate code patterns"
+            "issue": "Found 16 duplicate code patterns"
           },
           {
             "source_metric": "Duplication",
-            "amount": 2.7431421,
+            "amount": 2.5174828,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Code duplication: 13.7%"
+            "issue": "Code duplication: 12.6%"
           },
           {
             "source_metric": "StructuralComplexity",
-            "amount": 10.0,
+            "amount": 3.3000002,
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cognitive complexity: 50"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 10.5,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cyclomatic complexity: 51"
+            "issue": "High cognitive complexity: 26"
           },
           {
             "source_metric": "SemanticComplexity",
@@ -5946,49 +5938,49 @@
     },
     "./src/cli/dispatch_status.rs": {
       "content_hash": [
-        51,
-        239,
-        95,
-        115,
-        114,
-        208,
-        25,
-        209,
-        138,
-        247,
-        78,
-        25,
+        253,
+        2,
         97,
-        227,
-        190,
+        31,
+        85,
+        52,
+        251,
+        130,
+        223,
+        174,
+        10,
+        249,
+        210,
+        61,
+        243,
+        226,
         238,
-        121,
-        36,
-        86,
-        225,
-        9,
-        219,
+        18,
+        17,
         59,
-        68,
-        63,
-        93,
-        225,
-        73,
-        41,
-        157,
-        5,
-        97
+        102,
+        234,
+        107,
+        122,
+        51,
+        140,
+        149,
+        84,
+        76,
+        197,
+        161,
+        45
       ],
       "score": {
-        "structural_complexity": 0.0,
+        "structural_complexity": 16.0,
         "semantic_complexity": 15.0,
-        "duplication_ratio": 16.61157,
+        "duplication_ratio": 16.868885,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 71.61157,
-        "grade": "B-",
+        "total": 87.86888,
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./src/cli/dispatch_status.rs",
@@ -5999,31 +5991,31 @@
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 36 duplicate code patterns"
+            "issue": "Found 51 duplicate code patterns"
           },
           {
             "source_metric": "Duplication",
-            "amount": 3.3884299,
+            "amount": 3.1311154,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Code duplication: 16.9%"
+            "issue": "Code duplication: 15.7%"
           },
           {
             "source_metric": "StructuralComplexity",
-            "amount": 10.0,
+            "amount": 6.0,
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cognitive complexity: 75"
+            "issue": "High cognitive complexity: 35"
           },
           {
             "source_metric": "StructuralComplexity",
-            "amount": 15.0,
+            "amount": 3.0,
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cyclomatic complexity: 76"
+            "issue": "High cyclomatic complexity: 36"
           },
           {
             "source_metric": "SemanticComplexity",
@@ -6049,49 +6041,49 @@
     },
     "./src/cli/dispatch_status_b.rs": {
       "content_hash": [
-        119,
-        74,
-        237,
-        169,
-        90,
-        52,
-        238,
-        241,
-        209,
-        237,
-        191,
-        68,
-        17,
-        139,
-        83,
-        26,
-        44,
-        36,
-        49,
-        253,
-        7,
+        157,
+        97,
         179,
-        172,
-        26,
+        158,
+        78,
+        217,
+        240,
+        224,
+        167,
+        18,
+        1,
+        107,
+        109,
+        16,
+        223,
+        73,
+        232,
+        47,
         127,
-        63,
-        208,
-        220,
-        208,
-        183,
-        59,
-        235
+        135,
+        217,
+        97,
+        91,
+        115,
+        25,
+        50,
+        128,
+        187,
+        240,
+        95,
+        68,
+        89
       ],
       "score": {
-        "structural_complexity": 0.0,
+        "structural_complexity": 18.4,
         "semantic_complexity": 15.0,
-        "duplication_ratio": 16.666666,
+        "duplication_ratio": 17.063292,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 71.666664,
-        "grade": "B-",
+        "total": 90.463295,
+        "grade": "A",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./src/cli/dispatch_status_b.rs",
@@ -6102,31 +6094,31 @@
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 27 duplicate code patterns"
+            "issue": "Found 36 duplicate code patterns"
           },
           {
             "source_metric": "Duplication",
-            "amount": 3.3333335,
+            "amount": 2.936709,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Code duplication: 16.7%"
+            "issue": "Code duplication: 14.7%"
           },
           {
             "source_metric": "StructuralComplexity",
-            "amount": 10.0,
+            "amount": 5.1000004,
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cognitive complexity: 65"
+            "issue": "High cognitive complexity: 32"
           },
           {
             "source_metric": "StructuralComplexity",
-            "amount": 15.0,
+            "amount": 1.5,
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cyclomatic complexity: 66"
+            "issue": "High cyclomatic complexity: 33"
           },
           {
             "source_metric": "SemanticComplexity",
@@ -6294,38 +6286,38 @@
     },
     "./src/cli/dispatch_status_ext.rs": {
       "content_hash": [
-        146,
-        40,
-        80,
-        89,
-        249,
-        36,
-        200,
-        220,
-        171,
-        71,
-        201,
-        80,
-        7,
-        206,
-        140,
-        90,
-        155,
-        63,
-        95,
-        162,
-        115,
-        60,
-        138,
-        234,
-        35,
+        126,
+        227,
+        118,
+        123,
+        70,
+        197,
+        204,
+        161,
+        46,
+        53,
+        87,
+        142,
+        93,
+        141,
+        100,
+        157,
+        217,
+        190,
+        130,
+        94,
         81,
-        116,
         185,
-        75,
-        109,
-        84,
-        235
+        123,
+        59,
+        232,
+        116,
+        78,
+        88,
+        217,
+        188,
+        139,
+        120
       ],
       "score": {
         "structural_complexity": 25.0,
@@ -6347,7 +6339,7 @@
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 15 duplicate code patterns"
+            "issue": "Found 21 duplicate code patterns"
           },
           {
             "source_metric": "SemanticComplexity",
@@ -6373,76 +6365,68 @@
     },
     "./src/cli/dispatch_status_ext_b.rs": {
       "content_hash": [
-        141,
-        201,
-        35,
-        86,
-        10,
+        128,
+        53,
         98,
-        36,
-        33,
-        255,
-        178,
-        149,
-        150,
-        106,
-        51,
-        159,
-        155,
-        17,
-        108,
-        77,
-        82,
-        29,
-        156,
-        73,
-        32,
-        90,
+        13,
+        199,
+        58,
+        243,
+        27,
+        98,
+        67,
+        170,
+        141,
+        105,
+        21,
+        110,
+        114,
+        219,
+        78,
+        197,
+        86,
+        171,
+        198,
+        134,
+        198,
+        196,
+        46,
+        239,
+        243,
         74,
-        51,
-        200,
-        109,
-        7,
-        117,
-        102
+        129,
+        36,
+        194
       ],
       "score": {
-        "structural_complexity": 0.0,
+        "structural_complexity": 25.0,
         "semantic_complexity": 15.5,
-        "duplication_ratio": 20.0,
+        "duplication_ratio": 17.152779,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 6.5,
-        "total": 77.0,
-        "grade": "B",
+        "entropy_score": 5.0,
+        "total": 97.65278,
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./src/cli/dispatch_status_ext_b.rs",
         "penalties_applied": [
           {
             "source_metric": "Duplication",
-            "amount": 3.5,
+            "amount": 5.0,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 7 duplicate code patterns"
+            "issue": "Found 16 duplicate code patterns"
           },
           {
-            "source_metric": "StructuralComplexity",
-            "amount": 10.0,
+            "source_metric": "Duplication",
+            "amount": 2.847222,
             "applied_to": [
-              "StructuralComplexity"
+              "Duplication"
             ],
-            "issue": "High cognitive complexity: 70"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 15.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cyclomatic complexity: 71"
+            "issue": "Code duplication: 14.2%"
           },
           {
             "source_metric": "SemanticComplexity",
@@ -6689,49 +6673,49 @@
     },
     "./src/cli/dispatch_validate_b.rs": {
       "content_hash": [
-        75,
-        28,
-        147,
-        250,
-        17,
-        230,
-        236,
-        124,
-        93,
-        39,
-        97,
-        11,
         160,
-        224,
-        50,
-        240,
-        125,
-        91,
-        15,
-        2,
-        105,
-        63,
-        149,
+        212,
+        138,
+        83,
+        158,
+        167,
         222,
-        114,
-        63,
+        122,
+        70,
+        190,
+        77,
+        49,
+        133,
+        24,
+        171,
         27,
-        99,
-        44,
-        15,
-        38,
-        239
+        186,
+        51,
+        240,
+        101,
+        112,
+        157,
+        229,
+        59,
+        188,
+        161,
+        176,
+        22,
+        227,
+        243,
+        247,
+        102
       ],
       "score": {
-        "structural_complexity": 23.2,
+        "structural_complexity": 25.0,
         "semantic_complexity": 17.5,
-        "duplication_ratio": 13.638344,
+        "duplication_ratio": 13.318872,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 94.33835,
-        "grade": "A",
+        "total": 95.81887,
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./src/cli/dispatch_validate_b.rs",
@@ -6742,23 +6726,15 @@
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 150 duplicate code patterns"
+            "issue": "Found 147 duplicate code patterns"
           },
           {
             "source_metric": "Duplication",
-            "amount": 6.3616557,
+            "amount": 6.681128,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Code duplication: 31.8%"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 1.8000001,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 21"
+            "issue": "Code duplication: 33.4%"
           },
           {
             "source_metric": "SemanticComplexity",
@@ -6784,49 +6760,49 @@
     },
     "./src/cli/dispatch_validate_c.rs": {
       "content_hash": [
-        43,
-        135,
-        233,
-        164,
-        22,
-        93,
-        246,
-        103,
-        193,
-        57,
-        113,
-        101,
-        86,
-        255,
-        246,
-        111,
-        155,
-        238,
-        215,
-        221,
-        55,
-        166,
-        204,
-        108,
-        12,
-        137,
-        157,
-        208,
-        122,
+        105,
+        27,
         222,
-        75,
-        168
+        108,
+        187,
+        40,
+        15,
+        204,
+        151,
+        8,
+        61,
+        223,
+        94,
+        183,
+        180,
+        91,
+        133,
+        78,
+        13,
+        68,
+        32,
+        218,
+        113,
+        148,
+        15,
+        181,
+        134,
+        103,
+        78,
+        218,
+        232,
+        48
       ],
       "score": {
-        "structural_complexity": 0.5,
+        "structural_complexity": 21.1,
         "semantic_complexity": 15.5,
-        "duplication_ratio": 17.434402,
+        "duplication_ratio": 17.430555,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 73.4344,
-        "grade": "B-",
+        "total": 94.030556,
+        "grade": "A",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./src/cli/dispatch_validate_c.rs",
@@ -6841,7 +6817,7 @@
           },
           {
             "source_metric": "Duplication",
-            "amount": 2.5655975,
+            "amount": 2.5694444,
             "applied_to": [
               "Duplication"
             ],
@@ -6849,19 +6825,11 @@
           },
           {
             "source_metric": "StructuralComplexity",
-            "amount": 10.0,
+            "amount": 3.9,
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cognitive complexity: 58"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 14.5,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cyclomatic complexity: 59"
+            "issue": "High cognitive complexity: 28"
           },
           {
             "source_metric": "SemanticComplexity",
@@ -7803,48 +7771,48 @@
     },
     "./src/cli/drift.rs": {
       "content_hash": [
-        148,
-        240,
-        43,
-        12,
-        220,
-        155,
-        4,
-        53,
-        79,
-        119,
-        6,
-        168,
-        78,
-        205,
-        172,
-        84,
-        193,
-        88,
-        85,
+        162,
+        167,
+        128,
         3,
-        120,
-        14,
-        94,
-        147,
-        121,
-        116,
-        94,
-        250,
-        248,
-        41,
-        81,
-        30
+        57,
+        28,
+        165,
+        134,
+        159,
+        227,
+        176,
+        126,
+        183,
+        98,
+        95,
+        196,
+        57,
+        98,
+        8,
+        48,
+        142,
+        212,
+        0,
+        90,
+        155,
+        200,
+        119,
+        21,
+        135,
+        32,
+        197,
+        175
       ],
       "score": {
-        "structural_complexity": 7.0,
+        "structural_complexity": 8.5,
         "semantic_complexity": 17.5,
-        "duplication_ratio": 17.258064,
+        "duplication_ratio": 17.291666,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 81.758064,
+        "total": 83.291664,
         "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
@@ -7856,15 +7824,15 @@
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 42 duplicate code patterns"
+            "issue": "Found 39 duplicate code patterns"
           },
           {
             "source_metric": "Duplication",
-            "amount": 2.7419355,
+            "amount": 2.7083335,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Code duplication: 13.7%"
+            "issue": "Code duplication: 13.5%"
           },
           {
             "source_metric": "StructuralComplexity",
@@ -7872,15 +7840,15 @@
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cognitive complexity: 70"
+            "issue": "High cognitive complexity: 55"
           },
           {
             "source_metric": "StructuralComplexity",
-            "amount": 8.0,
+            "amount": 6.5,
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cyclomatic complexity: 46"
+            "issue": "High cyclomatic complexity: 43"
           },
           {
             "source_metric": "SemanticComplexity",
@@ -8333,48 +8301,48 @@
     },
     "./src/cli/fleet_reporting.rs": {
       "content_hash": [
-        46,
-        58,
-        63,
-        34,
-        122,
-        18,
-        242,
-        161,
-        140,
-        189,
-        215,
-        54,
-        97,
-        163,
-        240,
-        9,
-        187,
-        211,
-        212,
-        140,
-        100,
-        163,
+        158,
+        156,
         236,
-        215,
-        111,
-        234,
-        224,
-        211,
-        116,
-        210,
-        176,
-        92
+        101,
+        44,
+        3,
+        255,
+        153,
+        181,
+        77,
+        199,
+        134,
+        88,
+        121,
+        120,
+        24,
+        174,
+        225,
+        119,
+        160,
+        19,
+        231,
+        98,
+        118,
+        26,
+        32,
+        181,
+        73,
+        104,
+        83,
+        93,
+        4
       ],
       "score": {
-        "structural_complexity": 3.5,
+        "structural_complexity": 4.0,
         "semantic_complexity": 20.0,
         "duplication_ratio": 20.0,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 83.5,
+        "total": 84.0,
         "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
@@ -8386,7 +8354,7 @@
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 36 duplicate code patterns"
+            "issue": "Found 34 duplicate code patterns"
           },
           {
             "source_metric": "StructuralComplexity",
@@ -8394,15 +8362,15 @@
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cognitive complexity: 90"
+            "issue": "High cognitive complexity: 82"
           },
           {
             "source_metric": "StructuralComplexity",
-            "amount": 11.5,
+            "amount": 11.0,
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cyclomatic complexity: 53"
+            "issue": "High cyclomatic complexity: 52"
           }
         ],
         "critical_defects_count": 0,
@@ -9979,76 +9947,68 @@
     },
     "./src/cli/graph_intelligence_ext.rs": {
       "content_hash": [
-        171,
-        103,
-        184,
-        141,
-        141,
-        230,
-        121,
-        9,
-        148,
-        140,
-        66,
-        236,
-        115,
-        59,
-        234,
-        0,
-        245,
-        152,
-        142,
-        6,
-        158,
-        29,
-        240,
-        70,
-        74,
-        64,
-        182,
-        209,
-        99,
-        211,
-        174,
-        156
+        114,
+        32,
+        92,
+        238,
+        248,
+        23,
+        156,
+        30,
+        147,
+        166,
+        150,
+        250,
+        139,
+        60,
+        161,
+        78,
+        46,
+        58,
+        68,
+        227,
+        35,
+        49,
+        200,
+        133,
+        7,
+        147,
+        46,
+        155,
+        170,
+        47,
+        126,
+        154
       ],
       "score": {
-        "structural_complexity": 2.0,
-        "semantic_complexity": 17.5,
-        "duplication_ratio": 17.135416,
+        "structural_complexity": 4.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 17.368422,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 76.635414,
-        "grade": "B",
+        "total": 81.36842,
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./src/cli/graph_intelligence_ext.rs",
         "penalties_applied": [
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 1.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "Deep nesting: 5 levels"
-          },
           {
             "source_metric": "Duplication",
             "amount": 5.0,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 37 duplicate code patterns"
+            "issue": "Found 33 duplicate code patterns"
           },
           {
             "source_metric": "Duplication",
-            "amount": 2.8645835,
+            "amount": 2.631579,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Code duplication: 14.3%"
+            "issue": "Code duplication: 13.2%"
           },
           {
             "source_metric": "StructuralComplexity",
@@ -10056,23 +10016,15 @@
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cognitive complexity: 91"
+            "issue": "High cognitive complexity: 80"
           },
           {
             "source_metric": "StructuralComplexity",
-            "amount": 12.0,
+            "amount": 11.0,
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cyclomatic complexity: 54"
-          },
-          {
-            "source_metric": "SemanticComplexity",
-            "amount": 2.5,
-            "applied_to": [
-              "SemanticComplexity"
-            ],
-            "issue": "Too many parameters: 10"
+            "issue": "High cyclomatic complexity: 52"
           }
         ],
         "critical_defects_count": 0,
@@ -10185,61 +10137,53 @@
     },
     "./src/cli/graph_intelligence_ext2_b.rs": {
       "content_hash": [
-        105,
-        137,
-        156,
-        34,
-        71,
-        2,
-        49,
-        213,
         138,
-        239,
-        107,
-        20,
-        13,
-        178,
-        189,
+        141,
+        247,
         161,
+        218,
+        202,
+        208,
+        163,
         149,
-        254,
-        112,
-        32,
-        154,
-        222,
-        191,
-        136,
-        19,
-        156,
-        126,
-        122,
-        109,
-        66,
-        129,
-        91
+        46,
+        127,
+        14,
+        23,
+        181,
+        100,
+        63,
+        123,
+        102,
+        108,
+        176,
+        114,
+        50,
+        54,
+        97,
+        159,
+        253,
+        0,
+        61,
+        221,
+        221,
+        117,
+        19
       ],
       "score": {
-        "structural_complexity": 8.5,
+        "structural_complexity": 9.5,
         "semantic_complexity": 20.0,
-        "duplication_ratio": 16.67774,
+        "duplication_ratio": 16.721312,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 85.17774,
+        "total": 86.22131,
         "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./src/cli/graph_intelligence_ext2_b.rs",
         "penalties_applied": [
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 1.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "Deep nesting: 5 levels"
-          },
           {
             "source_metric": "Duplication",
             "amount": 5.0,
@@ -10250,11 +10194,11 @@
           },
           {
             "source_metric": "Duplication",
-            "amount": 3.3222592,
+            "amount": 3.2786884,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Code duplication: 16.6%"
+            "issue": "Code duplication: 16.4%"
           },
           {
             "source_metric": "StructuralComplexity",
@@ -10262,7 +10206,7 @@
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cognitive complexity: 80"
+            "issue": "High cognitive complexity: 72"
           },
           {
             "source_metric": "StructuralComplexity",
@@ -10288,61 +10232,53 @@
     },
     "./src/cli/graph_intelligence_ext_b.rs": {
       "content_hash": [
-        76,
-        203,
+        129,
+        243,
         181,
-        224,
-        34,
-        102,
-        115,
-        146,
-        214,
-        45,
-        230,
-        75,
-        199,
-        248,
-        193,
-        217,
-        180,
-        145,
-        112,
-        65,
-        16,
+        41,
+        1,
+        174,
+        165,
+        225,
+        203,
+        218,
+        249,
         192,
-        221,
-        118,
-        5,
-        46,
-        127,
-        59,
-        200,
-        162,
-        180,
-        52
+        121,
+        36,
+        8,
+        188,
+        215,
+        170,
+        128,
+        71,
+        201,
+        229,
+        90,
+        42,
+        153,
+        159,
+        148,
+        38,
+        209,
+        82,
+        25,
+        237
       ],
       "score": {
-        "structural_complexity": 0.0,
+        "structural_complexity": 0.5,
         "semantic_complexity": 20.0,
-        "duplication_ratio": 16.59824,
+        "duplication_ratio": 16.569767,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 76.598236,
+        "total": 77.06976,
         "grade": "B",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./src/cli/graph_intelligence_ext_b.rs",
         "penalties_applied": [
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 1.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "Deep nesting: 5 levels"
-          },
           {
             "source_metric": "Duplication",
             "amount": 5.0,
@@ -10353,11 +10289,11 @@
           },
           {
             "source_metric": "Duplication",
-            "amount": 3.4017596,
+            "amount": 3.4302328,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Code duplication: 17.0%"
+            "issue": "Code duplication: 17.2%"
           },
           {
             "source_metric": "StructuralComplexity",
@@ -10365,7 +10301,7 @@
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cognitive complexity: 106"
+            "issue": "High cognitive complexity: 98"
           },
           {
             "source_metric": "StructuralComplexity",
@@ -10921,48 +10857,48 @@
     },
     "./src/cli/graph_scoring.rs": {
       "content_hash": [
-        255,
-        143,
-        64,
-        217,
-        106,
-        97,
-        207,
+        232,
+        237,
+        46,
+        24,
+        233,
         227,
-        4,
-        173,
-        21,
-        238,
-        36,
+        76,
+        72,
+        66,
+        42,
         67,
         166,
-        204,
-        80,
+        33,
+        86,
+        119,
+        168,
+        67,
+        252,
         187,
-        247,
-        8,
-        122,
-        92,
-        21,
-        144,
-        53,
-        96,
-        176,
-        23,
-        118,
-        71,
-        220,
-        75
+        12,
+        253,
+        208,
+        225,
+        97,
+        133,
+        251,
+        19,
+        166,
+        94,
+        72,
+        171,
+        154
       ],
       "score": {
-        "structural_complexity": 8.5,
+        "structural_complexity": 9.5,
         "semantic_complexity": 20.0,
-        "duplication_ratio": 16.666666,
+        "duplication_ratio": 16.64516,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 85.166664,
+        "total": 86.14516,
         "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
@@ -10974,15 +10910,15 @@
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 30 duplicate code patterns"
+            "issue": "Found 29 duplicate code patterns"
           },
           {
             "source_metric": "Duplication",
-            "amount": 3.3333335,
+            "amount": 3.3548388,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Code duplication: 16.7%"
+            "issue": "Code duplication: 16.8%"
           },
           {
             "source_metric": "StructuralComplexity",
@@ -10990,15 +10926,15 @@
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cognitive complexity: 80"
+            "issue": "High cognitive complexity: 73"
           },
           {
             "source_metric": "StructuralComplexity",
-            "amount": 6.5,
+            "amount": 5.5,
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cyclomatic complexity: 43"
+            "issue": "High cyclomatic complexity: 41"
           }
         ],
         "critical_defects_count": 0,
@@ -11546,76 +11482,68 @@
     },
     "./src/cli/graph_visualization.rs": {
       "content_hash": [
-        185,
-        124,
-        86,
-        219,
-        165,
-        51,
-        75,
-        6,
-        91,
-        59,
-        153,
-        197,
-        123,
-        225,
-        200,
-        248,
-        229,
-        255,
-        103,
-        232,
-        207,
-        90,
-        105,
-        250,
-        177,
+        167,
+        94,
+        33,
+        182,
+        168,
+        137,
+        139,
+        220,
+        222,
+        139,
+        112,
+        37,
+        118,
+        4,
+        67,
+        117,
+        218,
+        209,
+        202,
+        121,
+        118,
+        37,
+        45,
+        122,
+        234,
+        87,
+        88,
         13,
-        231,
-        132,
-        175,
-        10,
-        146,
-        52
+        255,
+        59,
+        143,
+        117
       ],
       "score": {
-        "structural_complexity": 1.5,
+        "structural_complexity": 4.0,
         "semantic_complexity": 20.0,
-        "duplication_ratio": 15.6654,
+        "duplication_ratio": 15.812275,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 77.1654,
+        "total": 79.81227,
         "grade": "B",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./src/cli/graph_visualization.rs",
         "penalties_applied": [
           {
-            "source_metric": "StructuralComplexity",
-            "amount": 1.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "Deep nesting: 5 levels"
-          },
-          {
             "source_metric": "Duplication",
             "amount": 5.0,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 36 duplicate code patterns"
+            "issue": "Found 40 duplicate code patterns"
           },
           {
             "source_metric": "Duplication",
-            "amount": 4.334601,
+            "amount": 4.1877255,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Code duplication: 21.7%"
+            "issue": "Code duplication: 20.9%"
           },
           {
             "source_metric": "StructuralComplexity",
@@ -11623,15 +11551,15 @@
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cognitive complexity: 116"
+            "issue": "High cognitive complexity: 103"
           },
           {
             "source_metric": "StructuralComplexity",
-            "amount": 12.5,
+            "amount": 11.0,
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cyclomatic complexity: 55"
+            "issue": "High cyclomatic complexity: 52"
           }
         ],
         "critical_defects_count": 0,
@@ -12534,49 +12462,49 @@
     },
     "./src/cli/infra.rs": {
       "content_hash": [
-        244,
-        155,
-        176,
         157,
-        62,
-        195,
-        240,
-        152,
-        101,
-        101,
-        152,
-        182,
-        102,
-        171,
-        11,
-        2,
-        211,
-        28,
-        11,
-        179,
-        235,
-        96,
+        168,
+        202,
+        175,
+        81,
+        242,
+        82,
+        212,
+        141,
         108,
-        52,
-        73,
-        179,
-        231,
+        11,
+        103,
+        35,
+        45,
+        20,
+        201,
+        96,
+        86,
+        15,
+        169,
+        18,
+        36,
+        80,
         199,
-        244,
-        246,
-        237,
-        251
+        44,
+        255,
+        213,
+        202,
+        124,
+        1,
+        11,
+        80
       ],
       "score": {
-        "structural_complexity": 11.5,
+        "structural_complexity": 19.6,
         "semantic_complexity": 20.0,
-        "duplication_ratio": 17.617022,
+        "duplication_ratio": 17.877552,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 89.11702,
-        "grade": "A-",
+        "total": 97.477554,
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./src/cli/infra.rs",
@@ -12587,31 +12515,23 @@
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 28 duplicate code patterns"
+            "issue": "Found 27 duplicate code patterns"
           },
           {
             "source_metric": "Duplication",
-            "amount": 2.382979,
+            "amount": 2.122449,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Code duplication: 11.9%"
+            "issue": "Code duplication: 10.6%"
           },
           {
             "source_metric": "StructuralComplexity",
-            "amount": 10.0,
+            "amount": 5.4,
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cognitive complexity: 58"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 3.5,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cyclomatic complexity: 37"
+            "issue": "High cognitive complexity: 33"
           }
         ],
         "critical_defects_count": 0,
@@ -12724,48 +12644,48 @@
     },
     "./src/cli/infra_bench_baseline.rs": {
       "content_hash": [
-        192,
-        240,
-        228,
-        88,
-        1,
-        179,
-        167,
-        216,
-        65,
-        225,
-        42,
-        129,
-        31,
-        127,
-        245,
-        184,
-        30,
-        134,
-        66,
-        48,
-        78,
-        254,
-        255,
-        189,
-        4,
-        171,
+        85,
+        137,
+        35,
+        124,
+        143,
         57,
-        185,
-        207,
-        163,
+        58,
+        187,
+        77,
+        211,
+        187,
+        131,
+        54,
+        165,
         120,
-        232
+        67,
+        11,
+        228,
+        113,
+        145,
+        85,
+        113,
+        165,
+        141,
+        112,
+        158,
+        192,
+        86,
+        185,
+        138,
+        175,
+        153
       ],
       "score": {
-        "structural_complexity": 22.6,
+        "structural_complexity": 23.8,
         "semantic_complexity": 20.0,
         "duplication_ratio": 20.0,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 93.27273,
+        "total": 94.36364,
         "grade": "A",
         "confidence": 1.0,
         "language": "Rust",
@@ -12777,15 +12697,15 @@
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 15 duplicate code patterns"
+            "issue": "Found 14 duplicate code patterns"
           },
           {
             "source_metric": "StructuralComplexity",
-            "amount": 2.4,
+            "amount": 1.2,
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cognitive complexity: 23"
+            "issue": "High cognitive complexity: 19"
           }
         ],
         "critical_defects_count": 0,
@@ -12803,68 +12723,68 @@
     },
     "./src/cli/infra_query.rs": {
       "content_hash": [
-        21,
-        138,
-        147,
-        13,
-        74,
-        197,
-        149,
-        134,
-        90,
-        142,
-        79,
-        98,
-        161,
-        135,
-        226,
-        122,
-        55,
-        207,
-        210,
-        177,
-        131,
-        29,
-        16,
-        82,
+        123,
+        101,
         120,
-        249,
-        157,
-        205,
-        114,
-        70,
+        217,
+        23,
+        17,
+        27,
+        171,
+        101,
+        23,
+        71,
         62,
-        220
+        171,
+        120,
+        91,
+        213,
+        235,
+        10,
+        220,
+        136,
+        230,
+        54,
+        245,
+        91,
+        237,
+        163,
+        105,
+        141,
+        131,
+        210,
+        110,
+        157
       ],
       "score": {
-        "structural_complexity": 19.3,
+        "structural_complexity": 22.9,
         "semantic_complexity": 20.0,
         "duplication_ratio": 20.0,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 5.5,
-        "total": 99.8,
-        "grade": "A+",
+        "entropy_score": 6.5,
+        "total": 94.90909,
+        "grade": "A",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./src/cli/infra_query.rs",
         "penalties_applied": [
           {
             "source_metric": "Duplication",
-            "amount": 4.5,
+            "amount": 3.5,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 9 duplicate code patterns"
+            "issue": "Found 7 duplicate code patterns"
           },
           {
             "source_metric": "StructuralComplexity",
-            "amount": 5.7000003,
+            "amount": 2.1000001,
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cognitive complexity: 34"
+            "issue": "High cognitive complexity: 22"
           }
         ],
         "critical_defects_count": 0,
@@ -13190,61 +13110,53 @@
     },
     "./src/cli/lint.rs": {
       "content_hash": [
-        54,
-        93,
-        48,
-        238,
-        204,
-        101,
-        120,
-        78,
-        41,
-        85,
+        215,
+        160,
+        229,
+        44,
+        143,
+        60,
+        205,
+        75,
         181,
-        146,
-        131,
-        193,
-        85,
-        7,
-        220,
-        96,
-        46,
-        221,
-        137,
-        140,
-        21,
-        31,
-        162,
-        101,
+        97,
+        36,
         100,
-        79,
-        210,
-        253,
-        53,
-        138
+        58,
+        51,
+        92,
+        225,
+        57,
+        215,
+        113,
+        246,
+        122,
+        204,
+        234,
+        178,
+        148,
+        102,
+        65,
+        129,
+        133,
+        249,
+        135,
+        103
       ],
       "score": {
         "structural_complexity": 0.0,
         "semantic_complexity": 20.0,
-        "duplication_ratio": 17.88889,
+        "duplication_ratio": 17.929155,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 77.888885,
+        "total": 77.92915,
         "grade": "B",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./src/cli/lint.rs",
         "penalties_applied": [
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 1.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "Deep nesting: 5 levels"
-          },
           {
             "source_metric": "Duplication",
             "amount": 5.0,
@@ -13255,11 +13167,11 @@
           },
           {
             "source_metric": "Duplication",
-            "amount": 2.1111112,
+            "amount": 2.0708447,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Code duplication: 10.6%"
+            "issue": "Code duplication: 10.4%"
           },
           {
             "source_metric": "StructuralComplexity",
@@ -13267,7 +13179,7 @@
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cognitive complexity: 143"
+            "issue": "High cognitive complexity: 129"
           },
           {
             "source_metric": "StructuralComplexity",
@@ -13275,7 +13187,7 @@
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cyclomatic complexity: 72"
+            "issue": "High cyclomatic complexity: 71"
           }
         ],
         "critical_defects_count": 0,
@@ -13467,38 +13379,38 @@
     },
     "./src/cli/lock_core.rs": {
       "content_hash": [
-        114,
-        249,
-        210,
-        141,
-        42,
-        10,
-        253,
-        77,
-        32,
-        175,
-        17,
-        208,
-        163,
-        248,
-        161,
-        203,
-        225,
-        18,
-        88,
-        227,
-        59,
-        87,
-        216,
-        73,
-        118,
-        4,
-        143,
+        178,
+        145,
+        117,
+        75,
         127,
-        110,
-        149,
-        218,
-        107
+        187,
+        138,
+        237,
+        200,
+        27,
+        31,
+        136,
+        34,
+        59,
+        244,
+        144,
+        222,
+        11,
+        45,
+        198,
+        127,
+        142,
+        146,
+        235,
+        121,
+        165,
+        169,
+        48,
+        210,
+        182,
+        206,
+        198
       ],
       "score": {
         "structural_complexity": 2.5,
@@ -13520,7 +13432,7 @@
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 40 duplicate code patterns"
+            "issue": "Found 43 duplicate code patterns"
           },
           {
             "source_metric": "StructuralComplexity",
@@ -13528,7 +13440,7 @@
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cognitive complexity: 93"
+            "issue": "High cognitive complexity: 84"
           },
           {
             "source_metric": "StructuralComplexity",
@@ -13562,48 +13474,48 @@
     },
     "./src/cli/lock_lifecycle.rs": {
       "content_hash": [
-        52,
-        220,
-        12,
-        162,
-        63,
-        89,
-        199,
-        174,
-        209,
-        160,
-        27,
-        69,
-        181,
-        127,
-        207,
-        156,
-        120,
-        116,
-        156,
+        17,
+        80,
+        214,
+        205,
         1,
-        70,
-        110,
-        84,
-        8,
-        144,
-        18,
-        37,
-        98,
-        67,
-        121,
-        122,
-        103
+        3,
+        159,
+        236,
+        10,
+        88,
+        143,
+        23,
+        81,
+        171,
+        179,
+        100,
+        123,
+        34,
+        163,
+        239,
+        152,
+        240,
+        112,
+        255,
+        213,
+        190,
+        138,
+        194,
+        96,
+        89,
+        231,
+        2
       ],
       "score": {
-        "structural_complexity": 16.3,
+        "structural_complexity": 17.2,
         "semantic_complexity": 20.0,
         "duplication_ratio": 20.0,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 96.3,
+        "total": 97.2,
         "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
@@ -13615,15 +13527,15 @@
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 17 duplicate code patterns"
+            "issue": "Found 18 duplicate code patterns"
           },
           {
             "source_metric": "StructuralComplexity",
-            "amount": 8.700001,
+            "amount": 7.8,
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cognitive complexity: 44"
+            "issue": "High cognitive complexity: 41"
           }
         ],
         "critical_defects_count": 0,
@@ -14084,48 +13996,48 @@
     },
     "./src/cli/logs.rs": {
       "content_hash": [
-        203,
+        255,
+        118,
+        230,
+        231,
+        40,
+        207,
+        107,
+        238,
+        137,
+        166,
+        13,
+        197,
+        223,
+        97,
+        207,
+        135,
+        21,
+        27,
+        184,
+        81,
+        209,
+        32,
+        107,
+        204,
+        103,
+        123,
         108,
         215,
-        3,
-        138,
-        66,
-        11,
-        140,
-        19,
-        93,
-        39,
-        123,
-        9,
-        103,
-        208,
-        221,
-        129,
-        61,
-        230,
-        136,
-        49,
-        193,
-        113,
-        95,
-        250,
-        76,
-        78,
-        229,
-        98,
-        209,
-        191,
-        26
+        67,
+        255,
+        170,
+        29
       ],
       "score": {
-        "structural_complexity": 1.5,
+        "structural_complexity": 4.5,
         "semantic_complexity": 18.5,
-        "duplication_ratio": 20.0,
+        "duplication_ratio": 17.873417,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 80.0,
+        "total": 80.87341,
         "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
@@ -14137,7 +14049,15 @@
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 39 duplicate code patterns"
+            "issue": "Found 40 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 2.1265821,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 10.6%"
           },
           {
             "source_metric": "StructuralComplexity",
@@ -14145,15 +14065,15 @@
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cognitive complexity: 83"
+            "issue": "High cognitive complexity: 73"
           },
           {
             "source_metric": "StructuralComplexity",
-            "amount": 13.5,
+            "amount": 10.5,
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cyclomatic complexity: 57"
+            "issue": "High cyclomatic complexity: 51"
           },
           {
             "source_metric": "SemanticComplexity",
@@ -14250,48 +14170,48 @@
     },
     "./src/cli/logs_gc.rs": {
       "content_hash": [
-        199,
-        108,
         235,
-        98,
-        97,
-        181,
-        195,
-        16,
-        110,
-        0,
-        81,
-        97,
-        215,
-        189,
-        208,
-        34,
-        9,
-        44,
-        111,
-        187,
-        145,
-        101,
-        19,
-        46,
-        171,
-        20,
-        232,
-        7,
-        91,
+        83,
+        242,
         43,
+        145,
+        231,
+        52,
+        30,
+        188,
+        209,
+        141,
+        37,
+        152,
+        244,
+        150,
+        208,
+        92,
+        250,
+        26,
+        195,
+        224,
         81,
-        109
+        52,
+        205,
+        132,
+        52,
+        161,
+        114,
+        33,
+        142,
+        132,
+        167
       ],
       "score": {
-        "structural_complexity": 21.1,
-        "semantic_complexity": 20.0,
+        "structural_complexity": 23.5,
+        "semantic_complexity": 19.5,
         "duplication_ratio": 20.0,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 7.5,
-        "total": 94.181816,
+        "entropy_score": 5.0,
+        "total": 93.63636,
         "grade": "A",
         "confidence": 1.0,
         "language": "Rust",
@@ -14299,19 +14219,27 @@
         "penalties_applied": [
           {
             "source_metric": "Duplication",
-            "amount": 2.5,
+            "amount": 5.0,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 5 duplicate code patterns"
+            "issue": "Found 10 duplicate code patterns"
           },
           {
             "source_metric": "StructuralComplexity",
-            "amount": 3.9,
+            "amount": 1.5,
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cognitive complexity: 28"
+            "issue": "High cognitive complexity: 20"
+          },
+          {
+            "source_metric": "SemanticComplexity",
+            "amount": 0.5,
+            "applied_to": [
+              "SemanticComplexity"
+            ],
+            "issue": "Too many parameters: 6"
           }
         ],
         "critical_defects_count": 0,
@@ -15268,48 +15196,48 @@
     },
     "./src/cli/observe.rs": {
       "content_hash": [
-        198,
-        67,
-        189,
-        112,
-        102,
-        248,
-        81,
-        70,
-        67,
-        105,
-        35,
-        163,
-        216,
-        141,
-        157,
-        201,
-        109,
-        137,
-        81,
-        11,
-        220,
-        87,
-        4,
-        229,
-        194,
-        240,
-        154,
-        81,
+        51,
+        115,
+        227,
         144,
-        215,
-        232,
-        30
+        35,
+        167,
+        161,
+        245,
+        0,
+        167,
+        249,
+        231,
+        152,
+        126,
+        74,
+        250,
+        49,
+        241,
+        19,
+        245,
+        253,
+        80,
+        82,
+        53,
+        169,
+        147,
+        168,
+        199,
+        229,
+        85,
+        141,
+        157
       ],
       "score": {
-        "structural_complexity": 17.8,
+        "structural_complexity": 19.6,
         "semantic_complexity": 20.0,
         "duplication_ratio": 20.0,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 97.8,
+        "total": 99.6,
         "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
@@ -15321,15 +15249,15 @@
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 15 duplicate code patterns"
+            "issue": "Found 16 duplicate code patterns"
           },
           {
             "source_metric": "StructuralComplexity",
-            "amount": 7.2000003,
+            "amount": 5.4,
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cognitive complexity: 39"
+            "issue": "High cognitive complexity: 33"
           }
         ],
         "critical_defects_count": 0,
@@ -16706,48 +16634,48 @@
     },
     "./src/cli/prove.rs": {
       "content_hash": [
-        6,
-        111,
-        86,
-        184,
-        242,
-        153,
-        142,
-        62,
-        212,
-        82,
-        132,
-        68,
-        233,
-        49,
-        123,
+        186,
+        151,
         182,
-        47,
-        155,
-        166,
-        226,
-        113,
-        175,
-        207,
-        134,
+        76,
+        164,
+        31,
+        130,
+        246,
+        8,
+        126,
         128,
-        222,
+        251,
+        73,
+        235,
+        45,
+        154,
+        184,
+        84,
+        141,
+        133,
+        18,
+        245,
+        233,
+        180,
         94,
-        134,
-        104,
-        114,
-        90,
-        126
+        193,
+        63,
+        66,
+        2,
+        27,
+        254,
+        131
       ],
       "score": {
-        "structural_complexity": 8.0,
+        "structural_complexity": 8.5,
         "semantic_complexity": 20.0,
-        "duplication_ratio": 17.508196,
+        "duplication_ratio": 17.692308,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 85.508194,
+        "total": 86.19231,
         "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
@@ -16763,11 +16691,11 @@
           },
           {
             "source_metric": "Duplication",
-            "amount": 2.4918034,
+            "amount": 2.3076923,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Code duplication: 12.5%"
+            "issue": "Code duplication: 11.5%"
           },
           {
             "source_metric": "StructuralComplexity",
@@ -16775,15 +16703,15 @@
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cognitive complexity: 83"
+            "issue": "High cognitive complexity: 73"
           },
           {
             "source_metric": "StructuralComplexity",
-            "amount": 7.0,
+            "amount": 6.5,
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cyclomatic complexity: 44"
+            "issue": "High cyclomatic complexity: 43"
           }
         ],
         "critical_defects_count": 0,
@@ -18658,92 +18586,84 @@
     },
     "./src/cli/state_encrypt.rs": {
       "content_hash": [
-        231,
-        111,
-        180,
-        112,
-        169,
-        155,
-        109,
-        75,
-        23,
-        47,
-        205,
-        36,
-        155,
-        249,
-        77,
-        164,
+        195,
+        198,
+        193,
+        246,
+        143,
+        210,
+        20,
+        191,
         52,
-        231,
-        57,
-        78,
-        76,
-        164,
-        192,
-        103,
-        76,
-        203,
-        95,
-        169,
-        106,
-        65,
-        161,
-        33
+        157,
+        152,
+        212,
+        162,
+        28,
+        209,
+        69,
+        4,
+        138,
+        145,
+        163,
+        130,
+        253,
+        9,
+        210,
+        198,
+        102,
+        131,
+        206,
+        85,
+        189,
+        186,
+        90
       ],
       "score": {
-        "structural_complexity": 12.0,
+        "structural_complexity": 14.599999,
         "semantic_complexity": 20.0,
-        "duplication_ratio": 17.142857,
+        "duplication_ratio": 16.983606,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 89.14285,
-        "grade": "A-",
+        "total": 91.5836,
+        "grade": "A",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./src/cli/state_encrypt.rs",
         "penalties_applied": [
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 2.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "Deep nesting: 6 levels"
-          },
           {
             "source_metric": "Duplication",
             "amount": 5.0,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 31 duplicate code patterns"
+            "issue": "Found 35 duplicate code patterns"
           },
           {
             "source_metric": "Duplication",
-            "amount": 2.857143,
+            "amount": 3.0163934,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Code duplication: 14.3%"
+            "issue": "Code duplication: 15.1%"
           },
           {
             "source_metric": "StructuralComplexity",
-            "amount": 10.0,
+            "amount": 9.900001,
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cognitive complexity: 60"
+            "issue": "High cognitive complexity: 48"
           },
           {
             "source_metric": "StructuralComplexity",
-            "amount": 1.0,
+            "amount": 0.5,
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cyclomatic complexity: 32"
+            "issue": "High cyclomatic complexity: 31"
           }
         ],
         "critical_defects_count": 0,
@@ -19102,47 +19022,47 @@
     "./src/cli/status_compliance.rs": {
       "content_hash": [
         137,
-        108,
-        93,
-        119,
-        107,
-        91,
-        173,
-        135,
-        206,
-        167,
-        57,
-        106,
-        255,
         213,
-        131,
-        233,
-        39,
-        46,
-        56,
-        61,
-        191,
+        228,
+        115,
+        124,
         100,
-        246,
-        251,
-        122,
-        209,
-        144,
+        224,
+        255,
+        12,
+        18,
+        132,
+        24,
+        62,
+        152,
+        200,
+        138,
+        18,
+        231,
+        16,
+        52,
+        50,
+        162,
+        204,
+        96,
+        86,
         213,
-        123,
-        251,
-        17,
-        103
+        118,
+        230,
+        98,
+        38,
+        111,
+        105
       ],
       "score": {
-        "structural_complexity": 8.5,
+        "structural_complexity": 10.5,
         "semantic_complexity": 20.0,
-        "duplication_ratio": 17.610064,
+        "duplication_ratio": 17.863503,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 86.11006,
+        "total": 88.3635,
         "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
@@ -19158,11 +19078,11 @@
           },
           {
             "source_metric": "Duplication",
-            "amount": 2.389937,
+            "amount": 2.1364985,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Code duplication: 11.9%"
+            "issue": "Code duplication: 10.7%"
           },
           {
             "source_metric": "StructuralComplexity",
@@ -19170,15 +19090,15 @@
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cognitive complexity: 81"
+            "issue": "High cognitive complexity: 64"
           },
           {
             "source_metric": "StructuralComplexity",
-            "amount": 6.5,
+            "amount": 4.5,
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cyclomatic complexity: 43"
+            "issue": "High cyclomatic complexity: 39"
           }
         ],
         "critical_defects_count": 0,
@@ -19275,48 +19195,48 @@
     },
     "./src/cli/status_convergence.rs": {
       "content_hash": [
-        44,
-        208,
-        230,
-        219,
-        250,
-        146,
-        238,
-        86,
-        42,
-        113,
-        250,
-        249,
-        31,
-        135,
-        115,
-        254,
-        239,
-        146,
-        125,
-        196,
-        220,
-        82,
-        88,
-        149,
-        168,
         143,
-        6,
-        68,
-        154,
-        183,
-        239,
-        96
+        211,
+        229,
+        21,
+        66,
+        174,
+        222,
+        50,
+        3,
+        125,
+        173,
+        223,
+        33,
+        139,
+        156,
+        131,
+        200,
+        142,
+        18,
+        186,
+        182,
+        88,
+        133,
+        19,
+        217,
+        147,
+        51,
+        202,
+        96,
+        230,
+        209,
+        123
       ],
       "score": {
         "structural_complexity": 0.0,
         "semantic_complexity": 20.0,
-        "duplication_ratio": 17.695852,
+        "duplication_ratio": 17.747747,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 77.695854,
+        "total": 77.74775,
         "grade": "B",
         "confidence": 1.0,
         "language": "Rust",
@@ -19328,15 +19248,15 @@
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 37 duplicate code patterns"
+            "issue": "Found 34 duplicate code patterns"
           },
           {
             "source_metric": "Duplication",
-            "amount": 2.3041475,
+            "amount": 2.2522523,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Code duplication: 11.5%"
+            "issue": "Code duplication: 11.3%"
           },
           {
             "source_metric": "StructuralComplexity",
@@ -19344,7 +19264,7 @@
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cognitive complexity: 119"
+            "issue": "High cognitive complexity: 111"
           },
           {
             "source_metric": "StructuralComplexity",
@@ -19352,7 +19272,7 @@
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cyclomatic complexity: 72"
+            "issue": "High cyclomatic complexity: 70"
           }
         ],
         "critical_defects_count": 0,
@@ -20565,48 +20485,48 @@
     },
     "./src/cli/status_health.rs": {
       "content_hash": [
-        0,
-        92,
-        101,
-        197,
-        118,
-        130,
-        149,
-        253,
-        137,
-        117,
-        141,
-        52,
-        252,
-        11,
-        4,
-        161,
+        223,
+        255,
+        195,
+        231,
+        154,
+        45,
+        54,
+        50,
+        113,
+        47,
+        237,
+        133,
+        173,
         49,
-        146,
-        33,
-        41,
-        125,
-        151,
-        128,
-        138,
-        51,
-        92,
-        17,
-        225,
-        103,
-        175,
-        210,
-        219
+        62,
+        60,
+        4,
+        29,
+        237,
+        254,
+        172,
+        7,
+        200,
+        7,
+        154,
+        135,
+        93,
+        62,
+        220,
+        72,
+        226,
+        60
       ],
       "score": {
         "structural_complexity": 0.0,
         "semantic_complexity": 20.0,
-        "duplication_ratio": 17.333334,
+        "duplication_ratio": 17.362637,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 77.333336,
+        "total": 77.36264,
         "grade": "B",
         "confidence": 1.0,
         "language": "Rust",
@@ -20618,15 +20538,15 @@
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 45 duplicate code patterns"
+            "issue": "Found 46 duplicate code patterns"
           },
           {
             "source_metric": "Duplication",
-            "amount": 2.6666667,
+            "amount": 2.6373627,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Code duplication: 13.3%"
+            "issue": "Code duplication: 13.2%"
           },
           {
             "source_metric": "StructuralComplexity",
@@ -20634,7 +20554,7 @@
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cognitive complexity: 118"
+            "issue": "High cognitive complexity: 110"
           },
           {
             "source_metric": "StructuralComplexity",
@@ -20642,7 +20562,7 @@
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cyclomatic complexity: 71"
+            "issue": "High cyclomatic complexity: 68"
           }
         ],
         "critical_defects_count": 0,
@@ -21586,48 +21506,48 @@
     },
     "./src/cli/status_observability.rs": {
       "content_hash": [
-        227,
-        60,
-        46,
-        228,
-        0,
-        251,
-        225,
-        152,
-        121,
-        57,
-        198,
-        75,
-        227,
-        197,
-        171,
-        131,
-        47,
-        73,
+        231,
+        253,
+        38,
+        117,
+        179,
+        229,
+        137,
+        15,
+        13,
+        69,
         175,
-        79,
+        138,
+        179,
+        194,
+        213,
+        166,
+        203,
+        192,
+        32,
+        190,
+        77,
+        102,
+        107,
+        88,
+        83,
+        136,
+        219,
         151,
-        87,
-        210,
-        50,
-        168,
-        110,
-        109,
-        76,
-        189,
-        168,
-        1,
-        23
+        51,
+        72,
+        236,
+        43
       ],
       "score": {
         "structural_complexity": 0.0,
         "semantic_complexity": 20.0,
-        "duplication_ratio": 16.939314,
+        "duplication_ratio": 17.017994,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 76.939316,
+        "total": 77.01799,
         "grade": "B",
         "confidence": 1.0,
         "language": "Rust",
@@ -21639,15 +21559,15 @@
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 40 duplicate code patterns"
+            "issue": "Found 42 duplicate code patterns"
           },
           {
             "source_metric": "Duplication",
-            "amount": 3.060686,
+            "amount": 2.9820051,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Code duplication: 15.3%"
+            "issue": "Code duplication: 14.9%"
           },
           {
             "source_metric": "StructuralComplexity",
@@ -21655,7 +21575,7 @@
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cognitive complexity: 107"
+            "issue": "High cognitive complexity: 98"
           },
           {
             "source_metric": "StructuralComplexity",
@@ -21663,7 +21583,7 @@
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cyclomatic complexity: 67"
+            "issue": "High cyclomatic complexity: 65"
           }
         ],
         "critical_defects_count": 0,
@@ -22393,48 +22313,48 @@
     },
     "./src/cli/status_queries.rs": {
       "content_hash": [
-        100,
-        229,
-        121,
-        151,
-        28,
-        213,
-        202,
-        48,
-        64,
-        75,
-        65,
-        64,
-        203,
-        15,
-        72,
-        85,
-        24,
-        150,
-        27,
-        156,
-        171,
-        80,
-        116,
-        205,
-        246,
-        108,
-        158,
-        231,
+        249,
+        236,
+        248,
+        154,
+        128,
+        101,
         78,
-        204,
+        83,
+        177,
+        235,
+        67,
+        69,
+        227,
+        190,
+        7,
+        1,
+        142,
+        205,
+        148,
+        59,
+        19,
+        140,
+        209,
+        160,
+        161,
+        188,
+        165,
         123,
-        171
+        18,
+        78,
+        89,
+        34
       ],
       "score": {
-        "structural_complexity": 4.0,
+        "structural_complexity": 5.0,
         "semantic_complexity": 20.0,
-        "duplication_ratio": 16.0625,
+        "duplication_ratio": 16.70886,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 80.0625,
+        "total": 81.70886,
         "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
@@ -22450,11 +22370,11 @@
           },
           {
             "source_metric": "Duplication",
-            "amount": 3.9375,
+            "amount": 3.2911394,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Code duplication: 19.7%"
+            "issue": "Code duplication: 16.5%"
           },
           {
             "source_metric": "StructuralComplexity",
@@ -22462,15 +22382,15 @@
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cognitive complexity: 78"
+            "issue": "High cognitive complexity: 68"
           },
           {
             "source_metric": "StructuralComplexity",
-            "amount": 11.0,
+            "amount": 10.0,
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cyclomatic complexity: 52"
+            "issue": "High cyclomatic complexity: 50"
           }
         ],
         "critical_defects_count": 0,
@@ -23374,49 +23294,49 @@
     },
     "./src/cli/status_transport.rs": {
       "content_hash": [
-        247,
-        208,
-        252,
-        241,
-        169,
-        46,
-        205,
+        150,
+        5,
+        119,
+        183,
+        122,
+        147,
+        31,
+        125,
+        24,
+        115,
+        60,
+        24,
+        96,
+        22,
         27,
-        46,
-        15,
-        180,
-        69,
-        85,
-        208,
-        85,
-        189,
-        169,
-        169,
-        67,
-        160,
-        210,
-        117,
-        243,
-        190,
-        252,
-        220,
-        180,
-        253,
-        98,
-        168,
-        224,
-        126
+        209,
+        94,
+        240,
+        41,
+        17,
+        154,
+        20,
+        30,
+        150,
+        27,
+        93,
+        121,
+        33,
+        181,
+        28,
+        242,
+        215
       ],
       "score": {
-        "structural_complexity": 15.099999,
+        "structural_complexity": 20.8,
         "semantic_complexity": 20.0,
-        "duplication_ratio": 15.961538,
+        "duplication_ratio": 17.142857,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 91.06154,
-        "grade": "A",
+        "total": 97.942856,
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./src/cli/status_transport.rs",
@@ -23427,23 +23347,23 @@
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 40 duplicate code patterns"
+            "issue": "Found 29 duplicate code patterns"
           },
           {
             "source_metric": "Duplication",
-            "amount": 4.0384617,
+            "amount": 2.857143,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Code duplication: 20.2%"
+            "issue": "Code duplication: 14.3%"
           },
           {
             "source_metric": "StructuralComplexity",
-            "amount": 9.900001,
+            "amount": 4.2000003,
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cognitive complexity: 48"
+            "issue": "High cognitive complexity: 29"
           }
         ],
         "critical_defects_count": 0,
@@ -24725,48 +24645,48 @@
     },
     "./src/cli/validate_analytics.rs": {
       "content_hash": [
-        196,
-        244,
-        238,
-        142,
-        231,
-        234,
-        245,
-        8,
-        122,
-        139,
-        175,
-        211,
-        131,
-        170,
-        110,
-        166,
-        91,
-        125,
-        117,
-        178,
-        234,
-        177,
-        27,
-        55,
-        99,
         157,
-        94,
-        34,
-        152,
-        193,
-        30,
-        81
+        22,
+        134,
+        91,
+        17,
+        222,
+        39,
+        166,
+        35,
+        230,
+        158,
+        63,
+        186,
+        154,
+        14,
+        67,
+        85,
+        64,
+        189,
+        226,
+        232,
+        64,
+        203,
+        150,
+        103,
+        154,
+        31,
+        185,
+        145,
+        103,
+        31,
+        254
       ],
       "score": {
-        "structural_complexity": 7.5,
+        "structural_complexity": 8.0,
         "semantic_complexity": 20.0,
         "duplication_ratio": 20.0,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 87.5,
+        "total": 88.0,
         "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
@@ -24786,15 +24706,15 @@
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cognitive complexity: 81"
+            "issue": "High cognitive complexity: 78"
           },
           {
             "source_metric": "StructuralComplexity",
-            "amount": 7.5,
+            "amount": 7.0,
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cyclomatic complexity: 45"
+            "issue": "High cyclomatic complexity: 44"
           }
         ],
         "critical_defects_count": 0,
@@ -25160,48 +25080,48 @@
     },
     "./src/cli/validate_core.rs": {
       "content_hash": [
-        35,
-        180,
-        185,
-        217,
-        173,
         48,
-        165,
-        116,
-        44,
-        219,
-        108,
-        216,
-        253,
-        172,
-        120,
-        124,
-        92,
-        37,
-        122,
-        245,
+        221,
+        191,
+        121,
+        229,
+        197,
+        222,
+        176,
+        255,
+        146,
+        184,
+        162,
+        182,
+        53,
+        224,
+        204,
+        201,
+        209,
+        72,
+        238,
+        237,
+        17,
+        251,
         107,
-        110,
-        94,
-        157,
-        92,
-        225,
-        244,
-        179,
-        250,
-        203,
-        152,
-        182
+        210,
+        101,
+        255,
+        60,
+        205,
+        53,
+        212,
+        158
       ],
       "score": {
-        "structural_complexity": 5.5,
+        "structural_complexity": 6.5,
         "semantic_complexity": 20.0,
         "duplication_ratio": 20.0,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 85.5,
+        "total": 86.5,
         "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
@@ -25213,7 +25133,7 @@
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 26 duplicate code patterns"
+            "issue": "Found 27 duplicate code patterns"
           },
           {
             "source_metric": "StructuralComplexity",
@@ -25221,15 +25141,15 @@
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cognitive complexity: 78"
+            "issue": "High cognitive complexity: 75"
           },
           {
             "source_metric": "StructuralComplexity",
-            "amount": 9.5,
+            "amount": 8.5,
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cyclomatic complexity: 49"
+            "issue": "High cyclomatic complexity: 47"
           }
         ],
         "critical_defects_count": 0,
@@ -25793,76 +25713,68 @@
     },
     "./src/cli/validate_ordering_b.rs": {
       "content_hash": [
-        116,
-        237,
-        147,
-        252,
-        251,
-        111,
-        152,
-        43,
-        230,
+        110,
+        231,
+        143,
         44,
-        67,
-        138,
-        97,
-        224,
-        84,
-        240,
-        195,
-        16,
+        115,
+        96,
+        255,
+        96,
+        157,
+        183,
+        199,
+        132,
+        42,
+        7,
+        159,
+        68,
+        9,
+        185,
         177,
-        72,
-        31,
-        66,
-        212,
-        41,
-        249,
-        21,
-        175,
-        114,
-        88,
+        187,
+        102,
+        204,
+        5,
+        29,
+        70,
+        136,
+        106,
         244,
-        31,
-        22
+        197,
+        79,
+        96,
+        110
       ],
       "score": {
-        "structural_complexity": 2.5,
+        "structural_complexity": 4.0,
         "semantic_complexity": 20.0,
-        "duplication_ratio": 15.548388,
+        "duplication_ratio": 15.727554,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 78.048386,
+        "total": 79.727554,
         "grade": "B",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./src/cli/validate_ordering_b.rs",
         "penalties_applied": [
           {
-            "source_metric": "StructuralComplexity",
-            "amount": 1.0,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "Deep nesting: 5 levels"
-          },
-          {
             "source_metric": "Duplication",
             "amount": 5.0,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 29 duplicate code patterns"
+            "issue": "Found 28 duplicate code patterns"
           },
           {
             "source_metric": "Duplication",
-            "amount": 4.451613,
+            "amount": 4.2724457,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Code duplication: 22.3%"
+            "issue": "Code duplication: 21.4%"
           },
           {
             "source_metric": "StructuralComplexity",
@@ -25870,15 +25782,15 @@
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cognitive complexity: 95"
+            "issue": "High cognitive complexity: 87"
           },
           {
             "source_metric": "StructuralComplexity",
-            "amount": 11.5,
+            "amount": 11.0,
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cyclomatic complexity: 53"
+            "issue": "High cyclomatic complexity: 52"
           }
         ],
         "critical_defects_count": 0,
@@ -26276,48 +26188,48 @@
     },
     "./src/cli/validate_paths_b.rs": {
       "content_hash": [
-        191,
-        60,
-        152,
-        212,
-        241,
-        50,
-        164,
-        14,
-        124,
-        121,
-        100,
+        123,
+        72,
+        84,
+        176,
+        81,
+        207,
+        233,
+        93,
+        172,
+        107,
+        15,
+        194,
+        222,
+        3,
         211,
-        125,
-        87,
-        164,
-        142,
-        65,
-        78,
-        187,
-        209,
-        210,
-        145,
-        105,
-        144,
-        36,
-        54,
-        208,
-        90,
-        27,
-        118,
-        121,
-        144
+        123,
+        207,
+        212,
+        56,
+        238,
+        117,
+        47,
+        248,
+        255,
+        135,
+        162,
+        35,
+        68,
+        159,
+        14,
+        81,
+        139
       ],
       "score": {
-        "structural_complexity": 10.0,
+        "structural_complexity": 12.0,
         "semantic_complexity": 20.0,
         "duplication_ratio": 20.0,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 90.0,
+        "total": 92.0,
         "grade": "A",
         "confidence": 1.0,
         "language": "Rust",
@@ -26329,7 +26241,7 @@
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 19 duplicate code patterns"
+            "issue": "Found 17 duplicate code patterns"
           },
           {
             "source_metric": "StructuralComplexity",
@@ -26337,15 +26249,15 @@
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cognitive complexity: 78"
+            "issue": "High cognitive complexity: 68"
           },
           {
             "source_metric": "StructuralComplexity",
-            "amount": 5.0,
+            "amount": 3.0,
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cyclomatic complexity: 40"
+            "issue": "High cyclomatic complexity: 36"
           }
         ],
         "critical_defects_count": 0,
@@ -26901,49 +26813,49 @@
     },
     "./src/cli/validate_security.rs": {
       "content_hash": [
-        221,
-        71,
-        18,
-        224,
+        141,
+        121,
+        131,
+        26,
+        195,
         50,
-        37,
-        153,
-        166,
-        210,
-        171,
-        39,
-        106,
-        19,
-        189,
-        210,
-        103,
-        198,
-        178,
-        35,
-        3,
-        54,
-        250,
         63,
-        140,
-        0,
-        189,
-        1,
+        209,
+        227,
+        116,
+        202,
+        7,
+        88,
         188,
-        233,
-        254,
-        241,
-        132
+        220,
+        67,
+        222,
+        153,
+        6,
+        234,
+        111,
+        235,
+        201,
+        73,
+        116,
+        19,
+        218,
+        17,
+        101,
+        192,
+        150,
+        161
       ],
       "score": {
-        "structural_complexity": 18.1,
+        "structural_complexity": 19.6,
         "semantic_complexity": 20.0,
-        "duplication_ratio": 15.714286,
+        "duplication_ratio": 15.792507,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 93.814285,
-        "grade": "A",
+        "total": 95.3925,
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./src/cli/validate_security.rs",
@@ -26958,19 +26870,19 @@
           },
           {
             "source_metric": "Duplication",
-            "amount": 4.285714,
+            "amount": 4.207493,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Code duplication: 21.4%"
+            "issue": "Code duplication: 21.0%"
           },
           {
             "source_metric": "StructuralComplexity",
-            "amount": 6.9,
+            "amount": 5.4,
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cognitive complexity: 38"
+            "issue": "High cognitive complexity: 33"
           }
         ],
         "critical_defects_count": 0,
@@ -26988,49 +26900,49 @@
     },
     "./src/cli/validate_security_ext.rs": {
       "content_hash": [
-        203,
-        127,
-        6,
-        86,
-        203,
-        113,
-        55,
-        106,
-        176,
-        193,
-        114,
-        112,
-        118,
-        98,
-        239,
-        32,
-        187,
-        152,
-        23,
-        24,
-        153,
-        148,
-        247,
-        5,
-        239,
-        92,
-        40,
-        198,
+        182,
+        253,
+        54,
+        48,
+        255,
+        255,
+        225,
+        84,
+        69,
+        180,
+        59,
+        35,
+        205,
+        246,
+        61,
+        88,
+        64,
+        147,
+        12,
+        248,
+        209,
+        108,
         119,
-        152,
-        208,
-        25
+        176,
+        115,
+        224,
+        85,
+        22,
+        50,
+        16,
+        157,
+        180
       ],
       "score": {
-        "structural_complexity": 13.0,
+        "structural_complexity": 14.9,
         "semantic_complexity": 20.0,
-        "duplication_ratio": 15.252525,
+        "duplication_ratio": 15.522388,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 88.252525,
-        "grade": "A-",
+        "total": 90.42239,
+        "grade": "A",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./src/cli/validate_security_ext.rs",
@@ -27041,31 +26953,31 @@
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 57 duplicate code patterns"
+            "issue": "Found 53 duplicate code patterns"
           },
           {
             "source_metric": "Duplication",
-            "amount": 4.7474747,
+            "amount": 4.477612,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Code duplication: 23.7%"
+            "issue": "Code duplication: 22.4%"
           },
           {
             "source_metric": "StructuralComplexity",
-            "amount": 10.0,
+            "amount": 9.6,
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cognitive complexity: 61"
+            "issue": "High cognitive complexity: 47"
           },
           {
             "source_metric": "StructuralComplexity",
-            "amount": 2.0,
+            "amount": 0.5,
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cyclomatic complexity: 34"
+            "issue": "High cyclomatic complexity: 31"
           }
         ],
         "critical_defects_count": 0,
@@ -28767,49 +28679,49 @@
     },
     "./src/core/dogfood/exercises.rs": {
       "content_hash": [
-        148,
-        200,
-        34,
-        211,
-        13,
-        126,
-        62,
-        233,
-        146,
-        76,
-        54,
-        106,
+        162,
+        222,
+        220,
+        73,
         132,
-        124,
-        57,
-        236,
-        36,
-        164,
-        141,
-        8,
-        121,
-        150,
-        200,
-        70,
+        109,
+        177,
+        123,
+        98,
+        56,
+        109,
+        40,
+        65,
+        72,
+        137,
+        190,
+        175,
+        175,
+        38,
         127,
-        110,
-        251,
+        43,
+        41,
+        160,
+        108,
+        116,
+        196,
+        127,
+        118,
         240,
-        95,
-        178,
-        253,
-        107
+        17,
+        65,
+        182
       ],
       "score": {
-        "structural_complexity": 17.5,
+        "structural_complexity": 14.6,
         "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
+        "duplication_ratio": 17.9941,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 97.5,
-        "grade": "A+",
+        "total": 92.5941,
+        "grade": "A",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./src/core/dogfood/exercises.rs",
@@ -28820,23 +28732,31 @@
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 28 duplicate code patterns"
+            "issue": "Found 35 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 2.0058997,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 10.0%"
           },
           {
             "source_metric": "StructuralComplexity",
-            "amount": 3.0,
+            "amount": 3.9,
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cognitive complexity: 25"
+            "issue": "High cognitive complexity: 28"
           },
           {
             "source_metric": "StructuralComplexity",
-            "amount": 4.5,
+            "amount": 6.5,
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cyclomatic complexity: 39"
+            "issue": "High cyclomatic complexity: 43"
           }
         ],
         "critical_defects_count": 0,
@@ -31438,38 +31358,38 @@
     },
     "./src/core/parser/format_validation.rs": {
       "content_hash": [
-        99,
-        178,
-        55,
-        237,
-        224,
-        222,
-        130,
-        130,
-        153,
-        241,
-        150,
-        140,
-        157,
-        241,
-        132,
-        45,
-        53,
-        155,
-        88,
-        71,
+        38,
+        103,
+        81,
+        194,
+        211,
+        208,
+        216,
+        92,
+        8,
+        17,
         63,
-        227,
-        119,
+        8,
         163,
-        201,
+        149,
+        136,
+        18,
+        160,
+        67,
+        197,
+        197,
+        5,
+        220,
+        165,
         135,
-        207,
-        55,
-        82,
-        209,
-        255,
-        122
+        61,
+        163,
+        208,
+        174,
+        185,
+        150,
+        116,
+        188
       ],
       "score": {
         "structural_complexity": 8.0,
@@ -31499,7 +31419,7 @@
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cognitive complexity: 61"
+            "issue": "High cognitive complexity: 53"
           },
           {
             "source_metric": "StructuralComplexity",
@@ -44170,38 +44090,38 @@
     },
     "./src/core/types/refinement.rs": {
       "content_hash": [
-        69,
-        130,
-        89,
-        174,
-        233,
-        169,
-        229,
-        104,
-        12,
-        149,
-        193,
-        219,
-        243,
-        6,
-        57,
-        194,
-        211,
-        135,
-        102,
-        98,
-        218,
-        185,
-        153,
-        38,
+        28,
+        220,
+        1,
+        59,
         66,
-        132,
-        243,
-        19,
-        198,
-        71,
-        44,
-        242
+        35,
+        150,
+        234,
+        84,
+        211,
+        72,
+        204,
+        123,
+        1,
+        0,
+        199,
+        98,
+        211,
+        194,
+        1,
+        156,
+        43,
+        32,
+        52,
+        202,
+        82,
+        63,
+        249,
+        125,
+        59,
+        222,
+        3
       ],
       "score": {
         "structural_complexity": 25.0,
@@ -45568,48 +45488,48 @@
     },
     "./src/core/webhook_source.rs": {
       "content_hash": [
-        178,
-        60,
-        72,
-        255,
-        0,
-        34,
-        88,
-        14,
-        47,
-        30,
-        183,
-        121,
-        116,
-        102,
-        203,
-        182,
-        151,
-        231,
-        37,
-        106,
-        219,
-        151,
-        159,
-        54,
-        173,
-        43,
-        234,
-        254,
-        230,
-        56,
+        92,
+        130,
+        68,
+        169,
+        64,
+        32,
+        108,
+        53,
+        38,
+        233,
+        129,
+        82,
+        216,
+        52,
+        156,
+        146,
+        61,
+        167,
+        248,
+        96,
+        156,
+        67,
+        87,
+        213,
+        229,
+        185,
+        38,
+        51,
+        38,
+        127,
         7,
-        101
+        253
       ],
       "score": {
-        "structural_complexity": 17.0,
+        "structural_complexity": 18.2,
         "semantic_complexity": 20.0,
         "duplication_ratio": 20.0,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 97.0,
+        "total": 98.2,
         "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
@@ -45625,11 +45545,11 @@
           },
           {
             "source_metric": "StructuralComplexity",
-            "amount": 4.5,
+            "amount": 3.3000002,
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cognitive complexity: 30"
+            "issue": "High cognitive complexity: 26"
           },
           {
             "source_metric": "StructuralComplexity",
@@ -45979,49 +45899,49 @@
     },
     "./src/mcp/handlers_state.rs": {
       "content_hash": [
-        102,
-        111,
-        207,
-        227,
+        224,
+        53,
+        202,
+        121,
+        202,
+        239,
+        104,
+        10,
+        241,
         169,
-        45,
-        65,
-        3,
-        3,
-        226,
-        99,
+        97,
         8,
-        119,
-        54,
-        164,
-        161,
-        250,
-        137,
-        33,
-        127,
-        40,
+        255,
+        152,
+        198,
+        111,
+        226,
+        39,
+        107,
+        240,
+        30,
+        28,
         17,
-        151,
-        87,
-        218,
-        180,
-        195,
-        9,
-        34,
-        23,
-        140,
-        141
+        15,
+        60,
+        204,
+        164,
+        189,
+        66,
+        96,
+        25,
+        153
       ],
       "score": {
-        "structural_complexity": 14.0,
+        "structural_complexity": 19.5,
         "semantic_complexity": 20.0,
-        "duplication_ratio": 17.096775,
+        "duplication_ratio": 20.0,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 91.09677,
-        "grade": "A",
+        "total": 99.5,
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./src/mcp/handlers_state.rs",
@@ -46040,23 +45960,15 @@
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 21 duplicate code patterns"
-          },
-          {
-            "source_metric": "Duplication",
-            "amount": 2.9032257,
-            "applied_to": [
-              "Duplication"
-            ],
-            "issue": "Code duplication: 14.5%"
+            "issue": "Found 17 duplicate code patterns"
           },
           {
             "source_metric": "StructuralComplexity",
-            "amount": 10.0,
+            "amount": 4.5,
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cognitive complexity: 54"
+            "issue": "High cognitive complexity: 30"
           }
         ],
         "critical_defects_count": 0,
@@ -50605,14 +50517,14 @@
   },
   "summary": {
     "total_files": 619,
-    "avg_score": 92.95452,
+    "avg_score": 93.19434,
     "grade_distribution": {
-      "A+": 306,
-      "A": 207,
-      "A-": 35,
-      "B+": 23,
-      "B": 38,
-      "B-": 8,
+      "A+": 311,
+      "A": 209,
+      "A-": 33,
+      "B+": 24,
+      "B": 34,
+      "B-": 6,
       "C+": 2
     },
     "languages": {

--- a/examples/contract_pipeline_demo.rs
+++ b/examples/contract_pipeline_demo.rs
@@ -49,41 +49,74 @@ struct EquationYaml {
     invariants: Vec<String>,
 }
 
-fn main() {
-    println!("=== Contract Pipeline Demo ===\n");
+/// Everything phase 1 harvests from the `contracts/` directory.
+#[derive(Default)]
+struct LoadedContracts {
+    total_equations: usize,
+    total_invariants: usize,
+    entries: Vec<ContractEntry>,
+    assertions: Vec<ContractAssertion>,
+}
 
-    // Phase 1: Load contract YAML files from contracts/
-    let contracts_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("contracts");
+/// The `.yaml` contract files under `contracts/`, sorted, with the
+/// `binding.yaml` mapping file (which is not a contract) left out.
+fn contract_yaml_paths(contracts_dir: &std::path::Path) -> Vec<std::path::PathBuf> {
+    let mut paths: Vec<_> = std::fs::read_dir(contracts_dir)
+        .expect("read contracts/")
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("yaml"))
+        .filter(|p| p.file_stem().and_then(|s| s.to_str()) != Some("binding"))
+        .collect();
+    paths.sort();
+    paths
+}
+
+/// Fold one equation into the running totals, the coverage entries and the
+/// runtime assertions derived from its invariants.
+fn absorb_equation(stem: &str, eq_name: &str, eq: &EquationYaml, out: &mut LoadedContracts) {
+    let n_inv = eq.invariants.len();
+    out.total_equations += 1;
+    out.total_invariants += n_inv;
+    println!("      {eq_name}: {n_inv} invariants");
+
+    let module = format!("contracts::{}", stem.replace('-', "_"));
+    out.entries.push(ContractEntry {
+        function: eq_name.to_string(),
+        module: module.clone(),
+        contract_id: Some(format!("{stem}.yaml")),
+        tier: VerificationTier::Bounded,
+        verified_by: eq
+            .invariants
+            .iter()
+            .map(|inv| format!("invariant: {inv}"))
+            .collect(),
+    });
+
+    out.assertions
+        .extend(eq.invariants.iter().map(|inv| ContractAssertion {
+            function: eq_name.to_string(),
+            module: module.clone(),
+            kind: ContractKind::Invariant,
+            held: true,
+            expression: Some(inv.clone()),
+        }));
+}
+
+/// Phase 1 — parse every contract file, echoing each one as it is absorbed.
+fn load_contracts(contracts_dir: &std::path::Path) -> LoadedContracts {
     println!(
         "Phase 1: Loading contracts from {}\n",
         contracts_dir.display()
     );
 
-    let mut total_equations = 0usize;
-    let mut total_invariants = 0usize;
-    let mut contract_entries: Vec<ContractEntry> = Vec::new();
-    let mut runtime_assertions: Vec<ContractAssertion> = Vec::new();
-
-    let mut paths: Vec<_> = std::fs::read_dir(&contracts_dir)
-        .expect("read contracts/")
-        .filter_map(|e| e.ok())
-        .map(|e| e.path())
-        .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("yaml"))
-        .collect();
-    paths.sort();
-
-    for path in &paths {
+    let mut loaded = LoadedContracts::default();
+    for path in contract_yaml_paths(contracts_dir) {
         let stem = path
             .file_stem()
             .and_then(|s| s.to_str())
             .unwrap_or("unknown");
-
-        // Skip binding.yaml (it's a mapping file, not a contract)
-        if stem == "binding" {
-            continue;
-        }
-
-        let content = std::fs::read_to_string(path).expect("read yaml");
+        let content = std::fs::read_to_string(&path).expect("read yaml");
         let contract: ContractYaml = serde_yaml_ng::from_str(&content).expect("parse yaml");
 
         println!(
@@ -94,49 +127,21 @@ fn main() {
         println!("    Equations: {}", contract.equations.len());
 
         for (eq_name, eq) in &contract.equations {
-            total_equations += 1;
-            let n_inv = eq.invariants.len();
-            total_invariants += n_inv;
-
-            println!("      {eq_name}: {n_inv} invariants");
-
-            // Build a contract entry for the coverage report
-            let verified: Vec<String> = eq
-                .invariants
-                .iter()
-                .map(|inv| format!("invariant: {inv}"))
-                .collect();
-
-            contract_entries.push(ContractEntry {
-                function: eq_name.clone(),
-                module: format!("contracts::{}", stem.replace('-', "_")),
-                contract_id: Some(format!("{stem}.yaml")),
-                tier: VerificationTier::Bounded,
-                verified_by: verified,
-            });
-
-            // Build runtime assertions from invariants
-            for inv in &eq.invariants {
-                runtime_assertions.push(ContractAssertion {
-                    function: eq_name.clone(),
-                    module: format!("contracts::{}", stem.replace('-', "_")),
-                    kind: ContractKind::Invariant,
-                    held: true,
-                    expression: Some(inv.clone()),
-                });
-            }
+            absorb_equation(stem, eq_name, eq, &mut loaded);
         }
         println!();
     }
+    loaded
+}
 
-    // Phase 2: Show build-time env var mapping
+/// Phase 2 — the `CONTRACT_*` env vars build.rs derives from those contracts.
+fn print_build_env_mapping(loaded: &LoadedContracts) {
     println!("Phase 2: Build-time CONTRACT_* env vars\n");
     println!("  build.rs emits CONTRACT_INV_*, CONTRACT_PRE_*, CONTRACT_POST_* env vars");
-    println!("  Total equations: {total_equations}");
-    println!("  Total invariants: {total_invariants}");
+    println!("  Total equations: {}", loaded.total_equations);
+    println!("  Total invariants: {}", loaded.total_invariants);
     println!();
 
-    // Show a sample of what the env vars look like
     println!("  Sample env var keys:");
     let sample_keys = [
         "CONTRACT_INV_BLAKE3_STATE_V1_HASH_STRING_0",
@@ -144,24 +149,22 @@ fn main() {
         "CONTRACT_INV_EXECUTION_SAFETY_V1_ATOMIC_WRITE_0",
         "CONTRACT_INV_RECIPE_DETERMINISM_V1_EXPAND_RECIPE_0",
     ];
+    // Only the BLAKE3 key can be resolved here: `option_env!` needs a literal.
+    let blake3_val = option_env!("CONTRACT_INV_BLAKE3_STATE_V1_HASH_STRING_0");
     for key in &sample_keys {
-        // Try to read from env (set by build.rs at compile time)
-        let val = option_env!("CONTRACT_INV_BLAKE3_STATE_V1_HASH_STRING_0");
-        if key.contains("BLAKE3") {
-            if let Some(v) = val {
-                println!("    {key} = \"{v}\"");
-            } else {
-                println!("    {key} = (would be set by build.rs)");
-            }
-        } else {
-            println!("    {key} = (set by build.rs)");
+        match (key.contains("BLAKE3"), blake3_val) {
+            (true, Some(v)) => println!("    {key} = \"{v}\""),
+            (true, None) => println!("    {key} = (would be set by build.rs)"),
+            (false, _) => println!("    {key} = (set by build.rs)"),
         }
     }
     println!();
+}
 
-    // Phase 3: Runtime assertion display
+/// Phase 3 — the invariants as they would be checked at runtime.
+fn print_runtime_assertions(assertions: &[ContractAssertion]) {
     println!("Phase 3: Runtime Contract Assertions\n");
-    for a in &runtime_assertions {
+    for a in assertions {
         let status = if a.held { "HELD" } else { "VIOLATED" };
         println!(
             "  [{status}] {}::{} ({}: {})",
@@ -172,10 +175,11 @@ fn main() {
         );
     }
     println!();
+}
 
-    // Phase 4: Coverage report
-    println!("Phase 4: Contract Coverage Report\n");
-    let handler_invariants = vec![
+/// The per-resource-type verification tiers the demo report is built against.
+fn demo_handler_invariants() -> Vec<HandlerInvariantStatus> {
+    vec![
         HandlerInvariantStatus {
             resource_type: "file".into(),
             tier: VerificationTier::Bounded,
@@ -200,31 +204,38 @@ fn main() {
             exempt: true,
             exemption_reason: Some("imperative resource type".into()),
         },
-    ];
+    ]
+}
 
+/// Display name for a bucket of `ContractCoverageReport::histogram`.
+fn tier_label(index: usize) -> &'static str {
+    match index {
+        0 => "Unlabeled (L0)",
+        1 => "Labeled (L1)",
+        2 => "Runtime (L2)",
+        3 => "Bounded (L3)",
+        4 => "Proved (L4)",
+        5 => "Structural (L5)",
+        _ => "Unknown",
+    }
+}
+
+/// Phase 4 — summary, tier histogram and the at-or-above-Bounded count.
+fn print_coverage_report(entries: Vec<ContractEntry>) {
+    println!("Phase 4: Contract Coverage Report\n");
     let report = ContractCoverageReport {
-        total_functions: contract_entries.len(),
-        entries: contract_entries,
-        handler_invariants,
+        total_functions: entries.len(),
+        entries,
+        handler_invariants: demo_handler_invariants(),
     };
 
     print!("{}", report.format_summary());
     println!();
 
-    let hist = report.histogram();
     println!("  Tier Distribution:");
-    for (i, count) in hist.iter().enumerate() {
+    for (i, count) in report.histogram().iter().enumerate() {
         if *count > 0 {
-            let tier_name = match i {
-                0 => "Unlabeled (L0)",
-                1 => "Labeled (L1)",
-                2 => "Runtime (L2)",
-                3 => "Bounded (L3)",
-                4 => "Proved (L4)",
-                5 => "Structural (L5)",
-                _ => "Unknown",
-            };
-            println!("    {tier_name}: {count}");
+            println!("    {}: {count}", tier_label(i));
         }
     }
     println!(
@@ -232,6 +243,17 @@ fn main() {
         report.at_or_above(VerificationTier::Bounded),
         report.total_functions
     );
+}
+
+fn main() {
+    println!("=== Contract Pipeline Demo ===\n");
+
+    let contracts_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("contracts");
+    let loaded = load_contracts(&contracts_dir);
+
+    print_build_env_mapping(&loaded);
+    print_runtime_assertions(&loaded.assertions);
+    print_coverage_report(loaded.entries);
 
     println!("\n=== Pipeline Complete ===");
 }

--- a/src/cli/apply_variants.rs
+++ b/src/cli/apply_variants.rs
@@ -197,6 +197,77 @@ fn refreshed_live_hash(
     }
 }
 
+/// Live hash for a lock entry that is still eligible for refresh: it must be
+/// recorded as converged and still be present in the config. `None` means the
+/// entry is skipped — either it is not converged, the resource was removed from
+/// the config, or the live query did not answer.
+fn refreshable_live_hash(
+    config: &types::ForjarConfig,
+    machine: &types::Machine,
+    id: &str,
+    rl: &types::ResourceLock,
+    timeout: Option<u64>,
+) -> Option<String> {
+    if rl.status != types::ResourceStatus::Converged {
+        return None;
+    }
+    let resource = config.resources.get(id)?;
+    refreshed_live_hash(machine, resource, config, timeout)
+}
+
+/// True when a freshly queried hash differs from the OBSERVED state already
+/// recorded on the lock entry (an absent recording counts as a difference
+/// unless the new hash is empty, matching the pre-refactor comparison).
+///
+/// Reads through `observed_state()` rather than `details["live_hash"]`: #338
+/// split SPEC from STATUS and the accessor prefers the typed `observed` field,
+/// so a raw `details` read here would disagree with the drift path.
+fn observed_state_drifted(rl: &types::ResourceLock, hash: &str) -> bool {
+    // Compare against the OBSERVED state through the accessor, so this path and
+    // the drift path agree on where that value lives.
+    let old_hash = rl.observed_state().unwrap_or("");
+    hash != old_hash
+}
+
+/// Re-queries every refreshable resource of one machine, returning the lock with
+/// updated observed state plus (queried, drifted) counts.
+fn refresh_machine_lock(
+    config: &types::ForjarConfig,
+    machine: &types::Machine,
+    machine_name: &str,
+    lock: &types::StateLock,
+    timeout: Option<u64>,
+    verbose: bool,
+) -> (types::StateLock, usize, usize) {
+    let mut updated_lock = lock.clone();
+    let mut refreshed = 0usize;
+    let mut drift_count = 0usize;
+
+    for (id, rl) in &lock.resources {
+        let Some(hash) = refreshable_live_hash(config, machine, id, rl, timeout) else {
+            continue;
+        };
+        if observed_state_drifted(rl, &hash) {
+            drift_count += 1;
+            if verbose {
+                eprintln!("  drift: {id} on {machine_name} (hash changed)");
+            }
+        }
+        if let Some(entry) = updated_lock.resources.get_mut(id) {
+            // MUST go through the setter. Writing only `details` here would
+            // leave the typed `observed` field holding the PREVIOUS digest, and
+            // `observed_state()` prefers the typed field — so `--refresh` would
+            // update one of two copies and every later reader would see the
+            // stale one. That is forjar#305's exact shape (two stores, readers
+            // split between them), which this refactor exists to remove.
+            entry.set_observed_state(hash);
+        }
+        refreshed += 1;
+    }
+
+    (updated_lock, refreshed, drift_count)
+}
+
 /// FJ-1230: Refresh state only — re-query live state for all converged resources
 /// and update lock hashes without applying any changes.
 #[allow(clippy::too_many_arguments)]
@@ -221,46 +292,13 @@ pub(crate) fn cmd_refresh_only(
     let mut drift_count = 0usize;
 
     for (machine_name, lock) in &locks {
-        let machine = match config.machines.get(machine_name) {
-            Some(m) => m,
-            None => continue,
+        let Some(machine) = config.machines.get(machine_name) else {
+            continue;
         };
-
-        let mut updated_lock = lock.clone();
-        for (id, rl) in &lock.resources {
-            if rl.status != types::ResourceStatus::Converged {
-                continue;
-            }
-            let resource = match config.resources.get(id) {
-                Some(r) => r,
-                None => continue,
-            };
-            let new_hash = refreshed_live_hash(machine, resource, &config, timeout);
-
-            if let Some(ref hash) = new_hash {
-                // Compare against the OBSERVED state through the accessor, so
-                // this path and the drift path agree on where that value lives.
-                let old_hash = rl.observed_state().unwrap_or("");
-                if hash != old_hash {
-                    drift_count += 1;
-                    if verbose {
-                        eprintln!("  drift: {id} on {machine_name} (hash changed)");
-                    }
-                }
-                if let Some(entry) = updated_lock.resources.get_mut(id) {
-                    // MUST go through the setter. Writing only `details` here
-                    // would leave the typed `observed` field holding the
-                    // PREVIOUS digest, and `observed_state()` prefers the typed
-                    // field — so `--refresh` would update one of two copies and
-                    // every later reader would see the stale one. That is
-                    // forjar#305's exact shape (two stores, readers split
-                    // between them), which this refactor exists to remove.
-                    entry.set_observed_state(hash.clone());
-                }
-                refreshed += 1;
-            }
-        }
-
+        let (updated_lock, machine_refreshed, machine_drift) =
+            refresh_machine_lock(&config, machine, machine_name, lock, timeout, verbose);
+        refreshed += machine_refreshed;
+        drift_count += machine_drift;
         state::save_lock(state_dir, &updated_lock)?;
     }
 

--- a/src/cli/cbom.rs
+++ b/src/cli/cbom.rs
@@ -123,29 +123,40 @@ fn scan_tls_resources(config: &types::ForjarConfig, entries: &mut Vec<CryptoEntr
     }
 }
 
-fn scan_state_hashes(state_dir: &Path, entries: &mut Vec<CryptoEntry>) {
-    let mut has_hashes = false;
-    if let Ok(dir_entries) = std::fs::read_dir(state_dir) {
-        for entry in dir_entries.flatten() {
-            if !entry.path().is_dir() {
-                continue;
-            }
-            let name = entry.file_name().to_string_lossy().to_string();
-            if let Ok(Some(lock)) = state::load_lock(state_dir, &name) {
-                for (_id, res) in &lock.resources {
-                    if !res.hash.is_empty() && !has_hashes {
-                        has_hashes = true;
-                        entries.push(CryptoEntry {
-                            algorithm: "BLAKE3".to_string(),
-                            usage: "resource-integrity".to_string(),
-                            key_size: "256-bit".to_string(),
-                            location: format!("state/{name}/*.lock.yaml"),
-                        });
-                    }
-                }
-            }
-        }
+/// Names of the per-machine state subdirectories, in filesystem iteration order.
+fn state_machine_dirs(state_dir: &Path) -> Vec<String> {
+    let Ok(dir_entries) = std::fs::read_dir(state_dir) else {
+        return Vec::new();
+    };
+    dir_entries
+        .flatten()
+        .filter(|entry| entry.path().is_dir())
+        .map(|entry| entry.file_name().to_string_lossy().to_string())
+        .collect()
+}
+
+/// True when a machine's lock records at least one non-empty resource hash.
+fn lock_has_resource_hashes(state_dir: &Path, machine: &str) -> bool {
+    match state::load_lock(state_dir, machine) {
+        Ok(Some(lock)) => lock.resources.values().any(|res| !res.hash.is_empty()),
+        _ => false,
     }
+}
+
+fn scan_state_hashes(state_dir: &Path, entries: &mut Vec<CryptoEntry>) {
+    // A single entry covers the whole state tree, so the first hashed lock wins.
+    let Some(machine) = state_machine_dirs(state_dir)
+        .into_iter()
+        .find(|name| lock_has_resource_hashes(state_dir, name))
+    else {
+        return;
+    };
+    entries.push(CryptoEntry {
+        algorithm: "BLAKE3".to_string(),
+        usage: "resource-integrity".to_string(),
+        key_size: "256-bit".to_string(),
+        location: format!("state/{machine}/*.lock.yaml"),
+    });
 }
 
 fn scan_docker_digests(config: &types::ForjarConfig, entries: &mut Vec<CryptoEntry>) {

--- a/src/cli/check_test.rs
+++ b/src/cli/check_test.rs
@@ -202,6 +202,66 @@ struct TestTally {
     skip: usize,
 }
 
+/// One resource's identity for the sweep: the script to run and how to label
+/// the rows it produces.
+struct ResourceCheck<'a> {
+    resource_id: &'a str,
+    resource_type: &'a str,
+    script: &'a str,
+}
+
+/// A sweep's running output: one row per executed check, plus the tally.
+#[derive(Default)]
+struct SweepOutcome {
+    rows: Vec<TestRow>,
+    tally: TestTally,
+}
+
+/// The row recorded for a resource whose type generates no check script.
+fn no_check_script_row(resource_id: &str, resource_type: &str) -> TestRow {
+    TestRow {
+        resource_id: resource_id.to_string(),
+        machine: "-".to_string(),
+        resource_type: resource_type.to_string(),
+        status: "skip".to_string(),
+        detail: "no check script".to_string(),
+        duration_secs: 0.0,
+    }
+}
+
+/// Runs one resource's check script on every machine it targets, appending a
+/// row per execution and folding each outcome into the tally.
+fn run_check_on_machines(
+    config: &types::ForjarConfig,
+    localhost: &types::Machine,
+    resource: &types::Resource,
+    check: &ResourceCheck<'_>,
+    machine_filter: Option<&str>,
+    out: &mut SweepOutcome,
+) {
+    for machine_name in resource.machine.to_vec() {
+        let machine = config.machines.get(&machine_name).unwrap_or(localhost);
+        if skip_machine(&machine_name, machine_filter, resource, machine) {
+            out.tally.skip += 1;
+            continue;
+        }
+
+        let (row, passed) = run_test_check(
+            machine,
+            check.script,
+            check.resource_id,
+            &machine_name,
+            check.resource_type,
+        );
+        if passed {
+            out.tally.pass += 1;
+        } else {
+            out.tally.fail += 1;
+        }
+        out.rows.push(row);
+    }
+}
+
 /// Decides whether a resource is excluded before any check script is generated,
 /// and whether it counts toward the skip tally (`Some(true)`) or is silent
 /// (`Some(false)`). Exists to keep the three exclusion rules out of the sweep.
@@ -249,8 +309,7 @@ fn run_test_sweep(
     group_filter: Option<&str>,
 ) -> Result<(Vec<TestRow>, TestTally), String> {
     let localhost = localhost_machine();
-    let mut results: Vec<TestRow> = Vec::new();
-    let mut tally = TestTally::default();
+    let mut out = SweepOutcome::default();
 
     for resource_id in execution_order {
         let Some(resource) = config.resources.get(resource_id) else {
@@ -264,9 +323,7 @@ fn run_test_sweep(
             tag_filter,
             group_filter,
         ) {
-            if counts_as_skip {
-                tally.skip += 1;
-            }
+            out.tally.skip += usize::from(counts_as_skip);
             continue;
         }
 
@@ -274,41 +331,28 @@ fn run_test_sweep(
             resolver::resolve_resource_templates(resource, &config.params, &config.machines)?;
 
         let rtype = format!("{:?}", resource.resource_type).to_lowercase();
-        let check_script = match codegen::check_script(&resolved) {
-            Ok(s) => s,
-            Err(_) => {
-                tally.skip += 1;
-                results.push(TestRow {
-                    resource_id: resource_id.clone(),
-                    machine: "-".to_string(),
-                    resource_type: rtype,
-                    status: "skip".to_string(),
-                    detail: "no check script".to_string(),
-                    duration_secs: 0.0,
-                });
-                continue;
-            }
+        // A resource type with no check script is skipped, never failed.
+        let Ok(check_script) = codegen::check_script(&resolved) else {
+            out.tally.skip += 1;
+            out.rows.push(no_check_script_row(resource_id, &rtype));
+            continue;
         };
 
-        for machine_name in resource.machine.to_vec() {
-            let machine = config.machines.get(&machine_name).unwrap_or(&localhost);
-            if skip_machine(&machine_name, machine_filter, resource, machine) {
-                tally.skip += 1;
-                continue;
-            }
-
-            let (row, passed) =
-                run_test_check(machine, &check_script, resource_id, &machine_name, &rtype);
-            if passed {
-                tally.pass += 1;
-            } else {
-                tally.fail += 1;
-            }
-            results.push(row);
-        }
+        run_check_on_machines(
+            config,
+            &localhost,
+            resource,
+            &ResourceCheck {
+                resource_id,
+                resource_type: &rtype,
+                script: &check_script,
+            },
+            machine_filter,
+            &mut out,
+        );
     }
 
-    Ok((results, tally))
+    Ok((out.rows, out.tally))
 }
 
 /// FJ-2606: Writes the test artifacts next to the config file and announces the

--- a/src/cli/dispatch_graph.rs
+++ b/src/cli/dispatch_graph.rs
@@ -94,6 +94,28 @@ pub(super) fn try_topology(
     None
 }
 
+/// The three "what happens if this one resource changes" questions. Each names
+/// a resource and answers for it alone; they keep their original relative order
+/// so the flag precedence `try_impact` applies is unchanged.
+fn try_impact_of_change(
+    file: &Path,
+    json: bool,
+    change_impact: &Option<String>,
+    blast_radius: &Option<String>,
+    what_if: &Option<String>,
+) -> Option<Result<(), String>> {
+    if let Some(ref r) = change_impact {
+        return Some(cmd_graph_change_impact(file, r, json));
+    }
+    if let Some(ref r) = blast_radius {
+        return Some(cmd_graph_blast_radius(file, r, json));
+    }
+    if let Some(ref r) = what_if {
+        return Some(cmd_graph_what_if(file, r));
+    }
+    None
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(super) fn try_impact(
     file: &Path,
@@ -109,14 +131,8 @@ pub(super) fn try_impact(
     subgraph: &Option<String>,
     weight: bool,
 ) -> Option<Result<(), String>> {
-    if let Some(ref r) = change_impact {
-        return Some(cmd_graph_change_impact(file, r, json));
-    }
-    if let Some(ref r) = blast_radius {
-        return Some(cmd_graph_blast_radius(file, r, json));
-    }
-    if let Some(ref r) = what_if {
-        return Some(cmd_graph_what_if(file, r));
+    if let Some(result) = try_impact_of_change(file, json, change_impact, blast_radius, what_if) {
+        return Some(result);
     }
     if timeline_graph {
         return Some(cmd_graph_timeline(file));
@@ -157,6 +173,51 @@ fn try_visualization_focus(
     None
 }
 
+/// The whole-graph summaries: the JSON dump, the node/edge counts, and the
+/// listing of resources nothing depends on. None takes a resource or honours
+/// `format`. Their original relative order is preserved so the flag precedence
+/// `try_visualization` applies is unchanged.
+fn try_visualization_summary(
+    file: &Path,
+    json: bool,
+    stats: bool,
+    orphans: bool,
+) -> Option<Result<(), String>> {
+    if json {
+        return Some(cmd_graph_json(file));
+    }
+    if stats {
+        return Some(cmd_graph_stats(file));
+    }
+    if orphans {
+        return Some(cmd_graph_orphans(file));
+    }
+    None
+}
+
+/// The views that re-shape the whole graph before rendering it: grouped into
+/// clusters, with its edges flipped, or reduced to its critical path. Their
+/// original relative order is preserved so the flag precedence
+/// `try_visualization` applies is unchanged.
+fn try_visualization_shape(
+    file: &Path,
+    format: &str,
+    cluster: bool,
+    reverse: bool,
+    critical_path: bool,
+) -> Option<Result<(), String>> {
+    if cluster {
+        return Some(cmd_graph_cluster(file, format));
+    }
+    if reverse {
+        return Some(cmd_graph_reverse(file));
+    }
+    if critical_path {
+        return Some(cmd_graph_critical_path(file));
+    }
+    None
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(super) fn try_visualization(
     file: &Path,
@@ -183,23 +244,11 @@ pub(super) fn try_visualization(
     if let Some(result) = try_visualization_focus(file, format, prune, highlight) {
         return Some(result);
     }
-    if json {
-        return Some(cmd_graph_json(file));
+    if let Some(result) = try_visualization_summary(file, json, stats, orphans) {
+        return Some(result);
     }
-    if stats {
-        return Some(cmd_graph_stats(file));
-    }
-    if orphans {
-        return Some(cmd_graph_orphans(file));
-    }
-    if cluster {
-        return Some(cmd_graph_cluster(file, format));
-    }
-    if reverse {
-        return Some(cmd_graph_reverse(file));
-    }
-    if critical_path {
-        return Some(cmd_graph_critical_path(file));
+    if let Some(result) = try_visualization_shape(file, format, cluster, reverse, critical_path) {
+        return Some(result);
     }
     if let Some(ref r) = affected {
         return Some(cmd_graph_affected(file, r));
@@ -225,37 +274,35 @@ pub(super) fn try_graph_paths(
     resource_dependency_fanout: bool,
     resource_dependency_weight: bool,
 ) -> Option<Result<(), String>> {
+    // The only analysis here that takes an argument of its own, so it cannot go
+    // in the table below; it keeps its original first-in-line precedence.
     if let Some(ref target) = resource_dependency_chain {
         return Some(cmd_graph_resource_dependency_chain(file, target, json));
     }
-    if bottleneck_resources {
-        return Some(cmd_graph_bottleneck_resources(file, json));
-    }
-    if critical_dependency_path {
-        return Some(cmd_graph_critical_dependency_path(file, json));
-    }
-    if resource_depth_histogram {
-        return Some(cmd_graph_resource_depth_histogram(file, json));
-    }
-    if resource_coupling_score {
-        return Some(cmd_graph_resource_coupling_score(file, json));
-    }
-    if resource_change_frequency {
-        return Some(cmd_graph_resource_change_frequency(file, json));
-    }
-    if resource_impact_score {
-        return Some(cmd_graph_resource_impact_score(file, json));
-    }
-    if resource_stability_score {
-        return Some(cmd_graph_resource_stability_score(file, json));
-    }
-    if resource_dependency_fanout {
-        return Some(cmd_graph_resource_dependency_fanout(file, json));
-    }
-    if resource_dependency_weight {
-        return Some(cmd_graph_resource_dependency_weight(file, json));
-    }
-    None
+    first_enabled_analysis(
+        file,
+        json,
+        &[
+            (bottleneck_resources, cmd_graph_bottleneck_resources),
+            (critical_dependency_path, cmd_graph_critical_dependency_path),
+            (resource_depth_histogram, cmd_graph_resource_depth_histogram),
+            (resource_coupling_score, cmd_graph_resource_coupling_score),
+            (
+                resource_change_frequency,
+                cmd_graph_resource_change_frequency,
+            ),
+            (resource_impact_score, cmd_graph_resource_impact_score),
+            (resource_stability_score, cmd_graph_resource_stability_score),
+            (
+                resource_dependency_fanout,
+                cmd_graph_resource_dependency_fanout,
+            ),
+            (
+                resource_dependency_weight,
+                cmd_graph_resource_dependency_weight,
+            ),
+        ],
+    )
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src/cli/dispatch_graph_b.rs
+++ b/src/cli/dispatch_graph_b.rs
@@ -20,12 +20,12 @@ use std::path::Path;
 /// One `graph --resource-*` analysis. Every flag-selected analysis has the same
 /// shape: it re-reads the config file and reports its own findings, honouring
 /// `--json`.
-type GraphAnalysis = fn(&Path, bool) -> Result<(), String>;
+pub(super) type GraphAnalysis = fn(&Path, bool) -> Result<(), String>;
 
 /// Run the first analysis whose flag is set, in table order, and return its
 /// result; `None` when none of the flags in the table is set. Table order is
 /// the precedence order, and only the selected analysis is called.
-fn first_enabled_analysis(
+pub(super) fn first_enabled_analysis(
     file: &Path,
     json: bool,
     analyses: &[(bool, GraphAnalysis)],
@@ -122,47 +122,60 @@ pub(super) fn try_graph_scoring_phase81(
     resource_dependency_path_count: bool,
     resource_dependency_articulation_points: bool,
 ) -> Option<Result<(), String>> {
-    if resource_dependency_centrality_score {
-        return Some(cmd_graph_resource_dependency_centrality_score(file, json));
-    }
-    if resource_dependency_bridge_detection {
-        return Some(cmd_graph_resource_dependency_bridge_detection(file, json));
-    }
-    if resource_dependency_cluster_coefficient {
-        return Some(cmd_graph_resource_dependency_cluster_coefficient(
-            file, json,
-        ));
-    }
-    if resource_dependency_modularity_score {
-        return Some(cmd_graph_resource_dependency_modularity_score(file, json));
-    }
-    if resource_dependency_diameter {
-        return Some(cmd_graph_resource_dependency_diameter(file, json));
-    }
-    if resource_dependency_eccentricity {
-        return Some(cmd_graph_resource_dependency_eccentricity(file, json));
-    }
-    if resource_dependency_density {
-        return Some(cmd_graph_resource_dependency_density(file, json));
-    }
-    if resource_dependency_transitivity {
-        return Some(cmd_graph_resource_dependency_transitivity(file, json));
-    }
-    if resource_dependency_fan_out {
-        return Some(cmd_graph_resource_dependency_fan_out(file, json));
-    }
-    if resource_dependency_fan_in {
-        return Some(cmd_graph_resource_dependency_fan_in(file, json));
-    }
-    if resource_dependency_path_count {
-        return Some(cmd_graph_resource_dependency_path_count(file, json));
-    }
-    if resource_dependency_articulation_points {
-        return Some(cmd_graph_resource_dependency_articulation_points(
-            file, json,
-        ));
-    }
-    None
+    first_enabled_analysis(
+        file,
+        json,
+        &[
+            (
+                resource_dependency_centrality_score,
+                cmd_graph_resource_dependency_centrality_score,
+            ),
+            (
+                resource_dependency_bridge_detection,
+                cmd_graph_resource_dependency_bridge_detection,
+            ),
+            (
+                resource_dependency_cluster_coefficient,
+                cmd_graph_resource_dependency_cluster_coefficient,
+            ),
+            (
+                resource_dependency_modularity_score,
+                cmd_graph_resource_dependency_modularity_score,
+            ),
+            (
+                resource_dependency_diameter,
+                cmd_graph_resource_dependency_diameter,
+            ),
+            (
+                resource_dependency_eccentricity,
+                cmd_graph_resource_dependency_eccentricity,
+            ),
+            (
+                resource_dependency_density,
+                cmd_graph_resource_dependency_density,
+            ),
+            (
+                resource_dependency_transitivity,
+                cmd_graph_resource_dependency_transitivity,
+            ),
+            (
+                resource_dependency_fan_out,
+                cmd_graph_resource_dependency_fan_out,
+            ),
+            (
+                resource_dependency_fan_in,
+                cmd_graph_resource_dependency_fan_in,
+            ),
+            (
+                resource_dependency_path_count,
+                cmd_graph_resource_dependency_path_count,
+            ),
+            (
+                resource_dependency_articulation_points,
+                cmd_graph_resource_dependency_articulation_points,
+            ),
+        ],
+    )
 }
 #[allow(clippy::too_many_arguments)]
 pub(super) fn try_graph_phase87(
@@ -181,45 +194,60 @@ pub(super) fn try_graph_phase87(
     resource_dependency_eccentricity_map: bool,
     resource_dependency_diameter_path: bool,
 ) -> Option<Result<(), String>> {
-    if resource_dependency_longest_path {
-        return Some(cmd_graph_resource_dependency_longest_path(file, json));
-    }
-    if resource_dependency_strongly_connected {
-        return Some(cmd_graph_resource_dependency_strongly_connected(file, json));
-    }
-    if resource_dependency_topological_depth {
-        return Some(cmd_graph_resource_dependency_topological_depth(file, json));
-    }
-    if resource_dependency_weak_links {
-        return Some(cmd_graph_resource_dependency_weak_links(file, json));
-    }
-    if resource_dependency_minimum_cut {
-        return Some(cmd_graph_resource_dependency_minimum_cut(file, json));
-    }
-    if resource_dependency_dominator_tree {
-        return Some(cmd_graph_resource_dependency_dominator_tree(file, json));
-    }
-    if resource_dependency_resilience_score {
-        return Some(cmd_graph_resource_dependency_resilience_score(file, json));
-    }
-    if resource_dependency_pagerank {
-        return Some(cmd_graph_resource_dependency_pagerank(file, json));
-    }
-    if resource_dependency_betweenness_centrality {
-        return Some(cmd_graph_resource_dependency_betweenness_centrality(
-            file, json,
-        ));
-    }
-    if resource_dependency_closure_size {
-        return Some(cmd_graph_resource_dependency_closure_size(file, json));
-    }
-    if resource_dependency_eccentricity_map {
-        return Some(cmd_graph_resource_dependency_eccentricity_map(file, json));
-    }
-    if resource_dependency_diameter_path {
-        return Some(cmd_graph_resource_dependency_diameter_path(file, json));
-    }
-    None
+    first_enabled_analysis(
+        file,
+        json,
+        &[
+            (
+                resource_dependency_longest_path,
+                cmd_graph_resource_dependency_longest_path,
+            ),
+            (
+                resource_dependency_strongly_connected,
+                cmd_graph_resource_dependency_strongly_connected,
+            ),
+            (
+                resource_dependency_topological_depth,
+                cmd_graph_resource_dependency_topological_depth,
+            ),
+            (
+                resource_dependency_weak_links,
+                cmd_graph_resource_dependency_weak_links,
+            ),
+            (
+                resource_dependency_minimum_cut,
+                cmd_graph_resource_dependency_minimum_cut,
+            ),
+            (
+                resource_dependency_dominator_tree,
+                cmd_graph_resource_dependency_dominator_tree,
+            ),
+            (
+                resource_dependency_resilience_score,
+                cmd_graph_resource_dependency_resilience_score,
+            ),
+            (
+                resource_dependency_pagerank,
+                cmd_graph_resource_dependency_pagerank,
+            ),
+            (
+                resource_dependency_betweenness_centrality,
+                cmd_graph_resource_dependency_betweenness_centrality,
+            ),
+            (
+                resource_dependency_closure_size,
+                cmd_graph_resource_dependency_closure_size,
+            ),
+            (
+                resource_dependency_eccentricity_map,
+                cmd_graph_resource_dependency_eccentricity_map,
+            ),
+            (
+                resource_dependency_diameter_path,
+                cmd_graph_resource_dependency_diameter_path,
+            ),
+        ],
+    )
 }
 pub(super) fn try_graph_phase94(
     file: &Path,

--- a/src/cli/dispatch_status.rs
+++ b/src/cli/dispatch_status.rs
@@ -11,6 +11,27 @@ use super::status_resource_detail::*;
 #[allow(unused_imports)]
 use crate::core::{state, types};
 use std::path::Path;
+
+/// One `status --*` report. Almost every flag-selected report has the same
+/// shape: it reads the state directory, optionally narrowed to a single
+/// machine, and prints its findings honouring `--json`.
+type StatusReport = fn(&Path, Option<&str>, bool) -> Result<(), String>;
+
+/// Run the first report whose flag is set, in table order, and return its
+/// result; `None` when none of the flags in the table is set. Table order is
+/// the precedence order, and only the selected report is called.
+fn first_enabled_report(
+    sd: &Path,
+    machine: Option<&str>,
+    json: bool,
+    reports: &[(bool, StatusReport)],
+) -> Option<Result<(), String>> {
+    reports
+        .iter()
+        .find(|(enabled, _)| *enabled)
+        .map(|(_, report)| report(sd, machine, json))
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(super) fn try_status_phase59a(
     sd: &Path,
@@ -106,18 +127,20 @@ pub(super) fn try_status_phase65(
     error_rate: bool,
     fleet_health_summary: bool,
 ) -> Option<Result<(), String>> {
-    if resource_apply_age {
-        return Some(cmd_status_resource_apply_age(sd, machine, json));
+    if let Some(result) = first_enabled_report(
+        sd,
+        machine,
+        json,
+        &[
+            (resource_apply_age, cmd_status_resource_apply_age),
+            (machine_uptime, cmd_status_machine_uptime),
+            (resource_churn, cmd_status_resource_churn),
+            (last_drift_time, cmd_status_last_drift_time),
+        ],
+    ) {
+        return Some(result);
     }
-    if machine_uptime {
-        return Some(cmd_status_machine_uptime(sd, machine, json));
-    }
-    if resource_churn {
-        return Some(cmd_status_resource_churn(sd, machine, json));
-    }
-    if last_drift_time {
-        return Some(cmd_status_last_drift_time(sd, machine, json));
-    }
+    // Counting a machine's resources is a config-file question, not a state one.
     if machine_resource_count {
         let f = file.unwrap_or(std::path::Path::new("forjar.yaml"));
         return Some(cmd_status_machine_resource_count(f, json));
@@ -151,34 +174,28 @@ pub(super) fn try_status_phase68(
     fleet_convergence_trend: bool,
     resource_state_distribution: bool,
 ) -> Option<Result<(), String>> {
-    if machine_convergence_history {
-        return Some(cmd_status_machine_convergence_history(sd, machine, json));
-    }
-    if drift_history {
-        return Some(cmd_status_drift_history(sd, machine, json));
-    }
-    if resource_failure_rate {
-        return Some(cmd_status_resource_failure_rate(sd, machine, json));
-    }
-    if machine_last_apply {
-        return Some(cmd_status_machine_last_apply(sd, machine, json));
-    }
-    if fleet_drift_summary {
-        return Some(cmd_status_fleet_drift_summary(sd, machine, json));
-    }
-    if resource_apply_duration {
-        return Some(cmd_status_resource_apply_duration(sd, machine, json));
-    }
-    if machine_resource_health {
-        return Some(cmd_status_machine_resource_health(sd, machine, json));
-    }
-    if fleet_convergence_trend {
-        return Some(cmd_status_fleet_convergence_trend(sd, machine, json));
-    }
-    if resource_state_distribution {
-        return Some(cmd_status_resource_state_distribution(sd, machine, json));
-    }
-    None
+    first_enabled_report(
+        sd,
+        machine,
+        json,
+        &[
+            (
+                machine_convergence_history,
+                cmd_status_machine_convergence_history,
+            ),
+            (drift_history, cmd_status_drift_history),
+            (resource_failure_rate, cmd_status_resource_failure_rate),
+            (machine_last_apply, cmd_status_machine_last_apply),
+            (fleet_drift_summary, cmd_status_fleet_drift_summary),
+            (resource_apply_duration, cmd_status_resource_apply_duration),
+            (machine_resource_health, cmd_status_machine_resource_health),
+            (fleet_convergence_trend, cmd_status_fleet_convergence_trend),
+            (
+                resource_state_distribution,
+                cmd_status_resource_state_distribution,
+            ),
+        ],
+    )
 }
 #[allow(clippy::too_many_arguments)]
 pub(super) fn try_status_phase73(
@@ -232,47 +249,55 @@ pub(super) fn try_status_phase75(
     fleet_resource_type_health: bool,
     machine_resource_convergence_rate: bool,
 ) -> Option<Result<(), String>> {
-    if machine_resource_churn_rate {
-        return Some(cmd_status_machine_resource_churn_rate(sd, machine, json));
-    }
-    if fleet_resource_staleness {
-        return Some(cmd_status_fleet_resource_staleness(sd, machine, json));
-    }
-    if machine_convergence_trend {
-        return Some(cmd_status_machine_convergence_trend(sd, machine, json));
-    }
-    if machine_capacity_utilization {
-        return Some(cmd_status_machine_capacity_utilization(sd, machine, json));
-    }
-    if fleet_configuration_entropy {
-        return Some(cmd_status_fleet_configuration_entropy(sd, machine, json));
-    }
-    if machine_resource_freshness {
-        return Some(cmd_status_machine_resource_freshness(sd, machine, json));
-    }
-    if machine_error_budget {
-        return Some(cmd_status_machine_error_budget(sd, machine, json));
-    }
-    if fleet_compliance_score {
-        return Some(cmd_status_fleet_compliance_score(sd, machine, json));
-    }
-    if machine_mean_time_to_recovery {
-        return Some(cmd_status_machine_mean_time_to_recovery(sd, machine, json));
-    }
-    if machine_resource_dependency_health {
-        return Some(cmd_status_machine_resource_dependency_health(
-            sd, machine, json,
-        ));
-    }
-    if fleet_resource_type_health {
-        return Some(cmd_status_fleet_resource_type_health(sd, machine, json));
-    }
-    if machine_resource_convergence_rate {
-        return Some(cmd_status_machine_resource_convergence_rate(
-            sd, machine, json,
-        ));
-    }
-    None
+    first_enabled_report(
+        sd,
+        machine,
+        json,
+        &[
+            (
+                machine_resource_churn_rate,
+                cmd_status_machine_resource_churn_rate,
+            ),
+            (
+                fleet_resource_staleness,
+                cmd_status_fleet_resource_staleness,
+            ),
+            (
+                machine_convergence_trend,
+                cmd_status_machine_convergence_trend,
+            ),
+            (
+                machine_capacity_utilization,
+                cmd_status_machine_capacity_utilization,
+            ),
+            (
+                fleet_configuration_entropy,
+                cmd_status_fleet_configuration_entropy,
+            ),
+            (
+                machine_resource_freshness,
+                cmd_status_machine_resource_freshness,
+            ),
+            (machine_error_budget, cmd_status_machine_error_budget),
+            (fleet_compliance_score, cmd_status_fleet_compliance_score),
+            (
+                machine_mean_time_to_recovery,
+                cmd_status_machine_mean_time_to_recovery,
+            ),
+            (
+                machine_resource_dependency_health,
+                cmd_status_machine_resource_dependency_health,
+            ),
+            (
+                fleet_resource_type_health,
+                cmd_status_fleet_resource_type_health,
+            ),
+            (
+                machine_resource_convergence_rate,
+                cmd_status_machine_resource_convergence_rate,
+            ),
+        ],
+    )
 }
 #[allow(clippy::too_many_arguments)]
 pub(super) fn try_status_phase79(
@@ -304,44 +329,51 @@ pub(super) fn try_status_phase79(
     fleet_resource_convergence_streak: bool,
     machine_resource_error_distribution: bool,
 ) -> Option<Result<(), String>> {
-    if machine_resource_failure_correlation {
-        return Some(cmd_status_machine_resource_failure_correlation(
-            sd, machine, json,
-        ));
-    }
-    if fleet_resource_age_distribution {
-        return Some(cmd_status_fleet_resource_age_distribution(
-            sd, machine, json,
-        ));
-    }
-    if machine_resource_rollback_readiness {
-        return Some(cmd_status_machine_resource_rollback_readiness(
-            sd, machine, json,
-        ));
-    }
-    if machine_resource_health_trend {
-        return Some(cmd_status_machine_resource_health_trend(sd, machine, json));
-    }
-    if fleet_resource_drift_velocity {
-        return Some(cmd_status_fleet_resource_drift_velocity(sd, machine, json));
-    }
-    if machine_resource_apply_success_trend {
-        return Some(cmd_status_machine_resource_apply_success_trend(
-            sd, machine, json,
-        ));
-    }
-    if machine_resource_mttr_estimate {
-        return Some(cmd_status_machine_resource_mttr_estimate(sd, machine, json));
-    }
-    if fleet_resource_convergence_forecast {
-        return Some(cmd_status_fleet_resource_convergence_forecast(
-            sd, machine, json,
-        ));
-    }
-    if machine_resource_error_budget_forecast {
-        return Some(cmd_status_machine_resource_error_budget_forecast(
-            sd, machine, json,
-        ));
+    let phase79 = first_enabled_report(
+        sd,
+        machine,
+        json,
+        &[
+            (
+                machine_resource_failure_correlation,
+                cmd_status_machine_resource_failure_correlation,
+            ),
+            (
+                fleet_resource_age_distribution,
+                cmd_status_fleet_resource_age_distribution,
+            ),
+            (
+                machine_resource_rollback_readiness,
+                cmd_status_machine_resource_rollback_readiness,
+            ),
+            (
+                machine_resource_health_trend,
+                cmd_status_machine_resource_health_trend,
+            ),
+            (
+                fleet_resource_drift_velocity,
+                cmd_status_fleet_resource_drift_velocity,
+            ),
+            (
+                machine_resource_apply_success_trend,
+                cmd_status_machine_resource_apply_success_trend,
+            ),
+            (
+                machine_resource_mttr_estimate,
+                cmd_status_machine_resource_mttr_estimate,
+            ),
+            (
+                fleet_resource_convergence_forecast,
+                cmd_status_fleet_resource_convergence_forecast,
+            ),
+            (
+                machine_resource_error_budget_forecast,
+                cmd_status_machine_resource_error_budget_forecast,
+            ),
+        ],
+    );
+    if phase79.is_some() {
+        return phase79;
     }
     try_status_phase82(
         sd,
@@ -385,46 +417,51 @@ pub(super) fn try_status_phase82(
     fleet_resource_convergence_streak: bool,
     machine_resource_error_distribution: bool,
 ) -> Option<Result<(), String>> {
-    if machine_resource_dependency_lag {
-        return Some(cmd_status_machine_resource_dependency_lag(
-            sd, machine, json,
-        ));
-    }
-    if fleet_resource_dependency_lag {
-        return Some(cmd_status_fleet_resource_dependency_lag(sd, machine, json));
-    }
-    if machine_resource_config_drift_rate {
-        return Some(cmd_status_machine_resource_config_drift_rate(
-            sd, machine, json,
-        ));
-    }
-    if machine_resource_convergence_lag {
-        return Some(cmd_status_machine_resource_convergence_lag(
-            sd, machine, json,
-        ));
-    }
-    if fleet_resource_convergence_lag {
-        return Some(cmd_status_fleet_resource_convergence_lag(sd, machine, json));
-    }
-    if machine_resource_dependency_depth {
-        return Some(cmd_status_machine_resource_dependency_depth(
-            sd, machine, json,
-        ));
-    }
-    if machine_resource_convergence_velocity {
-        return Some(cmd_status_machine_resource_convergence_velocity(
-            sd, machine, json,
-        ));
-    }
-    if fleet_resource_convergence_velocity {
-        return Some(cmd_status_fleet_resource_convergence_velocity(
-            sd, machine, json,
-        ));
-    }
-    if machine_resource_failure_recurrence {
-        return Some(cmd_status_machine_resource_failure_recurrence(
-            sd, machine, json,
-        ));
+    let phase82 = first_enabled_report(
+        sd,
+        machine,
+        json,
+        &[
+            (
+                machine_resource_dependency_lag,
+                cmd_status_machine_resource_dependency_lag,
+            ),
+            (
+                fleet_resource_dependency_lag,
+                cmd_status_fleet_resource_dependency_lag,
+            ),
+            (
+                machine_resource_config_drift_rate,
+                cmd_status_machine_resource_config_drift_rate,
+            ),
+            (
+                machine_resource_convergence_lag,
+                cmd_status_machine_resource_convergence_lag,
+            ),
+            (
+                fleet_resource_convergence_lag,
+                cmd_status_fleet_resource_convergence_lag,
+            ),
+            (
+                machine_resource_dependency_depth,
+                cmd_status_machine_resource_dependency_depth,
+            ),
+            (
+                machine_resource_convergence_velocity,
+                cmd_status_machine_resource_convergence_velocity,
+            ),
+            (
+                fleet_resource_convergence_velocity,
+                cmd_status_fleet_resource_convergence_velocity,
+            ),
+            (
+                machine_resource_failure_recurrence,
+                cmd_status_machine_resource_failure_recurrence,
+            ),
+        ],
+    );
+    if phase82.is_some() {
+        return phase82;
     }
     try_status_phase85(
         sd,

--- a/src/cli/dispatch_status_b.rs
+++ b/src/cli/dispatch_status_b.rs
@@ -13,6 +13,26 @@ use super::status_transport::*;
 use super::{status_intelligence_ext::*, status_intelligence_ext2::*};
 use std::path::Path;
 
+/// Shape shared by every `status` sub-report reached from a phase dispatcher.
+/// Because it is uniform, a dispatcher can be written as a table of
+/// (flag, report) pairs rather than a chain of `if` statements.
+pub(super) type StatusReport = fn(&Path, Option<&str>, bool) -> Result<(), String>;
+
+/// Runs the first report whose flag is set, in table order, and returns `None`
+/// when no flag in the table is set. Reports past the first match are never
+/// called, so this keeps the short-circuiting the `if` chains had.
+pub(super) fn first_enabled_report(
+    sd: &Path,
+    machine: Option<&str>,
+    json: bool,
+    table: &[(bool, StatusReport)],
+) -> Option<Result<(), String>> {
+    table
+        .iter()
+        .find(|(enabled, _)| *enabled)
+        .map(|(_, report)| report(sd, machine, json))
+}
+
 fn try_status_phase87(
     sd: &Path,
     machine: Option<&str>,
@@ -212,36 +232,22 @@ pub(super) fn try_status_phases_97_99(
     f2: bool,
     f3: bool,
 ) -> Option<Result<(), String>> {
-    if d1 {
-        return Some(cmd_status_fleet_state_churn_analysis(sd, machine, json));
-    }
-    if d2 {
-        return Some(cmd_status_config_maturity_score(sd, machine, json));
-    }
-    if d3 {
-        return Some(cmd_status_fleet_capacity_utilization(sd, machine, json));
-    }
-    if e1 {
-        return Some(cmd_status_fleet_drift_velocity_trend(sd, machine, json));
-    }
-    if e2 {
-        return Some(cmd_status_machine_convergence_window(sd, machine, json));
-    }
-    if e3 {
-        return Some(cmd_status_fleet_resource_age_histogram(sd, machine, json));
-    }
-    if f1 {
-        return Some(cmd_status_fleet_security_posture_summary(sd, machine, json));
-    }
-    if f2 {
-        return Some(cmd_status_machine_resource_freshness_index(
-            sd, machine, json,
-        ));
-    }
-    if f3 {
-        return Some(cmd_status_fleet_resource_type_coverage(sd, machine, json));
-    }
-    None
+    first_enabled_report(
+        sd,
+        machine,
+        json,
+        &[
+            (d1, cmd_status_fleet_state_churn_analysis),
+            (d2, cmd_status_config_maturity_score),
+            (d3, cmd_status_fleet_capacity_utilization),
+            (e1, cmd_status_fleet_drift_velocity_trend),
+            (e2, cmd_status_machine_convergence_window),
+            (e3, cmd_status_fleet_resource_age_histogram),
+            (f1, cmd_status_fleet_security_posture_summary),
+            (f2, cmd_status_machine_resource_freshness_index),
+            (f3, cmd_status_fleet_resource_type_coverage),
+        ],
+    )
 }
 #[allow(clippy::too_many_arguments)]
 pub(super) fn try_status_phases_100_103(
@@ -261,61 +267,58 @@ pub(super) fn try_status_phases_100_103(
     machine_resource_drift_recovery_time: bool,
     fleet_resource_config_complexity_score: bool,
 ) -> Option<Result<(), String>> {
-    if fleet_apply_cadence {
-        return Some(cmd_status_fleet_apply_cadence(sd, machine, json));
-    }
-    if machine_resource_error_classification {
-        return Some(cmd_status_machine_resource_error_classification(
-            sd, machine, json,
-        ));
-    }
-    if fleet_resource_convergence_summary {
-        return Some(cmd_status_fleet_resource_convergence_summary(
-            sd, machine, json,
-        ));
-    }
-    if fleet_resource_staleness_report {
-        return Some(cmd_status_fleet_resource_staleness_report(
-            sd, machine, json,
-        ));
-    }
-    if machine_resource_type_distribution {
-        return Some(cmd_status_machine_resource_type_distribution(
-            sd, machine, json,
-        ));
-    }
-    if fleet_machine_health_score {
-        return Some(cmd_status_fleet_machine_health_score(sd, machine, json));
-    }
-    if fleet_resource_dependency_lag_report {
-        return Some(cmd_status_fleet_resource_dependency_lag_report(
-            sd, machine, json,
-        ));
-    }
-    if machine_resource_convergence_rate_trend {
-        return Some(cmd_status_machine_resource_convergence_rate_trend(
-            sd, machine, json,
-        ));
-    }
-    if fleet_resource_apply_lag {
-        return Some(cmd_status_fleet_resource_apply_lag(sd, machine, json));
-    }
-    if fleet_resource_error_rate_trend {
-        return Some(cmd_status_fleet_resource_error_rate_trend(
-            sd, machine, json,
-        ));
-    }
-    if machine_resource_drift_recovery_time {
-        return Some(cmd_status_machine_resource_drift_recovery_time(
-            sd, machine, json,
-        ));
-    }
-    if fleet_resource_config_complexity_score {
-        return Some(cmd_status_fleet_resource_config_complexity_score(
-            sd, machine, json,
-        ));
-    }
-    None
+    first_enabled_report(
+        sd,
+        machine,
+        json,
+        &[
+            (fleet_apply_cadence, cmd_status_fleet_apply_cadence),
+            (
+                machine_resource_error_classification,
+                cmd_status_machine_resource_error_classification,
+            ),
+            (
+                fleet_resource_convergence_summary,
+                cmd_status_fleet_resource_convergence_summary,
+            ),
+            (
+                fleet_resource_staleness_report,
+                cmd_status_fleet_resource_staleness_report,
+            ),
+            (
+                machine_resource_type_distribution,
+                cmd_status_machine_resource_type_distribution,
+            ),
+            (
+                fleet_machine_health_score,
+                cmd_status_fleet_machine_health_score,
+            ),
+            (
+                fleet_resource_dependency_lag_report,
+                cmd_status_fleet_resource_dependency_lag_report,
+            ),
+            (
+                machine_resource_convergence_rate_trend,
+                cmd_status_machine_resource_convergence_rate_trend,
+            ),
+            (
+                fleet_resource_apply_lag,
+                cmd_status_fleet_resource_apply_lag,
+            ),
+            (
+                fleet_resource_error_rate_trend,
+                cmd_status_fleet_resource_error_rate_trend,
+            ),
+            (
+                machine_resource_drift_recovery_time,
+                cmd_status_machine_resource_drift_recovery_time,
+            ),
+            (
+                fleet_resource_config_complexity_score,
+                cmd_status_fleet_resource_config_complexity_score,
+            ),
+        ],
+    )
 }
 #[allow(clippy::too_many_arguments)]
 pub(super) fn try_status_phases_104_107(
@@ -335,63 +338,25 @@ pub(super) fn try_status_phases_104_107(
     j2: bool,
     j3: bool,
 ) -> Option<Result<(), String>> {
-    if g1 {
-        return Some(cmd_status_fleet_resource_maturity_index(sd, machine, json));
-    }
-    if g2 {
-        return Some(cmd_status_machine_resource_convergence_stability_index(
-            sd, machine, json,
-        ));
-    }
-    if g3 {
-        return Some(cmd_status_fleet_resource_drift_pattern_analysis(
-            sd, machine, json,
-        ));
-    }
-    if h1 {
-        return Some(cmd_status_fleet_resource_apply_success_trend(
-            sd, machine, json,
-        ));
-    }
-    if h2 {
-        return Some(cmd_status_machine_resource_drift_age_distribution(
-            sd, machine, json,
-        ));
-    }
-    if h3 {
-        return Some(cmd_status_fleet_resource_convergence_gap_analysis(
-            sd, machine, json,
-        ));
-    }
-    if i1 {
-        return Some(cmd_status_fleet_resource_type_drift_correlation(
-            sd, machine, json,
-        ));
-    }
-    if i2 {
-        return Some(cmd_status_machine_resource_apply_cadence_report(
-            sd, machine, json,
-        ));
-    }
-    if i3 {
-        return Some(cmd_status_fleet_resource_drift_recovery_trend(
-            sd, machine, json,
-        ));
-    }
-    if j1 {
-        return Some(cmd_status_fleet_resource_quality_score(sd, machine, json));
-    }
-    if j2 {
-        return Some(cmd_status_machine_resource_drift_pattern_classification(
-            sd, machine, json,
-        ));
-    }
-    if j3 {
-        return Some(cmd_status_fleet_resource_convergence_window_analysis(
-            sd, machine, json,
-        ));
-    }
-    None
+    first_enabled_report(
+        sd,
+        machine,
+        json,
+        &[
+            (g1, cmd_status_fleet_resource_maturity_index),
+            (g2, cmd_status_machine_resource_convergence_stability_index),
+            (g3, cmd_status_fleet_resource_drift_pattern_analysis),
+            (h1, cmd_status_fleet_resource_apply_success_trend),
+            (h2, cmd_status_machine_resource_drift_age_distribution),
+            (h3, cmd_status_fleet_resource_convergence_gap_analysis),
+            (i1, cmd_status_fleet_resource_type_drift_correlation),
+            (i2, cmd_status_machine_resource_apply_cadence_report),
+            (i3, cmd_status_fleet_resource_drift_recovery_trend),
+            (j1, cmd_status_fleet_resource_quality_score),
+            (j2, cmd_status_machine_resource_drift_pattern_classification),
+            (j3, cmd_status_fleet_resource_convergence_window_analysis),
+        ],
+    )
 }
 #[allow(clippy::too_many_arguments)]
 pub(super) fn try_status_phases_87_92(

--- a/src/cli/dispatch_status_ext.rs
+++ b/src/cli/dispatch_status_ext.rs
@@ -98,7 +98,10 @@ pub(crate) fn dispatch_status_early(
     stale: Option<u64>,
     failed_since: &Option<String>,
 ) -> Result<(), String> {
-    if let Some(r) = try_status_phase71(
+    // Each `try_status_*` group returns `Some` only when one of the flags it
+    // owns was set, and `or_else` keeps the calls lazy — so the first group
+    // that recognises the request handles it and the rest are never reached.
+    let handled = try_status_phase71(
         sd,
         m,
         json,
@@ -108,141 +111,156 @@ pub(crate) fn dispatch_status_early(
         machine_uptime_estimate,
         fleet_resource_type_breakdown,
         resource_convergence_time,
-    ) {
-        return r;
+    )
+    .or_else(|| {
+        try_status_phase58(
+            sd,
+            m,
+            json,
+            resource_types_summary,
+            failed_resources,
+            drift_trend,
+            resource_inputs,
+            convergence_history,
+            config_hash,
+            last_apply_duration,
+            drift_details_all,
+            resource_size,
+            hash_verify,
+            lock_age,
+        )
+    })
+    .or_else(|| {
+        try_status_analytics(
+            sd,
+            m,
+            json,
+            change_frequency,
+            machine_summary,
+            recommendations,
+            uptime,
+            diagnostic,
+            resource_dependencies,
+            pipeline_status,
+            drift_forecast,
+            resource_cost,
+            security_posture,
+        )
+    })
+    .or_else(|| {
+        try_status_fleet(
+            sd,
+            m,
+            json,
+            error_summary,
+            resource_timeline,
+            convergence_time,
+            config_drift,
+            machine_health,
+            fleet_overview,
+            drift_velocity,
+            resource_graph,
+            audit_trail,
+            executive_summary,
+        )
+    })
+    .or_else(|| {
+        try_status_reports(
+            sd,
+            m,
+            json,
+            health_score,
+            staleness_report,
+            cost_estimate,
+            capacity,
+            prediction,
+            trend,
+            mttr,
+            compliance_report,
+            sla_report,
+            resource_age,
+            drift_summary,
+        )
+    })
+    .or_else(|| {
+        try_status_queries_a(
+            sd,
+            m,
+            json,
+            convergence_rate,
+            top_failures,
+            dependency_health,
+            histogram,
+            compliance,
+            diff_lock,
+            alerts,
+            compact,
+            export,
+            json_lines,
+        )
+    })
+    .or_else(|| {
+        try_status_queries_b(
+            sd,
+            m,
+            json,
+            since,
+            stale_resources,
+            health_threshold,
+            machines_only,
+            resources_by_type,
+            anomalies,
+            diff_from,
+            count,
+        )
+    })
+    .or_else(|| {
+        try_status_display(
+            sd,
+            m,
+            json,
+            status_format,
+            prometheus,
+            expired,
+            changes_since,
+            summary_by,
+            timeline,
+            drift_details,
+            health,
+            stale,
+            failed_since,
+        )
+    });
+    if let Some(result) = handled {
+        return result;
     }
-    if let Some(r) = try_status_phase58(
-        sd,
-        m,
-        json,
-        resource_types_summary,
-        failed_resources,
-        drift_trend,
-        resource_inputs,
-        convergence_history,
-        config_hash,
-        last_apply_duration,
-        drift_details_all,
-        resource_size,
-        hash_verify,
-        lock_age,
-    ) {
-        return r;
+
+    match watch {
+        Some(interval) => watch_status(sd, m, json, file, summary, interval),
+        None => cmd_status(sd, m, json, file, summary),
     }
-    if let Some(r) = try_status_analytics(
-        sd,
-        m,
-        json,
-        change_frequency,
-        machine_summary,
-        recommendations,
-        uptime,
-        diagnostic,
-        resource_dependencies,
-        pipeline_status,
-        drift_forecast,
-        resource_cost,
-        security_posture,
-    ) {
-        return r;
-    }
-    if let Some(r) = try_status_fleet(
-        sd,
-        m,
-        json,
-        error_summary,
-        resource_timeline,
-        convergence_time,
-        config_drift,
-        machine_health,
-        fleet_overview,
-        drift_velocity,
-        resource_graph,
-        audit_trail,
-        executive_summary,
-    ) {
-        return r;
-    }
-    if let Some(r) = try_status_reports(
-        sd,
-        m,
-        json,
-        health_score,
-        staleness_report,
-        cost_estimate,
-        capacity,
-        prediction,
-        trend,
-        mttr,
-        compliance_report,
-        sla_report,
-        resource_age,
-        drift_summary,
-    ) {
-        return r;
-    }
-    if let Some(r) = try_status_queries_a(
-        sd,
-        m,
-        json,
-        convergence_rate,
-        top_failures,
-        dependency_health,
-        histogram,
-        compliance,
-        diff_lock,
-        alerts,
-        compact,
-        export,
-        json_lines,
-    ) {
-        return r;
-    }
-    if let Some(r) = try_status_queries_b(
-        sd,
-        m,
-        json,
-        since,
-        stale_resources,
-        health_threshold,
-        machines_only,
-        resources_by_type,
-        anomalies,
-        diff_from,
-        count,
-    ) {
-        return r;
-    }
-    if let Some(r) = try_status_display(
-        sd,
-        m,
-        json,
-        status_format,
-        prometheus,
-        expired,
-        changes_since,
-        summary_by,
-        timeline,
-        drift_details,
-        health,
-        stale,
-        failed_since,
-    ) {
-        return r;
-    }
-    if let Some(interval) = watch {
-        let interval = interval.max(1);
-        loop {
-            print!("\x1b[2J\x1b[H");
-            cmd_status(sd, m, json, file, summary)?;
-            println!(
-                "\n{}",
-                dim(&format!("Refreshing every {interval}s (Ctrl+C to stop)"))
-            );
-            std::thread::sleep(std::time::Duration::from_secs(interval));
-        }
-    } else {
-        cmd_status(sd, m, json, file, summary)
+}
+
+/// Redraw the plain status every `interval` seconds (never faster than once a
+/// second) until the user interrupts. Only ever returns on a `cmd_status`
+/// failure — the success path is an endless loop.
+fn watch_status(
+    sd: &Path,
+    m: Option<&str>,
+    json: bool,
+    file: Option<&Path>,
+    summary: bool,
+    interval: u64,
+) -> Result<(), String> {
+    let interval = interval.max(1);
+    loop {
+        print!("\x1b[2J\x1b[H");
+        cmd_status(sd, m, json, file, summary)?;
+        println!(
+            "\n{}",
+            dim(&format!("Refreshing every {interval}s (Ctrl+C to stop)"))
+        );
+        std::thread::sleep(std::time::Duration::from_secs(interval));
     }
 }
 

--- a/src/cli/dispatch_status_ext_b.rs
+++ b/src/cli/dispatch_status_ext_b.rs
@@ -1,3 +1,4 @@
+use super::dispatch_status_b::first_enabled_report;
 use super::lock_ops::*;
 use super::status_alerts::*;
 use super::status_compliance::*;
@@ -13,6 +14,22 @@ use super::status_resource_detail::*;
 use super::status_resources::*;
 use super::status_trends::*;
 use std::path::Path;
+
+/// Fleet-wide reports take no machine filter. These adapters give them the
+/// uniform `(state_dir, machine, json)` report shape so they can sit in the
+/// same dispatch table as the per-machine reports, with the ignored filter
+/// spelled out rather than hidden.
+fn drift_details_all_report(sd: &Path, _machine: Option<&str>, json: bool) -> Result<(), String> {
+    cmd_status_drift_details_all(sd, json)
+}
+
+fn fleet_overview_report(sd: &Path, _machine: Option<&str>, json: bool) -> Result<(), String> {
+    cmd_status_fleet_overview(sd, json)
+}
+
+fn executive_summary_report(sd: &Path, _machine: Option<&str>, json: bool) -> Result<(), String> {
+    cmd_status_executive_summary(sd, json)
+}
 
 #[allow(clippy::too_many_arguments)]
 pub(super) fn try_status_phase58(
@@ -31,40 +48,24 @@ pub(super) fn try_status_phase58(
     hash_verify: bool,
     lock_age: bool,
 ) -> Option<Result<(), String>> {
-    if resource_types_summary {
-        return Some(cmd_status_resource_types_summary(sd, machine, json));
-    }
-    if failed_resources {
-        return Some(cmd_status_failed_resources(sd, machine, json));
-    }
-    if drift_trend {
-        return Some(cmd_status_drift_trend(sd, machine, json));
-    }
-    if resource_inputs {
-        return Some(cmd_status_resource_inputs(sd, machine, json));
-    }
-    if convergence_history {
-        return Some(cmd_status_convergence_history(sd, machine, json));
-    }
-    if config_hash {
-        return Some(cmd_status_config_hash(sd, machine, json));
-    }
-    if last_apply_duration {
-        return Some(cmd_status_last_apply_duration(sd, machine, json));
-    }
-    if drift_details_all {
-        return Some(cmd_status_drift_details_all(sd, json));
-    }
-    if resource_size {
-        return Some(cmd_status_resource_size(sd, machine, json));
-    }
-    if hash_verify {
-        return Some(cmd_status_hash_verify(sd, machine, json));
-    }
-    if lock_age {
-        return Some(cmd_status_lock_age(sd, machine, json));
-    }
-    None
+    first_enabled_report(
+        sd,
+        machine,
+        json,
+        &[
+            (resource_types_summary, cmd_status_resource_types_summary),
+            (failed_resources, cmd_status_failed_resources),
+            (drift_trend, cmd_status_drift_trend),
+            (resource_inputs, cmd_status_resource_inputs),
+            (convergence_history, cmd_status_convergence_history),
+            (config_hash, cmd_status_config_hash),
+            (last_apply_duration, cmd_status_last_apply_duration),
+            (drift_details_all, drift_details_all_report),
+            (resource_size, cmd_status_resource_size),
+            (hash_verify, cmd_status_hash_verify),
+            (lock_age, cmd_status_lock_age),
+        ],
+    )
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -83,37 +84,23 @@ pub(super) fn try_status_analytics(
     resource_cost: bool,
     security_posture: bool,
 ) -> Option<Result<(), String>> {
-    if change_frequency {
-        return Some(cmd_status_change_frequency(sd, machine, json));
-    }
-    if machine_summary {
-        return Some(cmd_status_machine_summary(sd, machine, json));
-    }
-    if recommendations {
-        return Some(cmd_status_recommendations(sd, machine, json));
-    }
-    if uptime {
-        return Some(cmd_status_uptime(sd, machine, json));
-    }
-    if diagnostic {
-        return Some(cmd_status_diagnostic(sd, machine, json));
-    }
-    if resource_dependencies {
-        return Some(cmd_status_resource_dependencies(sd, machine, json));
-    }
-    if pipeline_status {
-        return Some(cmd_status_pipeline_status(sd, machine, json));
-    }
-    if drift_forecast {
-        return Some(cmd_status_drift_forecast(sd, machine, json));
-    }
-    if resource_cost {
-        return Some(cmd_status_resource_cost(sd, machine, json));
-    }
-    if security_posture {
-        return Some(cmd_status_security_posture(sd, machine, json));
-    }
-    None
+    first_enabled_report(
+        sd,
+        machine,
+        json,
+        &[
+            (change_frequency, cmd_status_change_frequency),
+            (machine_summary, cmd_status_machine_summary),
+            (recommendations, cmd_status_recommendations),
+            (uptime, cmd_status_uptime),
+            (diagnostic, cmd_status_diagnostic),
+            (resource_dependencies, cmd_status_resource_dependencies),
+            (pipeline_status, cmd_status_pipeline_status),
+            (drift_forecast, cmd_status_drift_forecast),
+            (resource_cost, cmd_status_resource_cost),
+            (security_posture, cmd_status_security_posture),
+        ],
+    )
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -132,37 +119,23 @@ pub(super) fn try_status_fleet(
     audit_trail: bool,
     executive_summary: bool,
 ) -> Option<Result<(), String>> {
-    if error_summary {
-        return Some(cmd_status_error_summary(sd, machine, json));
-    }
-    if resource_timeline {
-        return Some(cmd_status_resource_timeline(sd, machine, json));
-    }
-    if convergence_time {
-        return Some(cmd_status_convergence_time(sd, machine, json));
-    }
-    if config_drift {
-        return Some(cmd_status_config_drift(sd, machine, json));
-    }
-    if machine_health {
-        return Some(cmd_status_machine_health(sd, machine, json));
-    }
-    if fleet_overview {
-        return Some(cmd_status_fleet_overview(sd, json));
-    }
-    if drift_velocity {
-        return Some(cmd_status_drift_velocity(sd, machine, json));
-    }
-    if resource_graph {
-        return Some(cmd_status_resource_graph(sd, machine, json));
-    }
-    if audit_trail {
-        return Some(cmd_status_audit_trail(sd, machine, json));
-    }
-    if executive_summary {
-        return Some(cmd_status_executive_summary(sd, json));
-    }
-    None
+    first_enabled_report(
+        sd,
+        machine,
+        json,
+        &[
+            (error_summary, cmd_status_error_summary),
+            (resource_timeline, cmd_status_resource_timeline),
+            (convergence_time, cmd_status_convergence_time),
+            (config_drift, cmd_status_config_drift),
+            (machine_health, cmd_status_machine_health),
+            (fleet_overview, fleet_overview_report),
+            (drift_velocity, cmd_status_drift_velocity),
+            (resource_graph, cmd_status_resource_graph),
+            (audit_trail, cmd_status_audit_trail),
+            (executive_summary, executive_summary_report),
+        ],
+    )
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -182,40 +155,30 @@ pub(super) fn try_status_reports(
     resource_age: bool,
     drift_summary: bool,
 ) -> Option<Result<(), String>> {
-    if health_score {
-        return Some(cmd_status_health_score(sd, machine, json));
-    }
-    if let Some(ref w) = staleness_report {
-        return Some(cmd_status_staleness_report(sd, machine, w, json));
-    }
-    if cost_estimate {
-        return Some(cmd_status_cost_estimate(sd, machine, json));
-    }
-    if capacity {
-        return Some(cmd_status_capacity(sd, machine, json));
-    }
-    if prediction {
-        return Some(cmd_status_prediction(sd, machine, json));
-    }
-    if let Some(n) = trend {
-        return Some(cmd_status_trend(sd, machine, n, json));
-    }
-    if mttr {
-        return Some(cmd_status_mttr(sd, machine, json));
-    }
-    if let Some(ref p) = compliance_report {
-        return Some(cmd_status_compliance_report(sd, machine, p, json));
-    }
-    if sla_report {
-        return Some(cmd_status_sla_report(sd, machine, json));
-    }
-    if resource_age {
-        return Some(cmd_status_resource_age(sd, machine, json));
-    }
-    if drift_summary {
-        return Some(cmd_status_drift_summary(sd, machine, json));
-    }
-    None
+    // Candidates in declaration order; `or_else` keeps the first-match-wins
+    // priority the `if` chain had, and evaluates nothing past that match.
+    // Reports carrying a value cannot join the plain flag table, so this
+    // dispatcher chains them instead.
+    health_score
+        .then(|| cmd_status_health_score(sd, machine, json))
+        .or_else(|| {
+            staleness_report
+                .as_deref()
+                .map(|w| cmd_status_staleness_report(sd, machine, w, json))
+        })
+        .or_else(|| cost_estimate.then(|| cmd_status_cost_estimate(sd, machine, json)))
+        .or_else(|| capacity.then(|| cmd_status_capacity(sd, machine, json)))
+        .or_else(|| prediction.then(|| cmd_status_prediction(sd, machine, json)))
+        .or_else(|| trend.map(|n| cmd_status_trend(sd, machine, n, json)))
+        .or_else(|| mttr.then(|| cmd_status_mttr(sd, machine, json)))
+        .or_else(|| {
+            compliance_report
+                .as_deref()
+                .map(|p| cmd_status_compliance_report(sd, machine, p, json))
+        })
+        .or_else(|| sla_report.then(|| cmd_status_sla_report(sd, machine, json)))
+        .or_else(|| resource_age.then(|| cmd_status_resource_age(sd, machine, json)))
+        .or_else(|| drift_summary.then(|| cmd_status_drift_summary(sd, machine, json)))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -234,37 +197,28 @@ pub(super) fn try_status_queries_a(
     export: &Option<std::path::PathBuf>,
     json_lines: bool,
 ) -> Option<Result<(), String>> {
-    if convergence_rate {
-        return Some(cmd_status_convergence_rate(sd, machine, json));
-    }
-    if top_failures {
-        return Some(cmd_status_top_failures(sd, machine, json));
-    }
-    if dependency_health {
-        return Some(cmd_status_dependency_health(sd, machine, json));
-    }
-    if histogram {
-        return Some(cmd_status_histogram(sd, machine, json));
-    }
-    if let Some(ref p) = compliance {
-        return Some(cmd_status_compliance(sd, machine, p, json));
-    }
-    if let Some(ref p) = diff_lock {
-        return Some(cmd_lock_diff(sd, p, json));
-    }
-    if alerts {
-        return Some(cmd_status_alerts(sd, machine, json));
-    }
-    if compact {
-        return Some(cmd_status_compact(sd, machine, json));
-    }
-    if let Some(ref p) = export {
-        return Some(cmd_status_export(sd, machine, p, json));
-    }
-    if json_lines {
-        return Some(cmd_status_json_lines(sd, machine));
-    }
-    None
+    // Candidates in declaration order; `or_else` keeps first-match-wins and
+    // evaluates nothing past the match. See `try_status_reports` for why the
+    // value-carrying queries are chained rather than tabulated.
+    convergence_rate
+        .then(|| cmd_status_convergence_rate(sd, machine, json))
+        .or_else(|| top_failures.then(|| cmd_status_top_failures(sd, machine, json)))
+        .or_else(|| dependency_health.then(|| cmd_status_dependency_health(sd, machine, json)))
+        .or_else(|| histogram.then(|| cmd_status_histogram(sd, machine, json)))
+        .or_else(|| {
+            compliance
+                .as_deref()
+                .map(|p| cmd_status_compliance(sd, machine, p, json))
+        })
+        .or_else(|| diff_lock.as_deref().map(|p| cmd_lock_diff(sd, p, json)))
+        .or_else(|| alerts.then(|| cmd_status_alerts(sd, machine, json)))
+        .or_else(|| compact.then(|| cmd_status_compact(sd, machine, json)))
+        .or_else(|| {
+            export
+                .as_deref()
+                .map(|p| cmd_status_export(sd, machine, p, json))
+        })
+        .or_else(|| json_lines.then(|| cmd_status_json_lines(sd, machine)))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -324,35 +278,35 @@ pub(super) fn try_status_display(
     stale: Option<u64>,
     failed_since: &Option<String>,
 ) -> Option<Result<(), String>> {
-    if let Some(ref f) = status_format {
-        return Some(cmd_status_format(sd, machine, f));
-    }
-    if prometheus {
-        return Some(cmd_status_prometheus(sd, machine));
-    }
-    if let Some(ref d) = expired {
-        return Some(cmd_status_expired(sd, machine, d, json));
-    }
-    if let Some(ref c) = changes_since {
-        return Some(cmd_status_changes_since(sd, c, json));
-    }
-    if let Some(ref d) = summary_by {
-        return Some(cmd_status_summary_by(sd, machine, d, json));
-    }
-    if timeline {
-        return Some(cmd_status_timeline(sd, machine, json));
-    }
-    if drift_details {
-        return Some(cmd_status_drift_details(sd, machine, json));
-    }
-    if health {
-        return Some(cmd_status_health(sd, machine, json));
-    }
-    if let Some(days) = stale {
-        return Some(cmd_status_stale(sd, machine, days, json));
-    }
-    if let Some(ref s) = failed_since {
-        return Some(cmd_status_failed_since(sd, machine, s, json));
-    }
-    None
+    // Candidates in declaration order; `or_else` keeps first-match-wins and
+    // evaluates nothing past the match. See `try_status_reports` for why the
+    // value-carrying displays are chained rather than tabulated.
+    status_format
+        .as_deref()
+        .map(|f| cmd_status_format(sd, machine, f))
+        .or_else(|| prometheus.then(|| cmd_status_prometheus(sd, machine)))
+        .or_else(|| {
+            expired
+                .as_deref()
+                .map(|d| cmd_status_expired(sd, machine, d, json))
+        })
+        .or_else(|| {
+            changes_since
+                .as_deref()
+                .map(|c| cmd_status_changes_since(sd, c, json))
+        })
+        .or_else(|| {
+            summary_by
+                .as_deref()
+                .map(|d| cmd_status_summary_by(sd, machine, d, json))
+        })
+        .or_else(|| timeline.then(|| cmd_status_timeline(sd, machine, json)))
+        .or_else(|| drift_details.then(|| cmd_status_drift_details(sd, machine, json)))
+        .or_else(|| health.then(|| cmd_status_health(sd, machine, json)))
+        .or_else(|| stale.map(|days| cmd_status_stale(sd, machine, days, json)))
+        .or_else(|| {
+            failed_since
+                .as_deref()
+                .map(|s| cmd_status_failed_since(sd, machine, s, json))
+        })
 }

--- a/src/cli/dispatch_validate_b.rs
+++ b/src/cli/dispatch_validate_b.rs
@@ -47,6 +47,48 @@ fn try_validate_advanced(
     }
     None
 }
+/// Gate every `validate` sub-check has to pass before dispatch.
+///
+/// GH-211: FJ-381 was destructured to `_schema_version` — accepted, never
+/// read. `validate --schema-version 99.0` reported the config valid against
+/// a schema version that was never consulted.
+///
+/// FJ-2500 / GH-272: unknown fields are errors. This was an inline copy of
+/// the check, which is how validate and every other verb came to disagree
+/// about whether the same file was valid. `parse_and_validate` now denies,
+/// so validate inherits the rule instead of reimplementing it — and loading
+/// here, BEFORE dispatch, covers every sub-check rather than only the ones
+/// that happen to load the config themselves. `--check-recipe-purity` reads
+/// raw YAML by design (purity keys are not typed fields) and so consulted
+/// no validation at all; it was the inline copy that had been masking that.
+///
+/// EMIT JSON ON THE FAILURE PATH TOO.
+///
+/// This was a bare `parse_and_validate(&file)?;` — the result discarded,
+/// the call kept only for its failure side effect — so it returned here,
+/// long before any sub-command could honour `--json`. `validate --json` on
+/// an invalid config therefore printed ZERO bytes to stdout and a
+/// plain-text error to stderr: the one case a machine consumer needs the
+/// structured errors, since a conforming config tells it nothing it did not
+/// already assume. Ledger id validate-json-emits-non-json-on-failure,
+/// confirmed at 1.12.3 and still live at 1.16.0.
+///
+/// The exit code and the human-facing stderr are deliberately unchanged.
+fn validate_preflight(file: &Path, json: bool, schema_version_given: bool) -> Result<(), String> {
+    super::inert_flags::reject_inert_flag("--schema-version", schema_version_given)?;
+
+    if let Err(e) = crate::core::parser::parse_and_validate(file) {
+        if json {
+            println!(
+                "{}",
+                crate::cli::validate_core::validation_failure_json(file, std::slice::from_ref(&e))
+            );
+        }
+        return Err(e);
+    }
+    Ok(())
+}
+
 pub(crate) fn dispatch_validate(args: ValidateArgs) -> Result<(), String> {
     let ValidateArgs {
         file,
@@ -202,48 +244,19 @@ pub(crate) fn dispatch_validate(args: ValidateArgs) -> Result<(), String> {
         deny_unknown_fields,
     } = args;
 
-    // GH-211: FJ-381 was destructured to `_schema_version` — accepted, never
-    // read. `validate --schema-version 99.0` reported the config valid against
-    // a schema version that was never consulted.
-    super::inert_flags::reject_inert_flag("--schema-version", _schema_version.is_some())?;
-
-    // FJ-2500 / GH-272: unknown fields are errors. This was an inline copy of
-    // the check, which is how validate and every other verb came to disagree
-    // about whether the same file was valid. `parse_and_validate` now denies,
-    // so validate inherits the rule instead of reimplementing it — and loading
-    // here, BEFORE dispatch, covers every sub-check rather than only the ones
-    // that happen to load the config themselves. `--check-recipe-purity` reads
-    // raw YAML by design (purity keys are not typed fields) and so consulted
-    // no validation at all; it was the inline copy that had been masking that.
     let _ = deny_unknown_fields; // always true for validate
-                                 // EMIT JSON ON THE FAILURE PATH TOO.
-                                 //
-                                 // This was a bare `parse_and_validate(&file)?;` — the result discarded,
-                                 // the call kept only for its failure side effect — so it returned here,
-                                 // long before any sub-command could honour `--json`. `validate --json` on
-                                 // an invalid config therefore printed ZERO bytes to stdout and a
-                                 // plain-text error to stderr: the one case a machine consumer needs the
-                                 // structured errors, since a conforming config tells it nothing it did not
-                                 // already assume. Ledger id validate-json-emits-non-json-on-failure,
-                                 // confirmed at 1.12.3 and still live at 1.16.0.
-                                 //
-                                 // The exit code and the human-facing stderr are deliberately unchanged.
-    if let Err(e) = crate::core::parser::parse_and_validate(&file) {
-        if json {
-            println!(
-                "{}",
-                crate::cli::validate_core::validation_failure_json(&file, std::slice::from_ref(&e))
-            );
-        }
-        return Err(e);
-    }
+    validate_preflight(&file, json, _schema_version.is_some())?;
 
     // FJ-2503: --deep runs all deep checks in a single aggregated pass
     if deep {
         return cmd_validate_deep(&file, json);
     }
 
-    if let Some(r) = try_validate_store(
+    // Sub-check groups in flag-priority order. `or_else` keeps the
+    // first-selected-wins behaviour of the `if let Some(r) = .. { return r }`
+    // chain this replaced, and no group past the selected one is evaluated.
+    // With nothing selected, plain `validate` runs.
+    try_validate_store(
         &file,
         json,
         check_recipe_purity,
@@ -276,214 +289,212 @@ pub(crate) fn dispatch_validate(args: ValidateArgs) -> Result<(), String> {
             check_duplicate_names,
             check_resource_groups,
         )
-    }) {
-        return r;
-    }
-    if let Some(r) = try_validate_governance(
-        &file,
-        json,
-        &check_resource_naming_pattern,
-        check_resource_provider_support,
-        check_resource_secret_refs,
-        check_resource_idempotency_hints,
-        check_resource_dependency_depth,
-        check_resource_machine_affinity,
-        check_resource_drift_risk,
-        check_resource_tag_coverage,
-    ) {
-        return r;
-    }
-    if let Some(r) = try_validate_governance_c(
-        &file,
-        json,
-        check_resource_dependency_completeness,
-        check_resource_state_coverage,
-        check_resource_rollback_safety,
-        check_resource_config_maturity,
-        check_resource_dependency_ordering,
-        check_resource_tag_completeness,
-        check_resource_naming_standards,
-        check_resource_dependency_symmetry,
-        check_resource_circular_alias,
-        check_resource_dependency_depth_limit,
-        check_resource_unused_params,
-        check_resource_machine_balance,
-    )
+    })
     .or_else(|| {
-        try_validate_governance_d(
+        try_validate_governance(
             &file,
             json,
-            check_resource_content_hash_consistency,
-            check_resource_dependency_refs,
-            check_resource_trigger_refs,
-            check_resource_param_type_safety,
-            check_resource_env_consistency,
-            check_resource_secret_rotation,
-            check_resource_lifecycle_completeness,
-            check_resource_provider_compatibility,
-            check_resource_naming_convention_strict,
-            check_resource_idempotency_annotations,
-            check_resource_content_size_limit,
-            check_resource_dependency_fan_limit,
-        )
-    }) {
-        return r;
-    }
-    if let Some(r) = try_validate_phases_94_96(
-        &file,
-        json,
-        check_resource_gpu_backend_consistency,
-        check_resource_when_condition_syntax,
-        check_resource_lifecycle_hook_coverage,
-        check_resource_secret_rotation_age,
-        check_resource_dependency_chain_depth,
-        check_recipe_input_completeness,
-        check_resource_cross_machine_content_duplicates,
-        check_resource_machine_reference_validity,
-    ) {
-        return r;
-    }
-    if let Some(r) = try_validate_phases_97_100(
-        &file,
-        json,
-        check_resource_health_correlation,
-        check_dependency_optimization,
-        check_resource_consolidation_opportunities,
-        check_resource_compliance_tags,
-        check_resource_rollback_coverage,
-        check_resource_dependency_balance,
-        check_resource_secret_scope,
-        check_resource_deprecation_usage,
-        check_resource_when_condition_coverage,
-        check_resource_dependency_symmetry_deep,
-        check_resource_tag_namespace,
-        check_resource_machine_capacity,
-    ) {
-        return r;
-    }
-    if let Some(r) = try_validate_phases_101_103(
-        &file,
-        json,
-        check_resource_dependency_fan_out_limit,
-        check_resource_tag_required_keys,
-        check_resource_content_drift_risk,
-        check_resource_circular_dependency_depth,
-        check_resource_orphan_detection_deep,
-        check_resource_provider_diversity,
-        check_resource_dependency_isolation,
-        check_resource_tag_value_consistency,
-        check_resource_machine_distribution_balance,
-    )
-    .or_else(|| {
-        try_validate_phases_104_106(
-            &file,
-            json,
-            check_resource_dependency_version_drift,
-            check_resource_naming_length_limit,
-            check_resource_type_coverage_per_machine,
-            check_resource_dependency_depth_variance,
-            check_resource_tag_key_naming,
-            check_resource_content_length_limit,
-            check_resource_dependency_completeness_audit,
-            check_resource_machine_coverage_gap,
-            check_resource_path_depth_limit,
+            &check_resource_naming_pattern,
+            check_resource_provider_support,
+            check_resource_secret_refs,
+            check_resource_idempotency_hints,
+            check_resource_dependency_depth,
+            check_resource_machine_affinity,
+            check_resource_drift_risk,
+            check_resource_tag_coverage,
         )
     })
     .or_else(|| {
-        try_validate_phase107(
+        try_validate_governance_c(
             &file,
             json,
-            check_resource_dependency_ordering_consistency,
-            check_resource_tag_value_format,
-            check_resource_provider_version_pinning,
+            check_resource_dependency_completeness,
+            check_resource_state_coverage,
+            check_resource_rollback_safety,
+            check_resource_config_maturity,
+            check_resource_dependency_ordering,
+            check_resource_tag_completeness,
+            check_resource_naming_standards,
+            check_resource_dependency_symmetry,
+            check_resource_circular_alias,
+            check_resource_dependency_depth_limit,
+            check_resource_unused_params,
+            check_resource_machine_balance,
         )
-    }) {
-        return r;
-    }
-    if let Some(r) = try_validate_governance_b(
-        &file,
-        json,
-        check_resource_lifecycle_hooks,
-        check_resource_provider_version,
-        check_resource_naming_convention,
-        check_resource_idempotency,
-        check_resource_documentation,
-        check_resource_ownership,
-        check_resource_secret_exposure,
-        check_resource_tag_standards,
-        check_resource_privilege_escalation,
-        check_resource_update_safety,
-        check_resource_cross_machine_consistency,
-        check_resource_version_pinning,
-    )
+        .or_else(|| {
+            try_validate_governance_d(
+                &file,
+                json,
+                check_resource_content_hash_consistency,
+                check_resource_dependency_refs,
+                check_resource_trigger_refs,
+                check_resource_param_type_safety,
+                check_resource_env_consistency,
+                check_resource_secret_rotation,
+                check_resource_lifecycle_completeness,
+                check_resource_provider_compatibility,
+                check_resource_naming_convention_strict,
+                check_resource_idempotency_annotations,
+                check_resource_content_size_limit,
+                check_resource_dependency_fan_limit,
+            )
+        })
+    })
     .or_else(|| {
-        try_validate_advanced(
+        try_validate_phases_94_96(
             &file,
             json,
-            check_orphan_resources,
-            check_machine_arch,
-            check_resource_health_conflicts,
-            check_resource_overlap,
-            check_resource_tags,
-            check_resource_state_consistency,
-            check_resource_dependencies_complete,
-            check_machine_connectivity,
+            check_resource_gpu_backend_consistency,
+            check_resource_when_condition_syntax,
+            check_resource_lifecycle_hook_coverage,
+            check_resource_secret_rotation_age,
+            check_resource_dependency_chain_depth,
+            check_recipe_input_completeness,
+            check_resource_cross_machine_content_duplicates,
+            check_resource_machine_reference_validity,
         )
     })
     .or_else(|| {
-        try_validate_structural(
+        try_validate_phases_97_100(
             &file,
             json,
-            check_mount_points,
-            check_group_consistency,
-            check_mode_consistency,
-            check_template_vars,
-            check_service_deps,
-            check_path_conflicts,
-            check_owner_consistency,
-            check_naming_conventions,
-            check_circular_refs,
-            check_machine_reachability,
+            check_resource_health_correlation,
+            check_dependency_optimization,
+            check_resource_consolidation_opportunities,
+            check_resource_compliance_tags,
+            check_resource_rollback_coverage,
+            check_resource_dependency_balance,
+            check_resource_secret_scope,
+            check_resource_deprecation_usage,
+            check_resource_when_condition_coverage,
+            check_resource_dependency_symmetry_deep,
+            check_resource_tag_namespace,
+            check_resource_machine_capacity,
         )
-    }) {
-        return r;
-    }
-    if let Some(r) = try_validate_quality(
-        &file,
-        json,
-        check_idempotency_deep,
-        check_permissions,
-        check_dependencies,
-        check_unused,
-        check_resource_limits,
-        check_portability,
-        check_compliance.as_deref(),
-        check_drift_risk,
-        check_deprecation,
-        check_security,
-        check_complexity,
-        check_limits,
-    ) {
-        return r;
-    }
-    if let Some(r) = try_validate_core(
-        &file,
-        json,
-        strict,
-        dry_expand,
-        check_overlaps,
-        check_naming,
-        check_cycles_deep,
-        check_drift_coverage,
-        check_idempotency,
-        check_secrets,
-        strict_deps,
-        check_templates,
-        check_connectivity,
-        policy_file.as_deref(),
-        exhaustive,
-    ) {
-        return r;
-    }
-    cmd_validate(&file, strict, json, dry_expand)
+    })
+    .or_else(|| {
+        try_validate_phases_101_103(
+            &file,
+            json,
+            check_resource_dependency_fan_out_limit,
+            check_resource_tag_required_keys,
+            check_resource_content_drift_risk,
+            check_resource_circular_dependency_depth,
+            check_resource_orphan_detection_deep,
+            check_resource_provider_diversity,
+            check_resource_dependency_isolation,
+            check_resource_tag_value_consistency,
+            check_resource_machine_distribution_balance,
+        )
+        .or_else(|| {
+            try_validate_phases_104_106(
+                &file,
+                json,
+                check_resource_dependency_version_drift,
+                check_resource_naming_length_limit,
+                check_resource_type_coverage_per_machine,
+                check_resource_dependency_depth_variance,
+                check_resource_tag_key_naming,
+                check_resource_content_length_limit,
+                check_resource_dependency_completeness_audit,
+                check_resource_machine_coverage_gap,
+                check_resource_path_depth_limit,
+            )
+        })
+        .or_else(|| {
+            try_validate_phase107(
+                &file,
+                json,
+                check_resource_dependency_ordering_consistency,
+                check_resource_tag_value_format,
+                check_resource_provider_version_pinning,
+            )
+        })
+    })
+    .or_else(|| {
+        try_validate_governance_b(
+            &file,
+            json,
+            check_resource_lifecycle_hooks,
+            check_resource_provider_version,
+            check_resource_naming_convention,
+            check_resource_idempotency,
+            check_resource_documentation,
+            check_resource_ownership,
+            check_resource_secret_exposure,
+            check_resource_tag_standards,
+            check_resource_privilege_escalation,
+            check_resource_update_safety,
+            check_resource_cross_machine_consistency,
+            check_resource_version_pinning,
+        )
+        .or_else(|| {
+            try_validate_advanced(
+                &file,
+                json,
+                check_orphan_resources,
+                check_machine_arch,
+                check_resource_health_conflicts,
+                check_resource_overlap,
+                check_resource_tags,
+                check_resource_state_consistency,
+                check_resource_dependencies_complete,
+                check_machine_connectivity,
+            )
+        })
+        .or_else(|| {
+            try_validate_structural(
+                &file,
+                json,
+                check_mount_points,
+                check_group_consistency,
+                check_mode_consistency,
+                check_template_vars,
+                check_service_deps,
+                check_path_conflicts,
+                check_owner_consistency,
+                check_naming_conventions,
+                check_circular_refs,
+                check_machine_reachability,
+            )
+        })
+    })
+    .or_else(|| {
+        try_validate_quality(
+            &file,
+            json,
+            check_idempotency_deep,
+            check_permissions,
+            check_dependencies,
+            check_unused,
+            check_resource_limits,
+            check_portability,
+            check_compliance.as_deref(),
+            check_drift_risk,
+            check_deprecation,
+            check_security,
+            check_complexity,
+            check_limits,
+        )
+    })
+    .or_else(|| {
+        try_validate_core(
+            &file,
+            json,
+            strict,
+            dry_expand,
+            check_overlaps,
+            check_naming,
+            check_cycles_deep,
+            check_drift_coverage,
+            check_idempotency,
+            check_secrets,
+            strict_deps,
+            check_templates,
+            check_connectivity,
+            policy_file.as_deref(),
+            exhaustive,
+        )
+    })
+    .unwrap_or_else(|| cmd_validate(&file, strict, json, dry_expand))
 }

--- a/src/cli/dispatch_validate_c.rs
+++ b/src/cli/dispatch_validate_c.rs
@@ -17,6 +17,25 @@ use super::validate_topology::*;
 use super::validate_transport::*;
 use std::path::Path;
 
+/// One `validate --check-*` check. Every flag-selected check has the same
+/// shape: it re-reads the config file and reports its own findings, honouring
+/// `--json`.
+type ValidateCheck = fn(&Path, bool) -> Result<(), String>;
+
+/// Run the first check whose flag is set, in table order, and return its
+/// result; `None` when none of the flags in the table is set. Table order is
+/// the precedence order, and only the selected check is called.
+fn first_enabled_check(
+    file: &Path,
+    json: bool,
+    checks: &[(bool, ValidateCheck)],
+) -> Option<Result<(), String>> {
+    checks
+        .iter()
+        .find(|(enabled, _)| *enabled)
+        .map(|(_, check)| check(file, json))
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(super) fn try_validate_phases_94_96(
     file: &Path,
@@ -157,49 +176,24 @@ pub(super) fn try_validate_phases_97_100(
     d2: bool,
     d3: bool,
 ) -> Option<Result<(), String>> {
-    if a1 {
-        return Some(cmd_validate_check_resource_health_correlation(file, json));
-    }
-    if a2 {
-        return Some(cmd_validate_check_dependency_optimization(file, json));
-    }
-    if a3 {
-        return Some(cmd_validate_check_resource_consolidation_opportunities(
-            file, json,
-        ));
-    }
-    if b1 {
-        return Some(cmd_validate_check_resource_compliance_tags(file, json));
-    }
-    if b2 {
-        return Some(cmd_validate_check_resource_rollback_coverage(file, json));
-    }
-    if b3 {
-        return Some(cmd_validate_check_resource_dependency_balance(file, json));
-    }
-    if c1 {
-        return Some(cmd_validate_check_resource_secret_scope(file, json));
-    }
-    if c2 {
-        return Some(cmd_validate_check_resource_deprecation_usage(file, json));
-    }
-    if c3 {
-        return Some(cmd_validate_check_resource_when_condition_coverage(
-            file, json,
-        ));
-    }
-    if d1 {
-        return Some(cmd_validate_check_resource_dependency_symmetry_deep(
-            file, json,
-        ));
-    }
-    if d2 {
-        return Some(cmd_validate_check_resource_tag_namespace(file, json));
-    }
-    if d3 {
-        return Some(cmd_validate_check_resource_machine_capacity(file, json));
-    }
-    None
+    first_enabled_check(
+        file,
+        json,
+        &[
+            (a1, cmd_validate_check_resource_health_correlation),
+            (a2, cmd_validate_check_dependency_optimization),
+            (a3, cmd_validate_check_resource_consolidation_opportunities),
+            (b1, cmd_validate_check_resource_compliance_tags),
+            (b2, cmd_validate_check_resource_rollback_coverage),
+            (b3, cmd_validate_check_resource_dependency_balance),
+            (c1, cmd_validate_check_resource_secret_scope),
+            (c2, cmd_validate_check_resource_deprecation_usage),
+            (c3, cmd_validate_check_resource_when_condition_coverage),
+            (d1, cmd_validate_check_resource_dependency_symmetry_deep),
+            (d2, cmd_validate_check_resource_tag_namespace),
+            (d3, cmd_validate_check_resource_machine_capacity),
+        ],
+    )
 }
 #[allow(clippy::too_many_arguments)]
 pub(super) fn try_validate_phases_101_103(
@@ -215,44 +209,21 @@ pub(super) fn try_validate_phases_101_103(
     g2: bool,
     g3: bool,
 ) -> Option<Result<(), String>> {
-    if e1 {
-        return Some(cmd_validate_check_resource_dependency_fan_out_limit(
-            file, json,
-        ));
-    }
-    if e2 {
-        return Some(cmd_validate_check_resource_tag_required_keys(file, json));
-    }
-    if e3 {
-        return Some(cmd_validate_check_resource_content_drift_risk(file, json));
-    }
-    if f1 {
-        return Some(cmd_validate_check_resource_circular_dependency_depth(
-            file, json,
-        ));
-    }
-    if f2 {
-        return Some(cmd_validate_check_resource_orphan_detection_deep(
-            file, json,
-        ));
-    }
-    if f3 {
-        return Some(cmd_validate_check_resource_provider_diversity(file, json));
-    }
-    if g1 {
-        return Some(cmd_validate_check_resource_dependency_isolation(file, json));
-    }
-    if g2 {
-        return Some(cmd_validate_check_resource_tag_value_consistency(
-            file, json,
-        ));
-    }
-    if g3 {
-        return Some(cmd_validate_check_resource_machine_distribution_balance(
-            file, json,
-        ));
-    }
-    None
+    first_enabled_check(
+        file,
+        json,
+        &[
+            (e1, cmd_validate_check_resource_dependency_fan_out_limit),
+            (e2, cmd_validate_check_resource_tag_required_keys),
+            (e3, cmd_validate_check_resource_content_drift_risk),
+            (f1, cmd_validate_check_resource_circular_dependency_depth),
+            (f2, cmd_validate_check_resource_orphan_detection_deep),
+            (f3, cmd_validate_check_resource_provider_diversity),
+            (g1, cmd_validate_check_resource_dependency_isolation),
+            (g2, cmd_validate_check_resource_tag_value_consistency),
+            (g3, cmd_validate_check_resource_machine_distribution_balance),
+        ],
+    )
 }
 #[allow(clippy::too_many_arguments)]
 pub(super) fn try_validate_phases_104_106(
@@ -268,42 +239,24 @@ pub(super) fn try_validate_phases_104_106(
     j2: bool,
     j3: bool,
 ) -> Option<Result<(), String>> {
-    if h1 {
-        return Some(cmd_validate_check_resource_dependency_version_drift(
-            file, json,
-        ));
-    }
-    if h2 {
-        return Some(cmd_validate_check_resource_naming_length_limit(file, json));
-    }
-    if h3 {
-        return Some(cmd_validate_check_resource_type_coverage_per_machine(
-            file, json,
-        ));
-    }
-    if i1 {
-        return Some(cmd_validate_check_resource_dependency_depth_variance(
-            file, json,
-        ));
-    }
-    if i2 {
-        return Some(cmd_validate_check_resource_tag_key_naming(file, json));
-    }
-    if i3 {
-        return Some(cmd_validate_check_resource_content_length_limit(file, json));
-    }
-    if j1 {
-        return Some(cmd_validate_check_resource_dependency_completeness_audit(
-            file, json,
-        ));
-    }
-    if j2 {
-        return Some(cmd_validate_check_resource_machine_coverage_gap(file, json));
-    }
-    if j3 {
-        return Some(cmd_validate_check_resource_path_depth_limit(file, json));
-    }
-    None
+    first_enabled_check(
+        file,
+        json,
+        &[
+            (h1, cmd_validate_check_resource_dependency_version_drift),
+            (h2, cmd_validate_check_resource_naming_length_limit),
+            (h3, cmd_validate_check_resource_type_coverage_per_machine),
+            (i1, cmd_validate_check_resource_dependency_depth_variance),
+            (i2, cmd_validate_check_resource_tag_key_naming),
+            (i3, cmd_validate_check_resource_content_length_limit),
+            (
+                j1,
+                cmd_validate_check_resource_dependency_completeness_audit,
+            ),
+            (j2, cmd_validate_check_resource_machine_coverage_gap),
+            (j3, cmd_validate_check_resource_path_depth_limit),
+        ],
+    )
 }
 pub(super) fn try_validate_phase107(
     file: &Path,

--- a/src/cli/drift.rs
+++ b/src/cli/drift.rs
@@ -242,23 +242,35 @@ fn scan_machines_for_drift(
 }
 
 /// Collect (machine_name, lock) pairs from state directory.
-fn collect_machine_locks(
+/// Machine directory names under `state_dir`, in read order, honouring an
+/// optional single-machine filter. Unreadable entries and non-directories are
+/// skipped; whether an empty result is an error is left to the caller.
+fn machine_state_dirs(
     state_dir: &Path,
     machine_filter: Option<&str>,
-) -> Result<Vec<(String, types::StateLock)>, String> {
+) -> Result<Vec<String>, String> {
     let entries = std::fs::read_dir(state_dir)
         .map_err(|e| format!("cannot read state dir {}: {}", state_dir.display(), e))?;
-    let mut locks = Vec::new();
+    let mut names = Vec::new();
     for entry in entries.flatten() {
         let name = entry.file_name().to_string_lossy().to_string();
-        if let Some(filter) = machine_filter {
-            if name != filter {
-                continue;
-            }
+        if machine_filter.is_some_and(|filter| name != filter) {
+            continue;
         }
         if !entry.path().is_dir() {
             continue;
         }
+        names.push(name);
+    }
+    Ok(names)
+}
+
+fn collect_machine_locks(
+    state_dir: &Path,
+    machine_filter: Option<&str>,
+) -> Result<Vec<(String, types::StateLock)>, String> {
+    let mut locks = Vec::new();
+    for name in machine_state_dirs(state_dir, machine_filter)? {
         if let Some(lock) = state::load_lock(state_dir, &name)? {
             locks.push((name, lock));
         }
@@ -377,48 +389,39 @@ pub(crate) fn cmd_drift(
     Ok(())
 }
 
-/// Dry-run mode for drift: lists resources that would be checked without connecting.
-pub(crate) fn cmd_drift_dry_run(
-    state_dir: &Path,
-    machine_filter: Option<&str>,
+/// Records what a drift check would inspect on one machine: in JSON mode each
+/// resource is appended to `checks`, otherwise the machine and its resources are
+/// printed. Returns the number of resources accounted for.
+fn record_dry_run_checks(
+    name: &str,
+    lock: &types::StateLock,
     json: bool,
-) -> Result<(), String> {
-    let entries = std::fs::read_dir(state_dir)
-        .map_err(|e| format!("cannot read state dir {}: {}", state_dir.display(), e))?;
-
-    let mut checks: Vec<serde_json::Value> = Vec::new();
-    let mut total = 0usize;
-
-    for entry in entries.flatten() {
-        let name = entry.file_name().to_string_lossy().to_string();
-        if let Some(filter) = machine_filter {
-            if name != filter {
-                continue;
-            }
-        }
-        if !entry.path().is_dir() {
-            continue;
-        }
-        if let Some(lock) = state::load_lock(state_dir, &name)? {
-            if !json {
-                println!("Machine: {} ({} resources)", name, lock.resources.len());
-            }
-            for (res_id, res_state) in &lock.resources {
-                total += 1;
-                if json {
-                    checks.push(serde_json::json!({
-                        "machine": name,
-                        "resource": res_id,
-                        "status": res_state.status,
-                        "hash": res_state.hash,
-                    }));
-                } else {
-                    println!("  would check: {} (status: {})", res_id, res_state.status);
-                }
-            }
+    checks: &mut Vec<serde_json::Value>,
+) -> usize {
+    if !json {
+        println!("Machine: {} ({} resources)", name, lock.resources.len());
+    }
+    for (res_id, res_state) in &lock.resources {
+        if json {
+            checks.push(serde_json::json!({
+                "machine": name,
+                "resource": res_id,
+                "status": res_state.status,
+                "hash": res_state.hash,
+            }));
+        } else {
+            println!("  would check: {} (status: {})", res_id, res_state.status);
         }
     }
+    lock.resources.len()
+}
 
+/// Emits the dry-run result: a JSON report, or a human-readable total.
+fn print_dry_run_report(
+    json: bool,
+    total: usize,
+    checks: &[serde_json::Value],
+) -> Result<(), String> {
     if json {
         let report = serde_json::json!({
             "dry_run": true,
@@ -432,6 +435,23 @@ pub(crate) fn cmd_drift_dry_run(
         println!();
         println!("Dry run: {total} resource(s) would be checked");
     }
-
     Ok(())
+}
+
+/// Dry-run mode for drift: lists resources that would be checked without connecting.
+pub(crate) fn cmd_drift_dry_run(
+    state_dir: &Path,
+    machine_filter: Option<&str>,
+    json: bool,
+) -> Result<(), String> {
+    let mut checks: Vec<serde_json::Value> = Vec::new();
+    let mut total = 0usize;
+
+    for name in machine_state_dirs(state_dir, machine_filter)? {
+        if let Some(lock) = state::load_lock(state_dir, &name)? {
+            total += record_dry_run_checks(&name, &lock, json, &mut checks);
+        }
+    }
+
+    print_dry_run_report(json, total, &checks)
 }

--- a/src/cli/fleet_reporting.rs
+++ b/src/cli/fleet_reporting.rs
@@ -5,24 +5,36 @@ use crate::core::{resolver, state, types};
 use crate::tripwire::eventlog;
 use std::path::Path;
 
-/// FJ-341: Audit trail — who applied what, when, from which config.
-pub(crate) fn cmd_audit(
+/// One audit event together with the machine whose log it came from.
+type MachineEvent = (String, types::TimestampedEvent);
+
+/// Parses one machine's JSONL event log, skipping blank lines and any line that
+/// does not deserialise — a truncated final write must not lose the whole log.
+fn append_logged_events(machine: &str, content: &str, out: &mut Vec<MachineEvent>) {
+    for line in content.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        if let Ok(event) = serde_json::from_str::<types::TimestampedEvent>(line) {
+            out.push((machine.to_string(), event));
+        }
+    }
+}
+
+/// Reads the event log of every machine under `state_dir` — or of just the one
+/// named by `machine_filter` — and returns every event tagged with its machine.
+fn collect_audit_events(
     state_dir: &Path,
     machine_filter: Option<&str>,
-    limit: usize,
-    json: bool,
-) -> Result<(), String> {
+) -> Result<Vec<MachineEvent>, String> {
     let entries = std::fs::read_dir(state_dir)
         .map_err(|e| format!("cannot read state dir {}: {}", state_dir.display(), e))?;
 
-    let mut all_events: Vec<(String, types::TimestampedEvent)> = Vec::new();
-
+    let mut all_events: Vec<MachineEvent> = Vec::new();
     for entry in entries.flatten() {
         let name = entry.file_name().to_string_lossy().to_string();
-        if let Some(filter) = machine_filter {
-            if name != filter {
-                continue;
-            }
+        if machine_filter.is_some_and(|filter| name != filter) {
+            continue;
         }
         if !entry.path().is_dir() {
             continue;
@@ -35,63 +47,75 @@ pub(crate) fn cmd_audit(
 
         let content = std::fs::read_to_string(&log_path)
             .map_err(|e| format!("cannot read {}: {}", log_path.display(), e))?;
-
-        for line in content.lines() {
-            if line.trim().is_empty() {
-                continue;
-            }
-            if let Ok(event) = serde_json::from_str::<types::TimestampedEvent>(line) {
-                all_events.push((name.clone(), event));
-            }
-        }
+        append_logged_events(&name, &content, &mut all_events);
     }
+    Ok(all_events)
+}
 
-    // Sort by timestamp descending
+/// The `--json` rendering: one object per event, machine-readable.
+fn print_audit_json(all_events: &[MachineEvent]) -> Result<(), String> {
+    let json_events: Vec<serde_json::Value> = all_events
+        .iter()
+        .map(|(machine, ev)| {
+            // SERIALISE THE EVENT, DO NOT Debug-PRINT IT.
+            //
+            // This was `format!("{:?}", ev.event)`, which stuffed Rust
+            // Debug syntax into a JSON *string*:
+            //   "event": "ApplyStarted { machine: \"local\", run_id: ..."
+            // so run_id, operator, config_hash, resource, action and
+            // duration were unreadable without re-parsing Debug out of a
+            // string — in a document that exists to be machine-read.
+            // ApplyEvent already derives Serialize (history --json emits it
+            // structured), so nothing was blocking this. Ledger id
+            // debug-formatting-leaks-into-output-and-json, confirmed at
+            // 1.12.3 and still live at 1.16.0.
+            serde_json::json!({
+                "machine": machine,
+                "timestamp": ev.ts,
+                "event": ev.event,
+            })
+        })
+        .collect();
+    println!(
+        "{}",
+        // NOT unwrap_or_default(): that prints an EMPTY STRING on a
+        // serialisation failure, which a consumer reads as "no events"
+        // rather than "this did not work".
+        serde_json::to_string_pretty(&json_events)
+            .map_err(|e| format!("cannot serialise audit events: {e}"))?
+    );
+    Ok(())
+}
+
+/// The human rendering: newest first, one line per event.
+fn print_audit_text(all_events: &[MachineEvent], limit: usize) {
+    if all_events.is_empty() {
+        println!("No audit events found.");
+        return;
+    }
+    println!("Audit trail (last {limit} events):\n");
+    for (machine, ev) in all_events {
+        println!("  {} [{}] {:?}", ev.ts, machine, ev.event);
+    }
+}
+
+/// FJ-341: Audit trail — who applied what, when, from which config.
+pub(crate) fn cmd_audit(
+    state_dir: &Path,
+    machine_filter: Option<&str>,
+    limit: usize,
+    json: bool,
+) -> Result<(), String> {
+    let mut all_events = collect_audit_events(state_dir, machine_filter)?;
+
+    // Newest first, then keep only the requested window.
     all_events.sort_by(|a, b| b.1.ts.cmp(&a.1.ts));
     all_events.truncate(limit);
 
     if json {
-        let json_events: Vec<serde_json::Value> = all_events
-            .iter()
-            .map(|(machine, ev)| {
-                // SERIALISE THE EVENT, DO NOT Debug-PRINT IT.
-                //
-                // This was `format!("{:?}", ev.event)`, which stuffed Rust
-                // Debug syntax into a JSON *string*:
-                //   "event": "ApplyStarted { machine: \"local\", run_id: ..."
-                // so run_id, operator, config_hash, resource, action and
-                // duration were unreadable without re-parsing Debug out of a
-                // string — in a document that exists to be machine-read.
-                // ApplyEvent already derives Serialize (history --json emits it
-                // structured), so nothing was blocking this. Ledger id
-                // debug-formatting-leaks-into-output-and-json, confirmed at
-                // 1.12.3 and still live at 1.16.0.
-                serde_json::json!({
-                    "machine": machine,
-                    "timestamp": ev.ts,
-                    "event": ev.event,
-                })
-            })
-            .collect();
-        println!(
-            "{}",
-            // NOT unwrap_or_default(): that prints an EMPTY STRING on a
-            // serialisation failure, which a consumer reads as "no events"
-            // rather than "this did not work".
-            serde_json::to_string_pretty(&json_events)
-                .map_err(|e| format!("cannot serialise audit events: {e}"))?
-        );
-    } else {
-        if all_events.is_empty() {
-            println!("No audit events found.");
-            return Ok(());
-        }
-        println!("Audit trail (last {limit} events):\n");
-        for (machine, ev) in &all_events {
-            println!("  {} [{}] {:?}", ev.ts, machine, ev.event);
-        }
+        return print_audit_json(&all_events);
     }
-
+    print_audit_text(&all_events, limit);
     Ok(())
 }
 

--- a/src/cli/graph_intelligence_ext.rs
+++ b/src/cli/graph_intelligence_ext.rs
@@ -314,94 +314,101 @@ pub(crate) fn cmd_graph_resource_dependency_strongly_connected(
     Ok(())
 }
 
+/// Bookkeeping that Tarjan's SCC algorithm threads through its recursion:
+/// per-node discovery index and lowlink, the "currently on the stack" flags,
+/// and the components closed so far. Nodes are addressed by their position in
+/// `names`; `idx_map` maps a resource name back to that position.
+struct TarjanState<'a> {
+    names: &'a [String],
+    idx_map: std::collections::HashMap<&'a str, usize>,
+    index_counter: usize,
+    stack: Vec<usize>,
+    on_stack: Vec<bool>,
+    indices: Vec<usize>,
+    lowlinks: Vec<usize>,
+    result: Vec<Vec<String>>,
+}
+
+impl<'a> TarjanState<'a> {
+    fn new(names: &'a [String]) -> Self {
+        let n = names.len();
+        Self {
+            names,
+            idx_map: names
+                .iter()
+                .enumerate()
+                .map(|(i, name)| (name.as_str(), i))
+                .collect(),
+            index_counter: 0,
+            stack: Vec::new(),
+            on_stack: vec![false; n],
+            indices: vec![usize::MAX; n],
+            lowlinks: vec![0usize; n],
+            result: Vec::new(),
+        }
+    }
+
+    /// Give `v` the next discovery index and put it on the SCC stack.
+    fn discover(&mut self, v: usize) {
+        self.indices[v] = self.index_counter;
+        self.lowlinks[v] = self.index_counter;
+        self.index_counter += 1;
+        self.stack.push(v);
+        self.on_stack[v] = true;
+    }
+
+    /// Walk `v`'s dependencies, recursing into ones not yet discovered, and
+    /// relax `v`'s lowlink against every neighbour still on the stack.
+    fn relax_dependencies(&mut self, v: usize, config: &types::ForjarConfig) {
+        let names = self.names;
+        let Some(res) = config.resources.get(&names[v]) else {
+            return;
+        };
+        for dep in &res.depends_on {
+            let Some(w) = self.idx_map.get(dep.as_str()).copied() else {
+                continue;
+            };
+            if self.indices[w] == usize::MAX {
+                self.strongconnect(w, config);
+                self.lowlinks[v] = self.lowlinks[v].min(self.lowlinks[w]);
+            } else if self.on_stack[w] {
+                self.lowlinks[v] = self.lowlinks[v].min(self.indices[w]);
+            }
+        }
+    }
+
+    /// `v` is an SCC root: pop everything above it off the stack as one
+    /// component, recorded in sorted order.
+    fn close_component_at(&mut self, v: usize) {
+        let mut component = Vec::new();
+        while let Some(w) = self.stack.pop() {
+            self.on_stack[w] = false;
+            component.push(self.names[w].clone());
+            if w == v {
+                break;
+            }
+        }
+        component.sort();
+        self.result.push(component);
+    }
+
+    fn strongconnect(&mut self, v: usize, config: &types::ForjarConfig) {
+        self.discover(v);
+        self.relax_dependencies(v, config);
+        if self.lowlinks[v] == self.indices[v] {
+            self.close_component_at(v);
+        }
+    }
+}
+
 pub(super) fn tarjan_scc(config: &types::ForjarConfig, names: &[String]) -> Vec<Vec<String>> {
-    let n = names.len();
-    let idx_map: std::collections::HashMap<&str, usize> = names
-        .iter()
-        .enumerate()
-        .map(|(i, n)| (n.as_str(), i))
-        .collect();
-    let mut index_counter = 0usize;
-    let mut stack = Vec::new();
-    let mut on_stack = vec![false; n];
-    let mut indices = vec![usize::MAX; n];
-    let mut lowlinks = vec![0usize; n];
-    let mut result = Vec::new();
-
-    #[allow(clippy::too_many_arguments)]
-    fn strongconnect(
-        v: usize,
-        config: &types::ForjarConfig,
-        names: &[String],
-        idx_map: &std::collections::HashMap<&str, usize>,
-        index_counter: &mut usize,
-        stack: &mut Vec<usize>,
-        on_stack: &mut [bool],
-        indices: &mut [usize],
-        lowlinks: &mut [usize],
-        result: &mut Vec<Vec<String>>,
-    ) {
-        indices[v] = *index_counter;
-        lowlinks[v] = *index_counter;
-        *index_counter += 1;
-        stack.push(v);
-        on_stack[v] = true;
-
-        if let Some(res) = config.resources.get(&names[v]) {
-            for dep in &res.depends_on {
-                if let Some(&w) = idx_map.get(dep.as_str()) {
-                    if indices[w] == usize::MAX {
-                        strongconnect(
-                            w,
-                            config,
-                            names,
-                            idx_map,
-                            index_counter,
-                            stack,
-                            on_stack,
-                            indices,
-                            lowlinks,
-                            result,
-                        );
-                        lowlinks[v] = lowlinks[v].min(lowlinks[w]);
-                    } else if on_stack[w] {
-                        lowlinks[v] = lowlinks[v].min(indices[w]);
-                    }
-                }
-            }
-        }
-
-        if lowlinks[v] == indices[v] {
-            let mut component = Vec::new();
-            while let Some(w) = stack.pop() {
-                on_stack[w] = false;
-                component.push(names[w].clone());
-                if w == v {
-                    break;
-                }
-            }
-            component.sort();
-            result.push(component);
+    let mut state = TarjanState::new(names);
+    for v in 0..names.len() {
+        if state.indices[v] == usize::MAX {
+            state.strongconnect(v, config);
         }
     }
-
-    for i in 0..n {
-        if indices[i] == usize::MAX {
-            strongconnect(
-                i,
-                config,
-                names,
-                &idx_map,
-                &mut index_counter,
-                &mut stack,
-                &mut on_stack,
-                &mut indices,
-                &mut lowlinks,
-                &mut result,
-            );
-        }
-    }
-    result
+    state.result
 }
 
 pub(super) use super::graph_intelligence_ext_b::*;

--- a/src/cli/graph_intelligence_ext2_b.rs
+++ b/src/cli/graph_intelligence_ext2_b.rs
@@ -201,6 +201,27 @@ pub(crate) fn cmd_graph_resource_dependency_bridge_criticality(
     print_bridge_criticality(&bridges, json);
     Ok(())
 }
+/// Nodes reachable from `start` over the adjacency matrix, `start` included.
+/// Depth-first, so a dense matrix costs O(n^2) per call.
+fn count_reachable_from(adj: &[Vec<bool>], start: usize, n: usize) -> usize {
+    let mut visited = vec![false; n];
+    let mut stack = vec![start];
+    let mut reached = 0;
+    while let Some(node) = stack.pop() {
+        if visited[node] {
+            continue;
+        }
+        visited[node] = true;
+        reached += 1;
+        for (k, visited_k) in visited.iter().enumerate().take(n) {
+            if adj[node][k] && !visited_k {
+                stack.push(k);
+            }
+        }
+    }
+    reached
+}
+
 fn find_bridge_criticality(
     names: &[&str],
     adj: &[Vec<bool>],
@@ -212,22 +233,8 @@ fn find_bridge_criticality(
             if !adj[i][j] {
                 continue;
             }
-            // Count downstream nodes reachable from j
-            let mut visited = vec![false; n];
-            let mut stack = vec![j];
-            let mut downstream = 0;
-            while let Some(node) = stack.pop() {
-                if visited[node] {
-                    continue;
-                }
-                visited[node] = true;
-                downstream += 1;
-                for (k, visited_k) in visited.iter().enumerate().take(n) {
-                    if adj[node][k] && !visited_k {
-                        stack.push(k);
-                    }
-                }
-            }
+            // How much of the graph hangs off the far end of this edge.
+            let downstream = count_reachable_from(adj, j, n);
             result.push((names[i].to_string(), names[j].to_string(), downstream));
         }
     }

--- a/src/cli/graph_intelligence_ext_b.rs
+++ b/src/cli/graph_intelligence_ext_b.rs
@@ -200,24 +200,32 @@ fn find_bridge_edges(
     }
     bridges
 }
+/// Marks every node reachable from `start` as visited. Iterative rather than
+/// recursive so a long dependency chain cannot overflow the call stack.
+fn mark_reachable(adj: &[Vec<bool>], start: usize, visited: &mut [bool]) {
+    let mut stack = vec![start];
+    while let Some(node) = stack.pop() {
+        if visited[node] {
+            continue;
+        }
+        visited[node] = true;
+        for (j, &is_adj) in adj[node].iter().enumerate() {
+            if is_adj && !visited[j] {
+                stack.push(j);
+            }
+        }
+    }
+}
+
+/// Connected components of an undirected adjacency matrix: one per node that no
+/// earlier flood fill has already reached.
 fn count_components(adj: &[Vec<bool>], n: usize) -> usize {
     let mut visited = vec![false; n];
     let mut components = 0;
     for i in 0..n {
         if !visited[i] {
             components += 1;
-            let mut stack = vec![i];
-            while let Some(node) = stack.pop() {
-                if visited[node] {
-                    continue;
-                }
-                visited[node] = true;
-                for (j, &is_adj) in adj[node].iter().enumerate() {
-                    if is_adj && !visited[j] {
-                        stack.push(j);
-                    }
-                }
-            }
+            mark_reachable(adj, i, &mut visited);
         }
     }
     components

--- a/src/cli/graph_scoring.rs
+++ b/src/cli/graph_scoring.rs
@@ -299,25 +299,33 @@ pub(crate) fn cmd_graph_resource_dependency_cycle_risk(
     Ok(())
 }
 
+/// The pair `(name, dep)` in lexicographic order when the two resources depend
+/// on each other, so that either direction of the edge yields the same key.
+/// `None` when `dep` is unknown or does not depend back on `name`.
+fn mutual_dependency_pair(
+    config: &types::ForjarConfig,
+    name: &str,
+    dep: &str,
+) -> Option<(String, String)> {
+    let dep_res = config.resources.get(dep)?;
+    if !dep_res.depends_on.iter().any(|d| d == name) {
+        return None;
+    }
+    Some(if name < dep {
+        (name.to_string(), dep.to_string())
+    } else {
+        (dep.to_string(), name.to_string())
+    })
+}
+
 pub(super) fn find_cycle_risks(config: &types::ForjarConfig) -> Vec<(String, String, usize)> {
-    let mut risks = Vec::new();
+    let mut risks: Vec<(String, String, usize)> = Vec::new();
     for (name, resource) in &config.resources {
         for dep in &resource.depends_on {
-            let dep_res = match config.resources.get(dep) {
-                Some(r) => r,
-                None => continue,
-            };
-            if !dep_res.depends_on.contains(name) {
+            let Some(pair) = mutual_dependency_pair(config, name, dep) else {
                 continue;
-            }
-            let pair = if name < dep {
-                (name.clone(), dep.clone())
-            } else {
-                (dep.clone(), name.clone())
             };
-            let already_found = risks
-                .iter()
-                .any(|(a, b, _): &(String, String, usize)| a == &pair.0 && b == &pair.1);
+            let already_found = risks.iter().any(|(a, b, _)| a == &pair.0 && b == &pair.1);
             if !already_found {
                 risks.push((pair.0, pair.1, 1));
             }

--- a/src/cli/graph_visualization.rs
+++ b/src/cli/graph_visualization.rs
@@ -45,34 +45,42 @@ fn print_prune_mermaid(
 
 // ── FJ-454: graph --prune ──
 
+/// The subtree cut away by `--prune`: the named resource plus everything that
+/// transitively depends on it. Iterated to a fixed point rather than walked
+/// once, because `order` can list a dependent before the dependency that pulls
+/// it into the set.
+fn transitive_dependents(
+    config: &types::ForjarConfig,
+    order: &[String],
+    resource: &str,
+) -> std::collections::HashSet<String> {
+    let mut pruned = std::collections::HashSet::new();
+    pruned.insert(resource.to_string());
+
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for name in order {
+            if pruned.contains(name) {
+                continue;
+            }
+            let Some(res) = config.resources.get(name) else {
+                continue;
+            };
+            if res.depends_on.iter().any(|dep| pruned.contains(dep)) {
+                pruned.insert(name.clone());
+                changed = true;
+            }
+        }
+    }
+    pruned
+}
+
 pub(crate) fn cmd_graph_prune(file: &Path, format: &str, resource: &str) -> Result<(), String> {
     let config = parse_and_validate(file)?;
     let order = resolver::build_execution_order(&config)?;
 
-    // Collect subtree of resource to prune (resource + all transitive dependents)
-    let mut pruned = std::collections::HashSet::new();
-    pruned.insert(resource.to_string());
-
-    // Find all resources that transitively depend on the pruned resource
-    let mut changed = true;
-    while changed {
-        changed = false;
-        for name in &order {
-            if pruned.contains(name) {
-                continue;
-            }
-            if let Some(res) = config.resources.get(name) {
-                for dep in &res.depends_on {
-                    if pruned.contains(dep) {
-                        pruned.insert(name.clone());
-                        changed = true;
-                        break;
-                    }
-                }
-            }
-        }
-    }
-
+    let pruned = transitive_dependents(&config, &order, resource);
     let remaining: Vec<&String> = order.iter().filter(|n| !pruned.contains(*n)).collect();
 
     if format == "dot" {
@@ -92,15 +100,17 @@ pub(crate) fn cmd_graph_prune(file: &Path, format: &str, resource: &str) -> Resu
 
 // ── FJ-464: graph --layers ──
 
-pub(crate) fn cmd_graph_layers(file: &Path) -> Result<(), String> {
-    let config = parse_and_validate(file)?;
-    let order = resolver::build_execution_order(&config)?;
-
-    // Compute layer (depth) for each resource
+/// Depth of every resource: 0 for a resource with no dependencies, otherwise
+/// one more than its deepest dependency. Iterated to a fixed point, so a
+/// resource is only placed once all of its dependencies have been. Resources
+/// whose dependencies never resolve stay unlayered and are simply not printed.
+fn assign_layers(
+    config: &types::ForjarConfig,
+    order: &[String],
+) -> std::collections::HashMap<String, usize> {
     let mut layers: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
 
-    // Resources with no deps are layer 0
-    for name in &order {
+    for name in order {
         if let Some(res) = config.resources.get(name) {
             if res.depends_on.is_empty() {
                 layers.insert(name.clone(), 0);
@@ -108,49 +118,57 @@ pub(crate) fn cmd_graph_layers(file: &Path) -> Result<(), String> {
         }
     }
 
-    // Iteratively assign layers
     let mut changed = true;
     while changed {
         changed = false;
-        for name in &order {
+        for name in order {
             if layers.contains_key(name) {
                 continue;
             }
-            if let Some(res) = config.resources.get(name) {
-                let max_dep = res
-                    .depends_on
-                    .iter()
-                    .filter_map(|d| layers.get(d))
-                    .max()
-                    .copied();
-                if let Some(max) = max_dep {
-                    layers.insert(name.clone(), max + 1);
-                    changed = true;
-                }
+            let Some(res) = config.resources.get(name) else {
+                continue;
+            };
+            let max_dep = res
+                .depends_on
+                .iter()
+                .filter_map(|d| layers.get(d))
+                .max()
+                .copied();
+            if let Some(max) = max_dep {
+                layers.insert(name.clone(), max + 1);
+                changed = true;
             }
         }
     }
+    layers
+}
 
-    // Group by layer
+/// One line per non-empty layer, resources listed in execution order.
+fn print_layers(order: &[String], layers: &std::collections::HashMap<String, usize>) {
     let max_layer = layers.values().copied().max().unwrap_or(0);
     for layer in 0..=max_layer {
-        let resources: Vec<&String> = order
+        let resources: Vec<&str> = order
             .iter()
             .filter(|n| layers.get(*n) == Some(&layer))
+            .map(String::as_str)
             .collect();
         if !resources.is_empty() {
             println!(
                 "Layer {} ({}): {}",
                 layer,
                 resources.len(),
-                resources
-                    .iter()
-                    .map(|s| s.as_str())
-                    .collect::<Vec<_>>()
-                    .join(", ")
+                resources.join(", ")
             );
         }
     }
+}
+
+pub(crate) fn cmd_graph_layers(file: &Path) -> Result<(), String> {
+    let config = parse_and_validate(file)?;
+    let order = resolver::build_execution_order(&config)?;
+
+    let layers = assign_layers(&config, &order);
+    print_layers(&order, &layers);
     Ok(())
 }
 

--- a/src/cli/infra.rs
+++ b/src/cli/infra.rs
@@ -69,13 +69,87 @@ pub(crate) fn cmd_mcp_schema() -> Result<(), String> {
     Ok(())
 }
 
+/// Locks of the machines under `state_dir` that pass the optional filter, in
+/// listing order. A machine whose lock is missing or unreadable is skipped:
+/// every `state` sub-command treats that as "nothing recorded here" rather than
+/// as an error.
+fn filtered_machine_locks(
+    state_dir: &Path,
+    machine_filter: Option<&str>,
+) -> Result<Vec<types::StateLock>, String> {
+    let mut locks = Vec::new();
+    for machine_name in list_state_machines(state_dir)? {
+        if machine_filter.is_some_and(|filter| machine_name != filter) {
+            continue;
+        }
+        if let Ok(Some(lock)) = crate::core::state::load_lock(state_dir, &machine_name) {
+            locks.push(lock);
+        }
+    }
+    Ok(locks)
+}
+
+/// Appends one row per resource recorded in `lock`, in lock order.
+fn push_state_rows(lock: &types::StateLock, rows: &mut Vec<serde_json::Value>) {
+    for (res_id, res_lock) in &lock.resources {
+        rows.push(serde_json::json!({
+            "machine": lock.machine,
+            "resource": res_id,
+            "type": res_lock.resource_type.to_string(),
+            "status": format!("{:?}", res_lock.status).to_lowercase(),
+            "hash": &res_lock.hash[..12.min(res_lock.hash.len())],
+            "applied_at": res_lock.applied_at.as_deref().unwrap_or("-"),
+        }));
+    }
+}
+
+/// Prints the collected rows as an aligned table with a machine-count footer.
+fn print_state_table(rows: &[serde_json::Value]) {
+    println!(
+        "{:<15} {:<25} {:<10} {:<10} {:<14} APPLIED AT",
+        "MACHINE", "RESOURCE", "TYPE", "STATUS", "HASH"
+    );
+    for row in rows {
+        println!(
+            "{:<15} {:<25} {:<10} {:<10} {:<14} {}",
+            row["machine"].as_str().unwrap_or("-"),
+            row["resource"].as_str().unwrap_or("-"),
+            row["type"].as_str().unwrap_or("-"),
+            row["status"].as_str().unwrap_or("-"),
+            row["hash"].as_str().unwrap_or("-"),
+            row["applied_at"].as_str().unwrap_or("-"),
+        );
+    }
+    println!(
+        "\n{} resources across {} machines.",
+        rows.len(),
+        rows.iter()
+            .map(|r| r["machine"].as_str().unwrap_or(""))
+            .collect::<std::collections::HashSet<_>>()
+            .len()
+    );
+}
+
+/// Renders the collected rows as JSON, as a table, or as the "nothing
+/// recorded" line.
+fn print_state_rows(rows: &[serde_json::Value], json: bool) {
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(rows).unwrap_or_else(|_| "[]".to_string())
+        );
+    } else if rows.is_empty() {
+        println!("No resources in state.");
+    } else {
+        print_state_table(rows);
+    }
+}
+
 pub(crate) fn cmd_state_list(
     state_dir: &Path,
     machine_filter: Option<&str>,
     json: bool,
 ) -> Result<(), String> {
-    use crate::core::state;
-
     if !state_dir.exists() {
         if json {
             println!("[]");
@@ -85,68 +159,48 @@ pub(crate) fn cmd_state_list(
         return Ok(());
     }
 
-    let machines = list_state_machines(state_dir)?;
     let mut all_rows: Vec<serde_json::Value> = Vec::new();
-
-    for machine_name in &machines {
-        if let Some(filter) = machine_filter {
-            if machine_name != filter {
-                continue;
-            }
-        }
-
-        let lock = match state::load_lock(state_dir, machine_name) {
-            Ok(Some(l)) => l,
-            _ => continue,
-        };
-
-        for (res_id, res_lock) in &lock.resources {
-            all_rows.push(serde_json::json!({
-                "machine": lock.machine,
-                "resource": res_id,
-                "type": res_lock.resource_type.to_string(),
-                "status": format!("{:?}", res_lock.status).to_lowercase(),
-                "hash": &res_lock.hash[..12.min(res_lock.hash.len())],
-                "applied_at": res_lock.applied_at.as_deref().unwrap_or("-"),
-            }));
-        }
+    for lock in filtered_machine_locks(state_dir, machine_filter)? {
+        push_state_rows(&lock, &mut all_rows);
     }
 
-    if json {
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&all_rows).unwrap_or_else(|_| "[]".to_string())
-        );
-    } else if all_rows.is_empty() {
-        println!("No resources in state.");
-    } else {
-        println!(
-            "{:<15} {:<25} {:<10} {:<10} {:<14} APPLIED AT",
-            "MACHINE", "RESOURCE", "TYPE", "STATUS", "HASH"
-        );
-        for row in &all_rows {
-            println!(
-                "{:<15} {:<25} {:<10} {:<10} {:<14} {}",
-                row["machine"].as_str().unwrap_or("-"),
-                row["resource"].as_str().unwrap_or("-"),
-                row["type"].as_str().unwrap_or("-"),
-                row["status"].as_str().unwrap_or("-"),
-                row["hash"].as_str().unwrap_or("-"),
-                row["applied_at"].as_str().unwrap_or("-"),
-            );
-        }
-        println!(
-            "\n{} resources across {} machines.",
-            all_rows.len(),
-            all_rows
-                .iter()
-                .map(|r| r["machine"].as_str().unwrap_or(""))
-                .collect::<std::collections::HashSet<_>>()
-                .len()
-        );
-    }
-
+    print_state_rows(&all_rows, json);
     Ok(())
+}
+
+/// Renames `old_id` to `new_id` in one machine's lock and saves it, reporting
+/// whether this machine recorded `old_id` at all. Refuses when `new_id` is
+/// already recorded here, since that would silently drop an entry.
+fn rename_in_machine_lock(
+    state_dir: &Path,
+    lock: &mut types::StateLock,
+    old_id: &str,
+    new_id: &str,
+) -> Result<bool, String> {
+    if !lock.resources.contains_key(old_id) {
+        return Ok(false);
+    }
+
+    if lock.resources.contains_key(new_id) {
+        return Err(format!(
+            "resource '{}' already exists on machine '{}'",
+            new_id, lock.machine
+        ));
+    }
+
+    // Move the resource entry
+    if let Some(resource_lock) = lock.resources.swap_remove(old_id) {
+        lock.resources.insert(new_id.to_string(), resource_lock);
+    }
+
+    crate::core::state::save_lock(state_dir, lock)
+        .map_err(|e| format!("failed to save lock: {e}"))?;
+
+    println!(
+        "Renamed '{}' → '{}' on machine '{}'",
+        old_id, new_id, lock.machine
+    );
+    Ok(true)
 }
 
 pub(crate) fn cmd_state_mv(
@@ -155,8 +209,6 @@ pub(crate) fn cmd_state_mv(
     new_id: &str,
     machine_filter: Option<&str>,
 ) -> Result<(), String> {
-    use crate::core::state;
-
     if old_id == new_id {
         return Err("old and new resource IDs are the same".to_string());
     }
@@ -165,44 +217,9 @@ pub(crate) fn cmd_state_mv(
         return Err("state directory does not exist".to_string());
     }
 
-    let machines = list_state_machines(state_dir)?;
     let mut moved = false;
-
-    for machine_name in &machines {
-        if let Some(filter) = machine_filter {
-            if machine_name != filter {
-                continue;
-            }
-        }
-
-        let mut lock = match state::load_lock(state_dir, machine_name) {
-            Ok(Some(l)) => l,
-            _ => continue,
-        };
-
-        if !lock.resources.contains_key(old_id) {
-            continue;
-        }
-
-        if lock.resources.contains_key(new_id) {
-            return Err(format!(
-                "resource '{}' already exists on machine '{}'",
-                new_id, lock.machine
-            ));
-        }
-
-        // Move the resource entry
-        if let Some(resource_lock) = lock.resources.swap_remove(old_id) {
-            lock.resources.insert(new_id.to_string(), resource_lock);
-        }
-
-        state::save_lock(state_dir, &lock).map_err(|e| format!("failed to save lock: {e}"))?;
-
-        println!(
-            "Renamed '{}' → '{}' on machine '{}'",
-            old_id, new_id, lock.machine
-        );
-        moved = true;
+    for mut lock in filtered_machine_locks(state_dir, machine_filter)? {
+        moved |= rename_in_machine_lock(state_dir, &mut lock, old_id, new_id)?;
     }
 
     if !moved {
@@ -216,70 +233,72 @@ pub(crate) fn cmd_state_mv(
 // FJ-213: state-rm — remove a resource from state
 // ============================================================================
 
+/// Other resources in `lock` whose recorded details mention `resource_id`.
+/// This is a textual, best-effort guard: state details are untyped, so the only
+/// evidence of a reference is the id appearing in a string value.
+fn state_dependents_of(lock: &types::StateLock, resource_id: &str) -> Vec<String> {
+    lock.resources
+        .keys()
+        .filter(|k| *k != resource_id)
+        .filter(|k| {
+            lock.resources[*k]
+                .details
+                .values()
+                .any(|v| v.as_str().map(|s| s.contains(resource_id)).unwrap_or(false))
+        })
+        .cloned()
+        .collect()
+}
+
+/// Drops `resource_id` from one machine's lock and saves it, reporting whether
+/// this machine recorded it at all. Without `force`, refuses while other
+/// entries still appear to reference it.
+fn remove_from_machine_lock(
+    state_dir: &Path,
+    lock: &mut types::StateLock,
+    resource_id: &str,
+    force: bool,
+) -> Result<bool, String> {
+    if !lock.resources.contains_key(resource_id) {
+        return Ok(false);
+    }
+
+    if !force {
+        let dependents = state_dependents_of(lock, resource_id);
+        if !dependents.is_empty() {
+            return Err(format!(
+                "resource '{}' may be referenced by: {}. Use --force to skip this check.",
+                resource_id,
+                dependents.join(", ")
+            ));
+        }
+    }
+
+    lock.resources.swap_remove(resource_id);
+
+    crate::core::state::save_lock(state_dir, lock)
+        .map_err(|e| format!("failed to save lock: {e}"))?;
+
+    println!(
+        "Removed '{}' from state on machine '{}' (resource still exists on machine)",
+        resource_id, lock.machine
+    );
+    Ok(true)
+}
+
 pub(crate) fn cmd_state_rm(
     state_dir: &Path,
     resource_id: &str,
     machine_filter: Option<&str>,
     force: bool,
 ) -> Result<(), String> {
-    use crate::core::state;
-
     if !state_dir.exists() {
         return Err("state directory does not exist".to_string());
     }
 
-    let machines = list_state_machines(state_dir)?;
     let mut removed = false;
-
-    for machine_name in &machines {
-        if let Some(filter) = machine_filter {
-            if machine_name != filter {
-                continue;
-            }
-        }
-
-        let mut lock = match state::load_lock(state_dir, machine_name) {
-            Ok(Some(l)) => l,
-            _ => continue,
-        };
-
-        if !lock.resources.contains_key(resource_id) {
-            continue;
-        }
-
-        // Check for dependents (other resources whose details reference this one)
-        if !force {
-            let dependents: Vec<String> = lock
-                .resources
-                .keys()
-                .filter(|k| *k != resource_id)
-                .filter(|k| {
-                    lock.resources[*k]
-                        .details
-                        .values()
-                        .any(|v| v.as_str().map(|s| s.contains(resource_id)).unwrap_or(false))
-                })
-                .cloned()
-                .collect();
-
-            if !dependents.is_empty() {
-                return Err(format!(
-                    "resource '{}' may be referenced by: {}. Use --force to skip this check.",
-                    resource_id,
-                    dependents.join(", ")
-                ));
-            }
-        }
-
-        lock.resources.swap_remove(resource_id);
-
-        state::save_lock(state_dir, &lock).map_err(|e| format!("failed to save lock: {e}"))?;
-
-        println!(
-            "Removed '{}' from state on machine '{}' (resource still exists on machine)",
-            resource_id, lock.machine
-        );
-        removed = true;
+    for mut lock in filtered_machine_locks(state_dir, machine_filter)? {
+        removed |= remove_from_machine_lock(state_dir, &mut lock, resource_id, force)?;
     }
 
     if !removed {

--- a/src/cli/infra_bench_baseline.rs
+++ b/src/cli/infra_bench_baseline.rs
@@ -55,6 +55,26 @@ pub(crate) fn load_baseline_from(path: &Path) -> Result<Vec<BaselineEntry>, Stri
     Ok(entries)
 }
 
+/// True for a line inside the table that carries data: a markdown row that is
+/// neither the `| Operation | ... |` header nor the `---` separator beneath it.
+fn is_baseline_data_row(line: &str) -> bool {
+    line.starts_with('|') && !line.contains("---") && !line.contains("Operation")
+}
+
+/// Parse one `| Operation | Target | Last Run | p50 | p95 | Status |` row.
+/// `None` when the row has too few columns, or its "Last Run" cell is not a
+/// duration literal — a malformed row is skipped, never guessed at.
+fn parse_baseline_row(line: &str) -> Option<BaselineEntry> {
+    let cols: Vec<&str> = line.split('|').collect();
+    if cols.len() < 5 {
+        return None;
+    }
+    Some(BaselineEntry {
+        name: cols[1].trim().to_string(),
+        avg_us: parse_duration_to_us(cols[3].trim())?,
+    })
+}
+
 /// Parse the rows between the BENCH-TABLE markers.
 pub(crate) fn parse_baseline_table(content: &str) -> Vec<BaselineEntry> {
     let mut entries = Vec::new();
@@ -67,16 +87,8 @@ pub(crate) fn parse_baseline_table(content: &str) -> Vec<BaselineEntry> {
         if line.contains("BENCH-TABLE-END") {
             break;
         }
-        if !in_table || !line.starts_with('|') || line.contains("---") || line.contains("Operation")
-        {
-            continue;
-        }
-        let cols: Vec<&str> = line.split('|').collect();
-        if cols.len() >= 5 {
-            let name = cols[1].trim().to_string();
-            if let Some(us) = parse_duration_to_us(cols[3].trim()) {
-                entries.push(BaselineEntry { name, avg_us: us });
-            }
+        if in_table && is_baseline_data_row(line) {
+            entries.extend(parse_baseline_row(line));
         }
     }
     entries

--- a/src/cli/infra_query.rs
+++ b/src/cli/infra_query.rs
@@ -81,35 +81,48 @@ fn execute_query(
     matches
 }
 
-fn matches_filter(id: &str, res: &crate::core::types::Resource, filter: &QueryFilter) -> bool {
-    if let Some(ref pat) = filter.pattern {
-        if !id.contains(pat)
-            && !format!("{:?}", res.resource_type)
-                .to_lowercase()
-                .contains(pat)
-        {
-            return false;
-        }
-    }
-    if let Some(ref rt) = filter.resource_type {
-        if !format!("{:?}", res.resource_type)
+/// The free-text pattern hits either the resource id (as written) or its type
+/// name (lowercased).
+fn matches_pattern(id: &str, res: &crate::core::types::Resource, pattern: &str) -> bool {
+    id.contains(pattern)
+        || format!("{:?}", res.resource_type)
             .to_lowercase()
-            .contains(&rt.to_lowercase())
-        {
-            return false;
-        }
-    }
-    if let Some(ref m) = filter.machine {
-        if !res.machine.iter().any(|mv| mv.contains(m)) {
-            return false;
-        }
-    }
-    if let Some(ref t) = filter.tag {
-        if !res.tags.iter().any(|tag| tag.contains(t)) {
-            return false;
-        }
-    }
-    true
+            .contains(pattern)
+}
+
+/// Type filter: case-insensitive substring of the type name.
+fn matches_resource_type(res: &crate::core::types::Resource, wanted: &str) -> bool {
+    format!("{:?}", res.resource_type)
+        .to_lowercase()
+        .contains(&wanted.to_lowercase())
+}
+
+/// Machine filter: substring of any machine the resource targets.
+fn matches_machine(res: &crate::core::types::Resource, wanted: &str) -> bool {
+    res.machine.iter().any(|mv| mv.contains(wanted))
+}
+
+/// Tag filter: substring of any tag on the resource.
+fn matches_tag(res: &crate::core::types::Resource, wanted: &str) -> bool {
+    res.tags.iter().any(|tag| tag.contains(wanted))
+}
+
+/// Every criterion the filter sets has to match; criteria left unset are
+/// ignored rather than treated as "matches nothing".
+fn matches_filter(id: &str, res: &crate::core::types::Resource, filter: &QueryFilter) -> bool {
+    filter
+        .pattern
+        .as_deref()
+        .is_none_or(|pat| matches_pattern(id, res, pat))
+        && filter
+            .resource_type
+            .as_deref()
+            .is_none_or(|rt| matches_resource_type(res, rt))
+        && filter
+            .machine
+            .as_deref()
+            .is_none_or(|m| matches_machine(res, m))
+        && filter.tag.as_deref().is_none_or(|t| matches_tag(res, t))
 }
 
 fn compute_status(id: &str, res: &crate::core::types::Resource, state_dir: &Path) -> String {

--- a/src/cli/lint.rs
+++ b/src/cli/lint.rs
@@ -274,10 +274,50 @@ fn heredoc_line_set(script: &str) -> std::collections::HashSet<usize> {
     inside
 }
 
+/// How many bashrs findings a lint sweep saw, by severity. Errors are also
+/// reported individually; the lower severities are only ever counted.
+#[derive(Default)]
+struct ScriptLintTally {
+    errors: usize,
+    warnings: usize,
+}
+
+/// Lints one generated script, pushing a message per error-severity finding and
+/// folding every finding into `tally`.
+fn lint_generated_script(
+    id: &str,
+    kind: &str,
+    script: &str,
+    warnings: &mut Vec<String>,
+    tally: &mut ScriptLintTally,
+) {
+    use bashrs::linter::Severity;
+
+    let heredoc_lines = heredoc_line_set(script);
+    for d in &crate::core::purifier::lint_script(script).diagnostics {
+        // SC1xxx rules have false positives on generated scripts (e.g. grep
+        // char classes parsed as test expressions); purifier::validate_script
+        // already filters these. Anything inside a heredoc is file data, not
+        // shell, so it is not the generator's to answer for either.
+        if d.code.starts_with("SC1") || heredoc_lines.contains(&d.span.start_line) {
+            continue;
+        }
+        match d.severity {
+            Severity::Error => {
+                tally.errors += 1;
+                warnings.push(format!(
+                    "bashrs: {}/{} [{}] {}",
+                    id, kind, d.code, d.message
+                ));
+            }
+            _ => tally.warnings += 1,
+        }
+    }
+}
+
 fn lint_scripts(config: &types::ForjarConfig) -> Vec<String> {
     let mut warnings = Vec::new();
-    let mut script_errors = 0usize;
-    let mut script_warnings_count = 0usize;
+    let mut tally = ScriptLintTally::default();
     for (id, resource) in &config.resources {
         for (kind, result) in [
             ("check", codegen::check_script(resource)),
@@ -285,41 +325,15 @@ fn lint_scripts(config: &types::ForjarConfig) -> Vec<String> {
             ("state_query", codegen::state_query_script(resource)),
         ] {
             if let Ok(script) = result {
-                let heredoc_lines = heredoc_line_set(&script);
-                let lint_result = crate::core::purifier::lint_script(&script);
-                for d in &lint_result.diagnostics {
-                    use bashrs::linter::Severity;
-                    // SC1xxx rules have false positives on generated scripts
-                    // (e.g. grep char classes parsed as test expressions).
-                    // purifier::validate_script already filters these.
-                    if d.code.starts_with("SC1") {
-                        continue;
-                    }
-                    // Skip diagnostics inside heredoc content (file data, not shell)
-                    if heredoc_lines.contains(&d.span.start_line) {
-                        continue;
-                    }
-                    match d.severity {
-                        Severity::Error => {
-                            script_errors += 1;
-                            warnings.push(format!(
-                                "bashrs: {}/{} [{}] {}",
-                                id, kind, d.code, d.message
-                            ));
-                        }
-                        _ => {
-                            script_warnings_count += 1;
-                        }
-                    }
-                }
+                lint_generated_script(id, kind, &script, &mut warnings, &mut tally);
             }
         }
     }
-    if script_errors > 0 || script_warnings_count > 0 {
+    if tally.errors > 0 || tally.warnings > 0 {
         warnings.push(format!(
             "bashrs script lint: {} error(s), {} warning(s) across {} resources",
-            script_errors,
-            script_warnings_count,
+            tally.errors,
+            tally.warnings,
             config.resources.len()
         ));
     }

--- a/src/cli/lock_core.rs
+++ b/src/cli/lock_core.rs
@@ -225,6 +225,94 @@ pub(crate) fn cmd_lock_info(state_dir: &Path, json: bool) -> Result<(), String> 
     Ok(())
 }
 
+/// Lock entries that no longer name a resource in the config.
+fn stale_lock_entries(
+    lock: &types::StateLock,
+    config_resources: &std::collections::HashSet<&String>,
+) -> Vec<String> {
+    lock.resources
+        .keys()
+        .filter(|k| !config_resources.contains(k))
+        .cloned()
+        .collect()
+}
+
+/// Drops the stale entries from the lock, naming each one as it goes.
+///
+/// ACTUALLY REMOVE IT.
+///
+/// This used to be the `println!` alone. `stale` was computed, printed and
+/// counted; the lock was never mutated and never saved. So `lock-prune --yes`
+/// announced "Pruned 'b' from local", exited 0, and left the lock file
+/// BYTE-IDENTICAL — the message was the only thing that happened. Ledger id
+/// lock-prune-yes-claims-pruned-but-changes-nothing, confirmed at 1.12.3 and
+/// still live at 1.16.0.
+fn remove_stale_entries(lock: &mut types::StateLock, stale: &[String], machine_name: &str) {
+    for s in stale {
+        lock.resources.shift_remove(s);
+        println!("  {} Pruned '{}' from {}", red("-"), s, machine_name);
+    }
+}
+
+/// Names the stale entries a `--yes` run would drop, touching nothing.
+fn preview_stale_entries(stale: &[String], machine_name: &str) {
+    for s in stale {
+        println!(
+            "  {} Would prune '{}' from {} (use --yes to apply)",
+            yellow("~"),
+            s,
+            machine_name
+        );
+    }
+}
+
+/// Prunes one machine's lock, returning how many stale entries it held.
+/// Without `--yes` this only previews. With it, the lock is saved, and a failed
+/// write is an error: saving also rewrites the `.b3` sidecar, so a pruned lock
+/// must never be reported as pruned unless it reached disk.
+fn prune_machine_lock(
+    state_dir: &Path,
+    machine_name: &str,
+    lock: &mut types::StateLock,
+    config_resources: &std::collections::HashSet<&String>,
+    yes: bool,
+) -> Result<usize, String> {
+    let stale = stale_lock_entries(lock, config_resources);
+    if stale.is_empty() {
+        return Ok(0);
+    }
+
+    if yes {
+        remove_stale_entries(lock, &stale, machine_name);
+        state::save_lock(state_dir, lock).map_err(|e| {
+            format!(
+                "pruned {} entr(ies) from {machine_name} but could not save the lock: {e}",
+                stale.len()
+            )
+        })?;
+    } else {
+        preview_stale_entries(&stale, machine_name);
+    }
+
+    Ok(stale.len())
+}
+
+/// Closing line for a prune run: nothing found, a preview total, or a count of
+/// what was removed.
+fn print_prune_summary(pruned: usize, yes: bool) {
+    if pruned == 0 {
+        println!("{} No stale lock entries found.", green("✓"));
+    } else if !yes {
+        println!(
+            "\n{} {} stale entries. Run with --yes to prune.",
+            yellow("Total:"),
+            pruned
+        );
+    } else {
+        println!("\n{} Pruned {} stale entries.", green("✓"), pruned);
+    }
+}
+
 // FJ-366: Lock prune — remove stale lock entries
 pub(crate) fn cmd_lock_prune(file: &Path, state_dir: &Path, yes: bool) -> Result<(), String> {
     let config = parse_and_validate(file)?;
@@ -240,68 +328,12 @@ pub(crate) fn cmd_lock_prune(file: &Path, state_dir: &Path, yes: bool) -> Result
         }
         let machine_name = entry.file_name().to_string_lossy().to_string();
         if let Some(mut lock) = state::load_lock(state_dir, &machine_name)? {
-            let stale: Vec<String> = lock
-                .resources
-                .keys()
-                .filter(|k| !config_resources.contains(k))
-                .cloned()
-                .collect();
-
-            if stale.is_empty() {
-                continue;
-            }
-
-            for s in &stale {
-                if yes {
-                    // ACTUALLY REMOVE IT.
-                    //
-                    // This branch used to be the println! alone. `stale` was
-                    // computed, printed and counted; the lock was never mutated
-                    // and never saved. So `lock-prune --yes` announced
-                    // "Pruned 'b' from local", exited 0, and left the lock file
-                    // BYTE-IDENTICAL — the message was the only thing that
-                    // happened. Ledger id
-                    // lock-prune-yes-claims-pruned-but-changes-nothing,
-                    // confirmed at 1.12.3 and still live at 1.16.0.
-                    lock.resources.shift_remove(s);
-                    println!("  {} Pruned '{}' from {}", red("-"), s, machine_name);
-                } else {
-                    println!(
-                        "  {} Would prune '{}' from {} (use --yes to apply)",
-                        yellow("~"),
-                        s,
-                        machine_name
-                    );
-                }
-            }
-            pruned += stale.len();
-
-            // Persist, and REFUSE TO CLAIM SUCCESS IF THE WRITE FAILED. Saving
-            // rewrites the .b3 sidecar alongside the lock, so a pruned lock
-            // stays consistent with its integrity record.
-            if yes {
-                state::save_lock(state_dir, &lock).map_err(|e| {
-                    format!(
-                        "pruned {} entr(ies) from {machine_name} but could not save the lock: {e}",
-                        stale.len()
-                    )
-                })?;
-            }
+            pruned +=
+                prune_machine_lock(state_dir, &machine_name, &mut lock, &config_resources, yes)?;
         }
     }
 
-    if pruned == 0 {
-        println!("{} No stale lock entries found.", green("✓"));
-    } else if !yes {
-        println!(
-            "\n{} {} stale entries. Run with --yes to prune.",
-            yellow("Total:"),
-            pruned
-        );
-    } else {
-        println!("\n{} Pruned {} stale entries.", green("✓"), pruned);
-    }
-
+    print_prune_summary(pruned, yes);
     Ok(())
 }
 

--- a/src/cli/lock_lifecycle.rs
+++ b/src/cli/lock_lifecycle.rs
@@ -3,6 +3,48 @@
 use super::helpers::*;
 use std::path::Path;
 
+/// Minified YAML: blank lines and whole-line comments dropped, every other line
+/// kept byte for byte.
+fn minify_yaml(content: &str) -> String {
+    let mut minified = String::new();
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        minified.push_str(line);
+        minified.push('\n');
+    }
+    minified
+}
+
+/// Writes `<machine>.lock.yaml.min` next to the state tree when minifying the
+/// machine's lock actually saves bytes, and returns how many. `Ok(0)` when
+/// there is no lock, it is empty, or minifying gains nothing — none of which is
+/// an error.
+fn compress_machine_lock(state_dir: &Path, machine: &str) -> Result<u64, String> {
+    let lock_path = state_dir.join(machine).join("state.lock.yaml");
+    if !lock_path.exists() {
+        return Ok(0);
+    }
+    let content = std::fs::read_to_string(&lock_path).unwrap_or_default();
+    let original_size = content.len() as u64;
+    if original_size == 0 {
+        return Ok(0);
+    }
+
+    let minified = minify_yaml(&content);
+    let new_size = minified.len() as u64;
+    if new_size >= original_size {
+        return Ok(0);
+    }
+
+    let compressed_path = state_dir.join(format!("{machine}.lock.yaml.min"));
+    std::fs::write(&compressed_path, &minified)
+        .map_err(|e| format!("Failed to write compressed lock: {e}"))?;
+    Ok(original_size - new_size)
+}
+
 /// FJ-565: Compress old lock files with zstd-like compression (base64 encoding for portability).
 pub(crate) fn cmd_lock_compress(state_dir: &Path, json: bool) -> Result<(), String> {
     let machines = discover_machines(state_dir);
@@ -10,33 +52,9 @@ pub(crate) fn cmd_lock_compress(state_dir: &Path, json: bool) -> Result<(), Stri
     let mut total_saved = 0u64;
 
     for m in &machines {
-        let lock_path = state_dir.join(m).join("state.lock.yaml");
-        if !lock_path.exists() {
-            continue;
-        }
-        let content = std::fs::read_to_string(&lock_path).unwrap_or_default();
-        let original_size = content.len() as u64;
-        if original_size == 0 {
-            continue;
-        }
-
-        // Write compressed version (minified YAML — remove comments and extra whitespace)
-        let mut minified = String::new();
-        for line in content.lines() {
-            let trimmed = line.trim();
-            if trimmed.is_empty() || trimmed.starts_with('#') {
-                continue;
-            }
-            minified.push_str(line);
-            minified.push('\n');
-        }
-
-        let new_size = minified.len() as u64;
-        if new_size < original_size {
-            let compressed_path = state_dir.join(format!("{m}.lock.yaml.min"));
-            std::fs::write(&compressed_path, &minified)
-                .map_err(|e| format!("Failed to write compressed lock: {e}"))?;
-            total_saved += original_size - new_size;
+        let saved = compress_machine_lock(state_dir, m)?;
+        if saved > 0 {
+            total_saved += saved;
             compressed += 1;
         }
     }

--- a/src/cli/logs.rs
+++ b/src/cli/logs.rs
@@ -66,49 +66,53 @@ fn runs_for_machine(
     run_filter: Option<&str>,
     failures_only: bool,
 ) -> Vec<DiscoveredRun> {
-    let mut runs = Vec::new();
-
     let runs_dir = machine_dir.join("runs");
     if !runs_dir.is_dir() {
-        return runs;
+        return Vec::new();
     }
 
-    let run_entries = match std::fs::read_dir(&runs_dir) {
-        Ok(e) => e,
-        Err(_) => return runs,
+    let Ok(run_entries) = std::fs::read_dir(&runs_dir) else {
+        return Vec::new();
     };
 
-    for run_entry in run_entries.flatten() {
-        let run_dir = run_entry.path();
-        if !run_dir.is_dir() {
-            continue;
-        }
-        let run_id = run_entry.file_name().to_string_lossy().to_string();
+    run_entries
+        .flatten()
+        .filter_map(|entry| discovered_run(&entry, machine_name, run_filter, failures_only))
+        .collect()
+}
 
-        if let Some(filter) = run_filter {
-            if run_id != filter {
-                continue;
-            }
-        }
-
-        let meta = match read_run_meta(&run_dir) {
-            Some(m) => m,
-            None => continue,
-        };
-
-        if failures_only && meta.summary.failed == 0 {
-            continue;
-        }
-
-        runs.push(DiscoveredRun {
-            machine: machine_name.to_string(),
-            run_id,
-            meta,
-            run_dir,
-        });
+/// One directory under `runs/` turned into a reportable run, or `None` when it
+/// is not one: not a directory at all, excluded by `--run`, carrying no usable
+/// `meta.yaml`, or filtered out by `--failures-only`. Exists so the walk above
+/// reads as "every run that survives the filters" rather than as five reasons
+/// to `continue`.
+fn discovered_run(
+    run_entry: &std::fs::DirEntry,
+    machine_name: &str,
+    run_filter: Option<&str>,
+    failures_only: bool,
+) -> Option<DiscoveredRun> {
+    let run_dir = run_entry.path();
+    if !run_dir.is_dir() {
+        return None;
     }
 
-    runs
+    let run_id = run_entry.file_name().to_string_lossy().to_string();
+    if run_filter.is_some_and(|filter| run_id != filter) {
+        return None;
+    }
+
+    let meta = read_run_meta(&run_dir)?;
+    if failures_only && meta.summary.failed == 0 {
+        return None;
+    }
+
+    Some(DiscoveredRun {
+        machine: machine_name.to_string(),
+        run_id,
+        meta,
+        run_dir,
+    })
 }
 
 /// Discover all runs under a state directory, optionally filtered.

--- a/src/cli/logs_gc.rs
+++ b/src/cli/logs_gc.rs
@@ -10,6 +10,90 @@ use super::logs::{discover_runs, DiscoveredRun};
 use crate::core::types::LogRetention;
 use std::path::Path;
 
+/// Runs bucketed by machine, keeping `discover_runs`' newest-first order within
+/// each bucket — the retention cut is "everything after the first N", so that
+/// order is load-bearing (see the module docs).
+fn group_runs_by_machine(
+    runs: &[DiscoveredRun],
+) -> std::collections::HashMap<String, Vec<&DiscoveredRun>> {
+    let mut by_machine: std::collections::HashMap<String, Vec<&DiscoveredRun>> =
+        std::collections::HashMap::new();
+    for run in runs {
+        by_machine.entry(run.machine.clone()).or_default().push(run);
+    }
+    by_machine
+}
+
+/// Frees one run: deleted outright, or merely named when this is a dry run.
+fn discard_run(machine: &str, run: &DiscoveredRun, size: u64, dry_run: bool, json: bool) {
+    if dry_run {
+        if !json {
+            println!(
+                "  would delete: {}/{} ({} bytes)",
+                machine, run.run_id, size
+            );
+        }
+    } else {
+        let _ = std::fs::remove_dir_all(&run.run_dir);
+    }
+}
+
+/// Applies the retention cut to one machine: everything past the newest
+/// `keep_runs` goes, except failed runs when `keep_failed` is set. Returns
+/// (bytes freed, runs discarded).
+fn gc_machine_runs(
+    machine: &str,
+    machine_runs: &[&DiscoveredRun],
+    keep_runs: usize,
+    dry_run: bool,
+    keep_failed: bool,
+    json: bool,
+) -> (u64, u32) {
+    let mut cleaned = 0u64;
+    let mut deleted = 0u32;
+    for run in machine_runs.iter().skip(keep_runs) {
+        if keep_failed && run.meta.summary.failed > 0 {
+            continue;
+        }
+        let size = dir_size(&run.run_dir);
+        discard_run(machine, run, size, dry_run, json);
+        cleaned += size;
+        deleted += 1;
+    }
+    (cleaned, deleted)
+}
+
+/// Reports the outcome of a GC pass as JSON, as "nothing to clean", or as a
+/// count of what was (or would be) removed.
+fn print_gc_report(
+    state_dir: &Path,
+    dry_run: bool,
+    json: bool,
+    deleted: u32,
+    cleaned: u64,
+    keep_runs: u32,
+) {
+    if json {
+        let output = serde_json::json!({
+            "action": if dry_run { "dry_run" } else { "gc" },
+            "state_dir": state_dir.display().to_string(),
+            "deleted_runs": deleted,
+            "freed_bytes": cleaned,
+        });
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&output).unwrap_or_default()
+        );
+    } else if deleted == 0 {
+        println!(
+            "Log garbage collection: nothing to clean (within retention: {keep_runs} runs/machine)"
+        );
+    } else {
+        let verb = if dry_run { "would delete" } else { "deleted" };
+        println!("Log garbage collection: {verb} {deleted} runs, {cleaned} bytes freed");
+    }
+}
+
 /// FJ-2301: Garbage-collect old run logs based on retention policy.
 pub(crate) fn cmd_logs_gc(
     state_dir: &Path,
@@ -22,65 +106,30 @@ pub(crate) fn cmd_logs_gc(
     let retention = retention.unwrap_or(&default_retention);
     let runs = discover_runs(state_dir, None, None, false);
 
-    // Group by machine
-    let mut by_machine: std::collections::HashMap<String, Vec<&DiscoveredRun>> =
-        std::collections::HashMap::new();
-    for run in &runs {
-        by_machine.entry(run.machine.clone()).or_default().push(run);
-    }
-
     let mut total_cleaned = 0u64;
     let mut total_deleted = 0u32;
 
-    for (machine, machine_runs) in &by_machine {
-        let to_keep = retention.keep_runs as usize;
-        if machine_runs.len() <= to_keep {
-            continue;
-        }
-
-        for run in machine_runs.iter().skip(to_keep) {
-            if keep_failed && run.meta.summary.failed > 0 {
-                continue;
-            }
-            let size = dir_size(&run.run_dir);
-            if dry_run {
-                if !json {
-                    println!(
-                        "  would delete: {}/{} ({} bytes)",
-                        machine, run.run_id, size
-                    );
-                }
-            } else {
-                let _ = std::fs::remove_dir_all(&run.run_dir);
-            }
-            total_cleaned += size;
-            total_deleted += 1;
-        }
+    for (machine, machine_runs) in &group_runs_by_machine(&runs) {
+        let (cleaned, deleted) = gc_machine_runs(
+            machine,
+            machine_runs,
+            retention.keep_runs as usize,
+            dry_run,
+            keep_failed,
+            json,
+        );
+        total_cleaned += cleaned;
+        total_deleted += deleted;
     }
 
-    if json {
-        let output = serde_json::json!({
-            "action": if dry_run { "dry_run" } else { "gc" },
-            "state_dir": state_dir.display().to_string(),
-            "deleted_runs": total_deleted,
-            "freed_bytes": total_cleaned,
-        });
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&output).unwrap_or_default()
-        );
-    } else if total_deleted == 0 {
-        println!(
-            "Log garbage collection: nothing to clean (within retention: {} runs/machine)",
-            retention.keep_runs
-        );
-    } else {
-        let verb = if dry_run { "would delete" } else { "deleted" };
-        println!(
-            "Log garbage collection: {} {} runs, {} bytes freed",
-            verb, total_deleted, total_cleaned
-        );
-    }
+    print_gc_report(
+        state_dir,
+        dry_run,
+        json,
+        total_deleted,
+        total_cleaned,
+        retention.keep_runs,
+    );
     Ok(())
 }
 

--- a/src/cli/observe.rs
+++ b/src/cli/observe.rs
@@ -78,32 +78,38 @@ pub(super) fn print_trace_text(all_spans: &[(String, tracer::TraceSpan)]) {
     }
 }
 
-pub(crate) fn cmd_trace(
+/// Every recorded trace span under `state_dir`, tagged with the machine it came
+/// from and honouring an optional single-machine filter. A machine whose trace
+/// data cannot be read contributes nothing rather than failing the command.
+fn collect_trace_spans(
     state_dir: &Path,
     machine_filter: Option<&str>,
-    json: bool,
-) -> Result<(), String> {
+) -> Result<Vec<(String, tracer::TraceSpan)>, String> {
     let entries = std::fs::read_dir(state_dir)
         .map_err(|e| format!("cannot read state dir {}: {}", state_dir.display(), e))?;
 
     let mut all_spans = Vec::new();
-
     for entry in entries.flatten() {
         let name = entry.file_name().to_string_lossy().to_string();
-        if let Some(filter) = machine_filter {
-            if name != filter {
-                continue;
-            }
+        if machine_filter.is_some_and(|filter| name != filter) {
+            continue;
         }
         if !entry.path().is_dir() {
             continue;
         }
         if let Ok(spans) = tracer::read_trace(state_dir, &name) {
-            for span in spans {
-                all_spans.push((name.clone(), span));
-            }
+            all_spans.extend(spans.into_iter().map(|span| (name.clone(), span)));
         }
     }
+    Ok(all_spans)
+}
+
+pub(crate) fn cmd_trace(
+    state_dir: &Path,
+    machine_filter: Option<&str>,
+    json: bool,
+) -> Result<(), String> {
+    let mut all_spans = collect_trace_spans(state_dir, machine_filter)?;
 
     if all_spans.is_empty() {
         if json {

--- a/src/cli/prove.rs
+++ b/src/cli/prove.rs
@@ -191,6 +191,30 @@ fn topo_sort_count(config: &types::ForjarConfig) -> (usize, usize) {
     (visited, config.resources.len())
 }
 
+/// Whether a resource belongs in the coverage count at all. Recipes are
+/// templates rather than deployed state and never count; `--machine` narrows
+/// the count to the resources that target that machine.
+fn counts_toward_state_coverage(resource: &types::Resource, machine_filter: Option<&str>) -> bool {
+    if resource.resource_type == types::ResourceType::Recipe {
+        return false;
+    }
+    match machine_filter {
+        Some(filter) => machine_matches(resource, filter),
+        None => true,
+    }
+}
+
+/// A resource is covered when at least one of the machines it targets records
+/// it in that machine's lock.
+fn resource_has_state_entry(state_dir: &Path, resource: &types::Resource, id: &str) -> bool {
+    resource.machine.iter().any(|machine| {
+        matches!(
+            state::load_lock(state_dir, machine),
+            Ok(Some(lock)) if lock.resources.contains_key(id)
+        )
+    })
+}
+
 fn prove_state_coverage(
     config: &types::ForjarConfig,
     state_dir: &Path,
@@ -200,24 +224,12 @@ fn prove_state_coverage(
     let mut covered = 0;
 
     for (id, resource) in &config.resources {
-        if let Some(filter) = machine_filter {
-            if !machine_matches(resource, filter) {
-                continue;
-            }
-        }
-        if resource.resource_type == types::ResourceType::Recipe {
+        if !counts_toward_state_coverage(resource, machine_filter) {
             continue;
         }
-
         total += 1;
-
-        for machine in resource.machine.iter() {
-            if let Ok(Some(lock)) = state::load_lock(state_dir, machine) {
-                if lock.resources.contains_key(id) {
-                    covered += 1;
-                    break;
-                }
-            }
+        if resource_has_state_entry(state_dir, resource, id) {
+            covered += 1;
         }
     }
 

--- a/src/cli/state_encrypt.rs
+++ b/src/cli/state_encrypt.rs
@@ -190,7 +190,23 @@ fn rekey_decrypt(file: &Path, passphrase: &str) -> Result<Vec<u8>, String> {
     Ok(plaintext)
 }
 
-/// Find lock files in a state directory.
+/// Appends every lock file sitting directly in `dir`. An unreadable directory
+/// contributes nothing: a state tree the caller cannot list is not an error
+/// here, it simply holds no locks to encrypt.
+fn push_lock_files_in(dir: &Path, files: &mut Vec<std::path::PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if is_lock_file(&path) {
+            files.push(path);
+        }
+    }
+}
+
+/// Find lock files in a state directory: those at the top level, plus those one
+/// level down in each machine subdirectory.
 fn find_lock_files(state_dir: &Path) -> Result<Vec<std::path::PathBuf>, String> {
     let mut files = Vec::new();
 
@@ -202,15 +218,7 @@ fn find_lock_files(state_dir: &Path) -> Result<Vec<std::path::PathBuf>, String> 
         for entry in entries.flatten() {
             let path = entry.path();
             if path.is_dir() {
-                // Recurse into machine subdirectories
-                if let Ok(sub_entries) = std::fs::read_dir(&path) {
-                    for sub_entry in sub_entries.flatten() {
-                        let sub_path = sub_entry.path();
-                        if is_lock_file(&sub_path) {
-                            files.push(sub_path);
-                        }
-                    }
-                }
+                push_lock_files_in(&path, &mut files);
             } else if is_lock_file(&path) {
                 files.push(path);
             }

--- a/src/cli/status_compliance.rs
+++ b/src/cli/status_compliance.rs
@@ -201,45 +201,64 @@ pub(crate) fn cmd_status_compliance_report(
     Ok(())
 }
 
-/// FJ-602: Show security-relevant resource states (modes, ownership).
-pub(crate) fn cmd_status_security_posture(
-    state_dir: &Path,
-    machine: Option<&str>,
-    json: bool,
-) -> Result<(), String> {
-    let machines = discover_machines(state_dir);
-    let mut items: Vec<(String, String, String, String)> = Vec::new(); // (machine, resource, type, status)
+/// Resource types whose recorded state carries security meaning — permissions,
+/// ownership, exposure.
+fn is_security_relevant(resource_type: &types::ResourceType) -> bool {
+    matches!(
+        resource_type,
+        types::ResourceType::File
+            | types::ResourceType::User
+            | types::ResourceType::Network
+            | types::ResourceType::Service
+    )
+}
 
-    for m in &machines {
-        if let Some(filter) = machine {
-            if m != filter {
-                continue;
-            }
+/// Appends `(machine, resource, type, status)` for every security-relevant
+/// entry in one machine's lock.
+fn push_security_resources(
+    m: &str,
+    lock: &types::StateLock,
+    items: &mut Vec<(String, String, String, String)>,
+) {
+    for (rname, rlock) in &lock.resources {
+        if is_security_relevant(&rlock.resource_type) {
+            items.push((
+                m.to_string(),
+                rname.clone(),
+                format!("{:?}", rlock.resource_type),
+                format!("{:?}", rlock.status),
+            ));
+        }
+    }
+}
+
+/// Security-relevant resources across the selected machines. A machine with no
+/// lock, or a lock that will not parse, contributes nothing.
+fn collect_security_resources(
+    state_dir: &Path,
+    machines: &[String],
+    machine: Option<&str>,
+) -> Vec<(String, String, String, String)> {
+    let mut items = Vec::new();
+    for m in machines {
+        if machine.is_some_and(|filter| m != filter) {
+            continue;
         }
         let lock_path = state_dir.join(m).join("state.lock.yaml");
         if !lock_path.exists() {
             continue;
         }
         let content = std::fs::read_to_string(&lock_path).unwrap_or_default();
-        if let Ok(lock) = serde_yaml_ng::from_str::<crate::core::types::StateLock>(&content) {
-            for (rname, rlock) in &lock.resources {
-                let rtype = format!("{:?}", rlock.resource_type);
-                // Security-relevant types: file, user, network, service
-                let is_security = matches!(
-                    rlock.resource_type,
-                    crate::core::types::ResourceType::File
-                        | crate::core::types::ResourceType::User
-                        | crate::core::types::ResourceType::Network
-                        | crate::core::types::ResourceType::Service
-                );
-                if is_security {
-                    let status = format!("{:?}", rlock.status);
-                    items.push((m.clone(), rname.clone(), rtype, status));
-                }
-            }
+        if let Ok(lock) = serde_yaml_ng::from_str::<types::StateLock>(&content) {
+            push_security_resources(m, &lock, &mut items);
         }
     }
+    items
+}
 
+/// Renders the security posture as JSON, as a per-resource listing, or as the
+/// "nothing relevant" line.
+fn print_security_posture(items: &[(String, String, String, String)], json: bool) {
     if json {
         let json_items: Vec<String> = items
             .iter()
@@ -256,11 +275,44 @@ pub(crate) fn cmd_status_security_posture(
         println!("No security-relevant resources found");
     } else {
         println!("Security posture ({} resources):", items.len());
-        for (m, r, t, s) in &items {
+        for (m, r, t, s) in items {
             println!("  {m}:{r} ({t}) — {s}");
         }
     }
+}
+
+/// FJ-602: Show security-relevant resource states (modes, ownership).
+pub(crate) fn cmd_status_security_posture(
+    state_dir: &Path,
+    machine: Option<&str>,
+    json: bool,
+) -> Result<(), String> {
+    let machines = discover_machines(state_dir);
+    let items = collect_security_resources(state_dir, &machines, machine);
+    print_security_posture(&items, json);
     Ok(())
+}
+
+/// One audit row — `(machine, resource, status, timestamp)` — from a single
+/// event-log line. `None` for a blank line or one that is not JSON; a field the
+/// event omits reads as "unknown" rather than dropping the row.
+fn audit_entry_from_line(m: &str, line: &str) -> Option<(String, String, String, String)> {
+    if line.trim().is_empty() {
+        return None;
+    }
+    let val = serde_json::from_str::<serde_json::Value>(line).ok()?;
+    let field = |key: &str| {
+        val.get(key)
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown")
+            .to_string()
+    };
+    Some((
+        m.to_string(),
+        field("resource"),
+        field("status"),
+        field("timestamp"),
+    ))
 }
 
 /// FJ-552: Full audit trail from event logs — who/what/when for each change.
@@ -271,39 +323,19 @@ fn collect_audit_entries(
 ) -> Vec<(String, String, String, String)> {
     let mut entries = Vec::new();
     for m in machines {
-        if let Some(filter) = machine {
-            if m != filter {
-                continue;
-            }
+        if machine.is_some_and(|filter| m != filter) {
+            continue;
         }
         let log_path = state_dir.join(format!("{m}.events.jsonl"));
         if !log_path.exists() {
             continue;
         }
         let content = std::fs::read_to_string(&log_path).unwrap_or_default();
-        for line in content.lines() {
-            if line.trim().is_empty() {
-                continue;
-            }
-            if let Ok(val) = serde_json::from_str::<serde_json::Value>(line) {
-                let resource = val
-                    .get("resource")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("unknown")
-                    .to_string();
-                let status = val
-                    .get("status")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("unknown")
-                    .to_string();
-                let timestamp = val
-                    .get("timestamp")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("unknown")
-                    .to_string();
-                entries.push((m.clone(), resource, status, timestamp));
-            }
-        }
+        entries.extend(
+            content
+                .lines()
+                .filter_map(|line| audit_entry_from_line(m, line)),
+        );
     }
     entries
 }

--- a/src/cli/status_convergence.rs
+++ b/src/cli/status_convergence.rs
@@ -244,12 +244,14 @@ fn summary_dimension_key(
     }
 }
 
-pub(crate) fn cmd_status_summary_by(
+/// Groups every locked resource under the state dir by the requested dimension,
+/// honouring the optional single-machine filter. The map is ordered, so the
+/// grouping is stable from run to run.
+fn group_resources_by_dimension(
     state_dir: &Path,
     machine_filter: Option<&str>,
     dimension: &str,
-    json: bool,
-) -> Result<(), String> {
+) -> Result<std::collections::BTreeMap<String, Vec<String>>, String> {
     let entries =
         std::fs::read_dir(state_dir).map_err(|e| format!("cannot read state dir: {e}"))?;
 
@@ -258,21 +260,42 @@ pub(crate) fn cmd_status_summary_by(
 
     for entry in entries.flatten() {
         let name = entry.file_name().to_string_lossy().to_string();
-        if let Some(filter) = machine_filter {
-            if name != filter {
-                continue;
-            }
+        if machine_filter.is_some_and(|filter| name != filter) {
+            continue;
         }
         if !entry.path().is_dir() {
             continue;
         }
-        if let Some(lock) = state::load_lock(state_dir, &name)? {
-            for (id, rl) in &lock.resources {
-                let key = summary_dimension_key(dimension, &lock, rl)?;
-                groups.entry(key).or_default().push(id.clone());
-            }
+        let Some(lock) = state::load_lock(state_dir, &name)? else {
+            continue;
+        };
+        for (id, rl) in &lock.resources {
+            let key = summary_dimension_key(dimension, &lock, rl)?;
+            groups.entry(key).or_default().push(id.clone());
         }
     }
+
+    Ok(groups)
+}
+
+/// The human rendering: one headed block per group, its resources beneath it.
+fn print_summary_groups(dimension: &str, groups: &std::collections::BTreeMap<String, Vec<String>>) {
+    println!("Summary by {}:\n", bold(dimension));
+    for (group, resources) in groups {
+        println!("  {} ({}):", bold(group), resources.len());
+        for r in resources {
+            println!("    {r}");
+        }
+    }
+}
+
+pub(crate) fn cmd_status_summary_by(
+    state_dir: &Path,
+    machine_filter: Option<&str>,
+    dimension: &str,
+    json: bool,
+) -> Result<(), String> {
+    let groups = group_resources_by_dimension(state_dir, machine_filter, dimension)?;
 
     if json {
         println!(
@@ -280,13 +303,7 @@ pub(crate) fn cmd_status_summary_by(
             serde_json::to_string_pretty(&groups).unwrap_or_else(|_| "{}".to_string())
         );
     } else {
-        println!("Summary by {}:\n", bold(dimension));
-        for (group, resources) in &groups {
-            println!("  {} ({}):", bold(group), resources.len());
-            for r in resources {
-                println!("    {r}");
-            }
-        }
+        print_summary_groups(dimension, &groups);
     }
 
     Ok(())

--- a/src/cli/status_health.rs
+++ b/src/cli/status_health.rs
@@ -99,6 +99,26 @@ fn is_lock_stale(lock_path: &Path, cutoff: std::time::SystemTime) -> bool {
         .unwrap_or(false)
 }
 
+/// One `(machine, resource, detail)` row per resource in a lock that has been
+/// judged stale. Staleness is a property of the lock file's mtime, so every
+/// resource it records is reported.
+fn stale_rows_from_lock(
+    name: &str,
+    lock: &types::StateLock,
+    days: u64,
+) -> Vec<(String, String, serde_json::Value)> {
+    lock.resources
+        .iter()
+        .map(|(resource_id, resource_state)| {
+            let val = serde_json::json!({
+                "machine": name, "resource": resource_id,
+                "last_applied": resource_state.applied_at, "days_stale": days,
+            });
+            (name.to_string(), resource_id.clone(), val)
+        })
+        .collect()
+}
+
 /// FJ-336: Show resources not updated in N days.
 fn collect_stale_by_days(
     state_dir: &Path,
@@ -110,13 +130,7 @@ fn collect_stale_by_days(
         .map_err(|e| format!("cannot read state dir {}: {}", state_dir.display(), e))?;
     let mut result = Vec::new();
     for entry in entries.flatten() {
-        let name = entry.file_name().to_string_lossy().to_string();
-        if let Some(filter) = machine_filter {
-            if name != filter {
-                continue;
-            }
-        }
-        if !entry.path().is_dir() {
+        if !is_matching_machine(&entry, machine_filter) {
             continue;
         }
         let lock_path = entry.path().join("state.lock.yaml");
@@ -126,13 +140,8 @@ fn collect_stale_by_days(
         let content = std::fs::read_to_string(&lock_path)
             .map_err(|e| format!("cannot read {}: {}", lock_path.display(), e))?;
         if let Ok(lock) = serde_yaml_ng::from_str::<types::StateLock>(&content) {
-            for (resource_id, resource_state) in &lock.resources {
-                let val = serde_json::json!({
-                    "machine": name, "resource": resource_id,
-                    "last_applied": resource_state.applied_at, "days_stale": days,
-                });
-                result.push((name.clone(), resource_id.clone(), val));
-            }
+            let name = entry.file_name().to_string_lossy().to_string();
+            result.extend(stale_rows_from_lock(&name, &lock, days));
         }
     }
     Ok(result)

--- a/src/cli/status_observability.rs
+++ b/src/cli/status_observability.rs
@@ -58,6 +58,41 @@ pub(crate) fn cmd_status_prometheus(
 
 // ── FJ-442: status --export ──
 
+/// The machine a directory entry stands for, or `None` when it is not one to
+/// export: plain files, dot-directories, and machines the filter excludes all
+/// fall out here.
+fn exportable_machine_name(entry: &std::fs::DirEntry, machine: Option<&str>) -> Option<String> {
+    let path = entry.path();
+    if !path.is_dir() {
+        return None;
+    }
+    let m_name = path
+        .file_name()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_string();
+    if m_name.starts_with('.') {
+        return None;
+    }
+    if machine.is_some_and(|filter| m_name != filter) {
+        return None;
+    }
+    Some(m_name)
+}
+
+/// One JSON object per resource recorded in a machine's lock.
+fn export_rows_from_lock(m_name: &str, lock: &types::StateLock) -> Vec<String> {
+    lock.resources
+        .iter()
+        .map(|(rname, rl)| {
+            format!(
+                "{{\"machine\":\"{}\",\"resource\":\"{}\",\"status\":\"{:?}\",\"hash\":\"{}\"}}",
+                m_name, rname, rl.status, rl.hash
+            )
+        })
+        .collect()
+}
+
 fn collect_export_entries(state_dir: &Path, machine: Option<&str>) -> Result<Vec<String>, String> {
     let mut entries = Vec::new();
     if !state_dir.exists() {
@@ -65,30 +100,11 @@ fn collect_export_entries(state_dir: &Path, machine: Option<&str>) -> Result<Vec
     }
     let dir_entries = std::fs::read_dir(state_dir).map_err(|e| e.to_string())?;
     for entry in dir_entries.flatten() {
-        let path = entry.path();
-        if !path.is_dir() {
+        let Some(m_name) = exportable_machine_name(&entry, machine) else {
             continue;
-        }
-        let m_name = path
-            .file_name()
-            .unwrap_or_default()
-            .to_string_lossy()
-            .to_string();
-        if m_name.starts_with('.') {
-            continue;
-        }
-        if let Some(filter) = machine {
-            if m_name != filter {
-                continue;
-            }
-        }
+        };
         if let Ok(Some(lock)) = state::load_lock(state_dir, &m_name) {
-            for (rname, rl) in &lock.resources {
-                entries.push(format!(
-                    "{{\"machine\":\"{}\",\"resource\":\"{}\",\"status\":\"{:?}\",\"hash\":\"{}\"}}",
-                    m_name, rname, rl.status, rl.hash
-                ));
-            }
+            entries.extend(export_rows_from_lock(&m_name, &lock));
         }
     }
     Ok(entries)

--- a/src/cli/status_queries.rs
+++ b/src/cli/status_queries.rs
@@ -165,6 +165,22 @@ fn build_compact_line(m_name: &str, lock: &types::StateLock, json: bool) -> Stri
     }
 }
 
+/// The machine directories a status walk should report on: real directories,
+/// no dotfiles, narrowed to `--machine` when one was given.
+fn selected_machine_dirs(state_dir: &Path, machine: Option<&str>) -> Result<Vec<String>, String> {
+    let entries = std::fs::read_dir(state_dir).map_err(|e| e.to_string())?;
+    Ok(entries
+        .flatten()
+        .filter(|entry| entry.path().is_dir())
+        .map(|entry| entry.file_name().to_string_lossy().to_string())
+        .filter(|name| !name.starts_with('.'))
+        .filter(|name| match machine {
+            Some(filter) => name == filter,
+            None => true,
+        })
+        .collect())
+}
+
 pub(crate) fn cmd_status_compact(
     state_dir: &Path,
     machine: Option<&str>,
@@ -174,30 +190,15 @@ pub(crate) fn cmd_status_compact(
         println!("No state directory found.");
         return Ok(());
     }
-    let entries = std::fs::read_dir(state_dir).map_err(|e| e.to_string())?;
-    let mut lines = Vec::new();
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if !path.is_dir() {
-            continue;
-        }
-        let m_name = path
-            .file_name()
-            .unwrap_or_default()
-            .to_string_lossy()
-            .to_string();
-        if m_name.starts_with('.') {
-            continue;
-        }
-        if let Some(filter) = machine {
-            if m_name != filter {
-                continue;
-            }
-        }
-        if let Ok(Some(lock)) = state::load_lock(state_dir, &m_name) {
-            lines.push(build_compact_line(&m_name, &lock, json));
-        }
-    }
+
+    let lines: Vec<String> = selected_machine_dirs(state_dir, machine)?
+        .into_iter()
+        .filter_map(|m_name| match state::load_lock(state_dir, &m_name) {
+            Ok(Some(lock)) => Some(build_compact_line(&m_name, &lock, json)),
+            _ => None,
+        })
+        .collect();
+
     for line in &lines {
         println!("{line}");
     }

--- a/src/cli/status_transport.rs
+++ b/src/cli/status_transport.rs
@@ -3,61 +3,97 @@
 use std::collections::BTreeMap;
 use std::path::Path;
 
-/// FJ-1029: `status --machine-ssh-connection-health`
-pub(crate) fn cmd_status_machine_ssh_connection_health(
+/// The value of a top-level `key: value` line in a lock file, unquoted.
+/// `None` when the lock does not carry that key at all.
+fn lock_scalar(content: &str, key: &str) -> Option<String> {
+    content.lines().find(|l| l.starts_with(key)).map(|l| {
+        l.trim_start_matches(key)
+            .trim()
+            .trim_matches('"')
+            .to_string()
+    })
+}
+
+/// What every lock walk prints when the state directory cannot be read at all —
+/// an empty JSON object, or the plain "nothing here" line.
+fn print_no_machine_state(json: bool) {
+    if json {
+        println!("{{}}");
+    } else {
+        println!("  No machine state found.");
+    }
+}
+
+/// Walks the state directory, honouring `--machine`, and summarises every
+/// machine that has a `state.lock.yaml` with `summarise`, which is handed the
+/// lock's path and its contents. `None` when the state directory itself cannot
+/// be read — distinct from an empty map, which means "readable, but no locks".
+fn summarise_machine_locks(
     state_dir: &Path,
     machine: Option<&str>,
-    json: bool,
-) -> Result<(), String> {
-    // Read state lock files from state_dir/{machine}/state.lock.yaml
-    // Report SSH connection health (latency estimates based on lock timestamps)
-    let mut results: BTreeMap<String, serde_json::Value> = BTreeMap::new();
+    summarise: impl Fn(&Path, &str) -> serde_json::Value,
+) -> Option<BTreeMap<String, serde_json::Value>> {
+    let entries = std::fs::read_dir(state_dir).ok()?;
 
-    let Ok(entries) = std::fs::read_dir(state_dir) else {
-        if json {
-            println!("{{}}");
-        } else {
-            println!("  No machine state found.");
-        }
-        return Ok(());
-    };
+    let mut results: BTreeMap<String, serde_json::Value> = BTreeMap::new();
     for entry in entries.flatten() {
         let name = entry.file_name().to_string_lossy().to_string();
-        if let Some(filter) = machine {
-            if name != filter {
-                continue;
-            }
+        if machine.is_some_and(|filter| name != filter) {
+            continue;
         }
         let lock_path = entry.path().join("state.lock.yaml");
         if !lock_path.exists() {
             continue;
         }
         let content = std::fs::read_to_string(&lock_path).unwrap_or_default();
-        let connected = content.contains("generated_at:");
-        let generator = content
-            .lines()
-            .find(|l| l.starts_with("generator:"))
-            .map(|l| {
-                l.trim_start_matches("generator:")
-                    .trim()
-                    .trim_matches('"')
-                    .to_string()
-            })
-            .unwrap_or_else(|| "unknown".to_string());
-        let transport = if generator.contains("ssh") || content.contains("ssh") {
-            "ssh"
-        } else {
-            "local"
-        };
-        results.insert(
-            name,
-            serde_json::json!({
-                "connected": connected,
-                "transport": transport,
-                "healthy": connected,
-            }),
-        );
+        results.insert(name, summarise(&lock_path, &content));
     }
+    Some(results)
+}
+
+/// One machine's SSH connection health, inferred from its lock file: a lock
+/// that was generated at all proves the machine was reachable.
+fn ssh_connection_health(content: &str) -> serde_json::Value {
+    let connected = content.contains("generated_at:");
+    let generator = lock_scalar(content, "generator:").unwrap_or_else(|| "unknown".to_string());
+    let transport = if generator.contains("ssh") || content.contains("ssh") {
+        "ssh"
+    } else {
+        "local"
+    };
+    serde_json::json!({
+        "connected": connected,
+        "transport": transport,
+        "healthy": connected,
+    })
+}
+
+/// The human rendering of the SSH connection health report.
+fn print_ssh_health_text(results: &BTreeMap<String, serde_json::Value>) {
+    println!("=== Machine SSH Connection Health ===");
+    if results.is_empty() {
+        println!("  No machine state found.");
+    }
+    for (m, info) in results {
+        let healthy = info["healthy"].as_bool().unwrap_or(false);
+        let transport = info["transport"].as_str().unwrap_or("unknown");
+        let symbol = if healthy { "✓" } else { "✗" };
+        println!("  {symbol} {m}: transport={transport}, healthy={healthy}");
+    }
+}
+
+/// FJ-1029: `status --machine-ssh-connection-health`
+pub(crate) fn cmd_status_machine_ssh_connection_health(
+    state_dir: &Path,
+    machine: Option<&str>,
+    json: bool,
+) -> Result<(), String> {
+    let Some(results) = summarise_machine_locks(state_dir, machine, |_lock_path, content| {
+        ssh_connection_health(content)
+    }) else {
+        print_no_machine_state(json);
+        return Ok(());
+    };
 
     if json {
         println!(
@@ -68,18 +104,42 @@ pub(crate) fn cmd_status_machine_ssh_connection_health(
             .unwrap_or_default()
         );
     } else {
-        println!("=== Machine SSH Connection Health ===");
-        if results.is_empty() {
-            println!("  No machine state found.");
-        }
-        for (m, info) in &results {
-            let healthy = info["healthy"].as_bool().unwrap_or(false);
-            let transport = info["transport"].as_str().unwrap_or("unknown");
-            let symbol = if healthy { "✓" } else { "✗" };
-            println!("  {symbol} {m}: transport={transport}, healthy={healthy}");
-        }
+        print_ssh_health_text(&results);
     }
     Ok(())
+}
+
+/// One lock file's staleness facts: when it was generated, how much it records,
+/// and how big it is. A lock with no `generated_at` is treated as stale.
+fn lock_staleness(lock_path: &Path, content: &str) -> serde_json::Value {
+    let generated_at = lock_scalar(content, "generated_at:").unwrap_or_default();
+    let resource_count = content
+        .lines()
+        .filter(|l| l.starts_with("  ") && l.contains("type:"))
+        .count();
+    let file_size = std::fs::metadata(lock_path).map(|m| m.len()).unwrap_or(0);
+    serde_json::json!({
+        "generated_at": generated_at,
+        "resource_count": resource_count,
+        "file_size_bytes": file_size,
+        "stale": generated_at.is_empty(),
+    })
+}
+
+/// The human rendering of the lock file staleness report.
+fn print_staleness_text(results: &BTreeMap<String, serde_json::Value>) {
+    println!("=== Lock File Staleness Report ===");
+    if results.is_empty() {
+        println!("  No lock files found.");
+    }
+    for (m, info) in results {
+        let generated = info["generated_at"].as_str().unwrap_or("unknown");
+        let count = info["resource_count"].as_u64().unwrap_or(0);
+        let size = info["file_size_bytes"].as_u64().unwrap_or(0);
+        let stale = info["stale"].as_bool().unwrap_or(true);
+        let marker = if stale { " [STALE]" } else { "" };
+        println!("  {m}: generated={generated}, resources={count}, size={size}B{marker}");
+    }
 }
 
 /// FJ-1032: `status --lock-file-staleness-report`
@@ -88,53 +148,10 @@ pub(crate) fn cmd_status_lock_file_staleness_report(
     machine: Option<&str>,
     json: bool,
 ) -> Result<(), String> {
-    let mut results: BTreeMap<String, serde_json::Value> = BTreeMap::new();
-
-    let Ok(entries) = std::fs::read_dir(state_dir) else {
-        if json {
-            println!("{{}}");
-        } else {
-            println!("  No machine state found.");
-        }
+    let Some(results) = summarise_machine_locks(state_dir, machine, lock_staleness) else {
+        print_no_machine_state(json);
         return Ok(());
     };
-    for entry in entries.flatten() {
-        let name = entry.file_name().to_string_lossy().to_string();
-        if let Some(filter) = machine {
-            if name != filter {
-                continue;
-            }
-        }
-        let lock_path = entry.path().join("state.lock.yaml");
-        if !lock_path.exists() {
-            continue;
-        }
-        let content = std::fs::read_to_string(&lock_path).unwrap_or_default();
-        let generated_at = content
-            .lines()
-            .find(|l| l.starts_with("generated_at:"))
-            .map(|l| {
-                l.trim_start_matches("generated_at:")
-                    .trim()
-                    .trim_matches('"')
-                    .to_string()
-            })
-            .unwrap_or_default();
-        let resource_count = content
-            .lines()
-            .filter(|l| l.starts_with("  ") && l.contains("type:"))
-            .count();
-        let file_size = std::fs::metadata(&lock_path).map(|m| m.len()).unwrap_or(0);
-        results.insert(
-            name,
-            serde_json::json!({
-                "generated_at": generated_at,
-                "resource_count": resource_count,
-                "file_size_bytes": file_size,
-                "stale": generated_at.is_empty(),
-            }),
-        );
-    }
 
     if json {
         println!(
@@ -145,18 +162,7 @@ pub(crate) fn cmd_status_lock_file_staleness_report(
             .unwrap_or_default()
         );
     } else {
-        println!("=== Lock File Staleness Report ===");
-        if results.is_empty() {
-            println!("  No lock files found.");
-        }
-        for (m, info) in &results {
-            let generated = info["generated_at"].as_str().unwrap_or("unknown");
-            let count = info["resource_count"].as_u64().unwrap_or(0);
-            let size = info["file_size_bytes"].as_u64().unwrap_or(0);
-            let stale = info["stale"].as_bool().unwrap_or(true);
-            let marker = if stale { " [STALE]" } else { "" };
-            println!("  {m}: generated={generated}, resources={count}, size={size}B{marker}");
-        }
+        print_staleness_text(&results);
     }
     Ok(())
 }

--- a/src/cli/validate_analytics.rs
+++ b/src/cli/validate_analytics.rs
@@ -302,6 +302,13 @@ struct ConsolidationOpportunity {
     reason: String,
 }
 
+/// Only same-type resources placed on different machines are candidates for
+/// consolidation — merging two resources that already share a machine, or that
+/// are not the same kind of thing, is not an opportunity.
+fn pair_is_consolidatable(res_a: &types::Resource, res_b: &types::Resource) -> bool {
+    res_a.resource_type == res_b.resource_type && on_different_machines(res_a, res_b)
+}
+
 /// Find consolidation opportunities across resources of the same type on
 /// different machines.
 fn find_consolidation_opportunities(config: &types::ForjarConfig) -> Vec<ConsolidationOpportunity> {
@@ -314,10 +321,7 @@ fn find_consolidation_opportunities(config: &types::ForjarConfig) -> Vec<Consoli
             let (name_a, res_a) = entries[i];
             let (name_b, res_b) = entries[j];
 
-            if res_a.resource_type != res_b.resource_type {
-                continue;
-            }
-            if !on_different_machines(res_a, res_b) {
+            if !pair_is_consolidatable(res_a, res_b) {
                 continue;
             }
 

--- a/src/cli/validate_core.rs
+++ b/src/cli/validate_core.rs
@@ -114,71 +114,72 @@ pub(crate) fn validation_failure_json(file: &Path, errors: &[String]) -> String 
         .unwrap_or_else(|_| r#"{"valid":false,"errors":["<unserialisable>"]}"#.to_string())
 }
 
-pub(crate) fn cmd_validate(
+/// Parses the config, first emitting the structured failure document when
+/// `--json` is set.
+///
+/// EMIT JSON ON THE FAILURE PATH TOO.
+///
+/// This was `parse_and_validate(file)?`, which returns before the reporting
+/// step is ever reached — so `validate --json` emitted ZERO bytes on stdout for
+/// an invalid config and printed a plain-text error instead. That is the one
+/// case a machine consumer needs the structured errors: a conforming config
+/// tells it nothing it did not already assume. Ledger id
+/// validate-json-emits-non-json-on-failure, confirmed at 1.12.3, still live at
+/// 1.16.0.
+///
+/// The error is still returned, so the human-facing behaviour and the exit code
+/// are unchanged.
+fn parse_for_validate(file: &Path, json: bool) -> Result<types::ForjarConfig, String> {
+    parse_and_validate(file).inspect_err(|e| {
+        if json {
+            println!("{}", validation_failure_json(file, std::slice::from_ref(e)));
+        }
+    })
+}
+
+/// Always detect circular dependencies — a cycle makes the config unusable.
+fn check_no_dependency_cycle(
     file: &Path,
+    config: &types::ForjarConfig,
+    json: bool,
+) -> Result<(), String> {
+    let Err(e) = resolver::build_execution_order(config) else {
+        return Ok(());
+    };
+    let msg = format!("dependency cycle: {e}");
+    if json {
+        println!(
+            "{}",
+            validation_failure_json(file, std::slice::from_ref(&msg))
+        );
+    }
+    Err(msg)
+}
+
+/// FJ-330: Show fully expanded config after template resolution.
+fn print_expanded_config(config: &types::ForjarConfig) -> Result<(), String> {
+    let mut expanded = config.clone();
+    for (_id, resource) in expanded.resources.iter_mut() {
+        *resource =
+            resolver::resolve_resource_templates(resource, &expanded.params, &expanded.machines)?;
+    }
+    let yaml =
+        serde_yaml_ng::to_string(&expanded).map_err(|e| format!("serialization error: {e}"))?;
+    println!("{yaml}");
+    Ok(())
+}
+
+/// Reports the outcome of a validation run: the machine-readable document under
+/// `--json`, the errors on stderr otherwise. Errors make the command fail in
+/// both modes, after the report has been emitted.
+fn report_validation(
+    config: &types::ForjarConfig,
     strict: bool,
     json: bool,
-    dry_expand: bool,
+    errors: &[String],
 ) -> Result<(), String> {
-    // EMIT JSON ON THE FAILURE PATH TOO.
-    //
-    // This was `parse_and_validate(file)?`, which returns before the `if json`
-    // block below is ever reached — so `validate --json` emitted ZERO bytes on
-    // stdout for an invalid config and printed a plain-text error instead. That
-    // is the one case a machine consumer needs the structured errors: a
-    // conforming config tells it nothing it did not already assume. Ledger id
-    // validate-json-emits-non-json-on-failure, confirmed at 1.12.3, still live
-    // at 1.16.0.
-    //
-    // `?` is kept for the non-json path so the human-facing behaviour and exit
-    // code are unchanged.
-    let config = match parse_and_validate(file) {
-        Ok(c) => c,
-        Err(e) if json => {
-            println!(
-                "{}",
-                validation_failure_json(file, std::slice::from_ref(&e))
-            );
-            return Err(e);
-        }
-        Err(e) => return Err(e),
-    };
-
-    // Always detect circular dependencies — a cycle makes the config unusable
-    if let Err(e) = resolver::build_execution_order(&config) {
-        let msg = format!("dependency cycle: {e}");
-        if json {
-            println!(
-                "{}",
-                validation_failure_json(file, std::slice::from_ref(&msg))
-            );
-        }
-        return Err(msg);
-    }
-
-    // FJ-330: Show fully expanded config after template resolution
-    if dry_expand {
-        let mut expanded = config.clone();
-        for (_id, resource) in expanded.resources.iter_mut() {
-            *resource = resolver::resolve_resource_templates(
-                resource,
-                &expanded.params,
-                &expanded.machines,
-            )?;
-        }
-        let yaml =
-            serde_yaml_ng::to_string(&expanded).map_err(|e| format!("serialization error: {e}"))?;
-        println!("{yaml}");
-        return Ok(());
-    }
-
-    let errors = if strict {
-        run_strict_checks(&config)
-    } else {
-        Vec::new()
-    };
-
     let valid = errors.is_empty();
+    let failure = || format!("strict validation failed: {} error(s)", errors.len());
 
     if json {
         let output = serde_json::json!({
@@ -193,22 +194,17 @@ pub(crate) fn cmd_validate(
             "{}",
             serde_json::to_string_pretty(&output).map_err(|e| format!("JSON error: {e}"))?
         );
-        if !valid {
-            return Err(format!(
-                "strict validation failed: {} error(s)",
-                errors.len()
-            ));
+    } else if !valid {
+        for e in errors {
+            eprintln!("  {}", red(e));
         }
-    } else {
-        if !valid {
-            for e in &errors {
-                eprintln!("  {}", red(e));
-            }
-            return Err(format!(
-                "strict validation failed: {} error(s)",
-                errors.len()
-            ));
-        }
+    }
+
+    if !valid {
+        return Err(failure());
+    }
+
+    if !json {
         println!(
             "OK: {} ({} machines, {} resources)",
             config.name,
@@ -216,8 +212,28 @@ pub(crate) fn cmd_validate(
             config.resources.len()
         );
     }
-
     Ok(())
+}
+
+pub(crate) fn cmd_validate(
+    file: &Path,
+    strict: bool,
+    json: bool,
+    dry_expand: bool,
+) -> Result<(), String> {
+    let config = parse_for_validate(file, json)?;
+    check_no_dependency_cycle(file, &config, json)?;
+
+    if dry_expand {
+        return print_expanded_config(&config);
+    }
+
+    let errors = if strict {
+        run_strict_checks(&config)
+    } else {
+        Vec::new()
+    };
+    report_validation(&config, strict, json, &errors)
 }
 
 // ── FJ-391: validate --exhaustive ──

--- a/src/cli/validate_ordering_b.rs
+++ b/src/cli/validate_ordering_b.rs
@@ -178,6 +178,48 @@ pub(crate) fn cmd_validate_check_resource_machine_balance(
     Ok(())
 }
 
+/// The `{{...}}` placeholders in a resource's content, in the order they
+/// appear. An unterminated `{{` ends the scan — nothing after it can close.
+fn template_placeholders(content: &str) -> Vec<&str> {
+    let mut vars = Vec::new();
+    let mut rest = content;
+    while let Some(start) = rest.find("{{") {
+        rest = &rest[start + 2..];
+        let Some(end) = rest.find("}}") else {
+            break;
+        };
+        vars.push(&rest[..end]);
+        rest = &rest[end + 2..];
+    }
+    vars
+}
+
+/// A placeholder that names a param: bare alphanumerics and underscores only,
+/// so anything with an expression or a path in it is left alone.
+fn is_param_placeholder(var: &str) -> bool {
+    var.chars().all(|c| c.is_alphanumeric() || c == '_')
+}
+
+/// One warning per `{{param}}` a resource references that the config never
+/// declares.
+fn undeclared_param_warnings(
+    config: &types::ForjarConfig,
+    declared_params: &std::collections::HashSet<String>,
+) -> Vec<(String, String)> {
+    let mut warnings: Vec<(String, String)> = Vec::new();
+    for (name, res) in &config.resources {
+        let Some(ref content) = res.content else {
+            continue;
+        };
+        for var in template_placeholders(content) {
+            if is_param_placeholder(var) && !declared_params.contains(var) {
+                warnings.push((name.clone(), format!("references undeclared param '{var}'")));
+            }
+        }
+    }
+    warnings
+}
+
 /// FJ-973: Validate environment variable references match declared params.
 pub(crate) fn cmd_validate_check_resource_env_consistency(
     file: &Path,
@@ -188,27 +230,7 @@ pub(crate) fn cmd_validate_check_resource_env_consistency(
         serde_yaml_ng::from_str(&content).map_err(|e| e.to_string())?;
     let declared_params: std::collections::HashSet<String> =
         config.params.keys().cloned().collect();
-    let mut warnings: Vec<(String, String)> = Vec::new();
-    for (name, res) in &config.resources {
-        if let Some(ref c) = res.content {
-            let mut rest = c.as_str();
-            while let Some(start) = rest.find("{{") {
-                rest = &rest[start + 2..];
-                if let Some(end) = rest.find("}}") {
-                    let var = &rest[..end];
-                    if var.chars().all(|c| c.is_alphanumeric() || c == '_')
-                        && !declared_params.contains(var)
-                    {
-                        warnings
-                            .push((name.clone(), format!("references undeclared param '{var}'")));
-                    }
-                    rest = &rest[end + 2..];
-                } else {
-                    break;
-                }
-            }
-        }
-    }
+    let warnings = undeclared_param_warnings(&config, &declared_params);
     if json {
         let items: Vec<String> = warnings
             .iter()

--- a/src/cli/validate_paths_b.rs
+++ b/src/cli/validate_paths_b.rs
@@ -17,33 +17,28 @@ pub(super) fn find_mount_conflicts(mount_paths: &[(String, String)]) -> Vec<(Str
     conflicts
 }
 
-/// Validate a cron field token against min/max range.
-fn validate_cron_field(field: &str, min: u32, max: u32) -> bool {
-    if field == "*" {
+/// One comma-separated token of a cron field, with any `/step` suffix already
+/// stripped: a wildcard, an `a-b` range inside `min..=max`, or a plain number
+/// inside `min..=max`.
+fn is_valid_cron_token(token: &str, min: u32, max: u32) -> bool {
+    if token == "*" {
         return true;
     }
-    for part in field.split(',') {
-        let part = part.split('/').next().unwrap_or(part);
-        if part == "*" {
-            continue;
-        }
-        if let Some((a, b)) = part.split_once('-') {
-            let (Ok(a), Ok(b)) = (a.parse::<u32>(), b.parse::<u32>()) else {
-                return false;
-            };
-            if a < min || b > max || a > b {
-                return false;
-            }
-        } else {
-            let Ok(v) = part.parse::<u32>() else {
-                return false;
-            };
-            if v < min || v > max {
-                return false;
-            }
-        }
+    if let Some((a, b)) = token.split_once('-') {
+        let (Ok(a), Ok(b)) = (a.parse::<u32>(), b.parse::<u32>()) else {
+            return false;
+        };
+        return a >= min && b <= max && a <= b;
     }
-    true
+    matches!(token.parse::<u32>(), Ok(v) if v >= min && v <= max)
+}
+
+/// Validate a cron field token against min/max range.
+fn validate_cron_field(field: &str, min: u32, max: u32) -> bool {
+    field.split(',').all(|part| {
+        // Only the base token is range-checked; the `/step` suffix is not.
+        is_valid_cron_token(part.split('/').next().unwrap_or(part), min, max)
+    })
 }
 
 /// FJ-731: Validate cron schedule expressions in resources.

--- a/src/cli/validate_security.rs
+++ b/src/cli/validate_security.rs
@@ -177,9 +177,26 @@ pub(crate) fn cmd_validate_check_resource_deprecation_usage(
 /// does NOT have a `when` condition, B will always be applied even when A
 /// is conditionally skipped. This is likely unintentional.
 fn find_when_condition_coverage_warnings(config: &types::ForjarConfig) -> Vec<(String, String)> {
-    let mut warnings = Vec::new();
+    let dependents_map = build_dependents_map(config);
 
-    // Build a map: resource -> list of its dependents (resources that depend on it).
+    let mut warnings = Vec::new();
+    for (name, resource) in &config.resources {
+        if resource.when.is_none() {
+            continue;
+        }
+        if let Some(dependents) = dependents_map.get(name) {
+            warn_unconditional_dependents(config, name, dependents, &mut warnings);
+        }
+    }
+    warnings.sort_by(|a, b| a.0.cmp(&b.0));
+    warnings
+}
+
+/// The reverse of `depends_on`: for each resource, the resources that name it
+/// as a dependency.
+fn build_dependents_map(
+    config: &types::ForjarConfig,
+) -> std::collections::HashMap<String, Vec<String>> {
     let mut dependents_map: std::collections::HashMap<String, Vec<String>> =
         std::collections::HashMap::new();
     for (name, resource) in &config.resources {
@@ -190,33 +207,30 @@ fn find_when_condition_coverage_warnings(config: &types::ForjarConfig) -> Vec<(S
                 .push(name.clone());
         }
     }
+    dependents_map
+}
 
-    // For each resource with a `when` condition, check its dependents.
-    for (name, resource) in &config.resources {
-        if resource.when.is_none() {
+/// Warns for every dependent of `name` that carries no `when` condition of its
+/// own, and so would still be applied on a run where `name` is skipped.
+fn warn_unconditional_dependents(
+    config: &types::ForjarConfig,
+    name: &str,
+    dependents: &[String],
+    warnings: &mut Vec<(String, String)>,
+) {
+    for dep_name in dependents {
+        let Some(dep_resource) = config.resources.get(dep_name) else {
             continue;
-        }
-        let dependents = match dependents_map.get(name) {
-            Some(deps) => deps,
-            None => continue,
         };
-        for dep_name in dependents {
-            let dep_resource = match config.resources.get(dep_name) {
-                Some(r) => r,
-                None => continue,
-            };
-            if dep_resource.when.is_none() {
-                warnings.push((
-                    dep_name.clone(),
-                    format!(
-                        "depends on '{name}' which has a when condition, but has no when condition itself"
-                    ),
-                ));
-            }
+        if dep_resource.when.is_none() {
+            warnings.push((
+                dep_name.clone(),
+                format!(
+                    "depends on '{name}' which has a when condition, but has no when condition itself"
+                ),
+            ));
         }
     }
-    warnings.sort_by(|a, b| a.0.cmp(&b.0));
-    warnings
 }
 
 /// FJ-1060: Check that dependents of conditional resources also have when conditions.

--- a/src/cli/validate_security_ext.rs
+++ b/src/cli/validate_security_ext.rs
@@ -19,33 +19,45 @@ fn build_adjacency(config: &types::ForjarConfig) -> HashMap<String, Vec<String>>
     adj
 }
 
+/// Queues `node`'s not-yet-seen dependencies for the BFS, stopping early and
+/// reporting `true` as soon as one of them is `start` — the walk has come back
+/// round to where it began.
+fn enqueue_dependencies(
+    node: &str,
+    start: &str,
+    adj: &HashMap<String, Vec<String>>,
+    visited: &mut HashSet<String>,
+    queue: &mut VecDeque<String>,
+) -> bool {
+    let Some(deps) = adj.get(node) else {
+        return false;
+    };
+    for dep in deps {
+        if dep == start {
+            return true;
+        }
+        if visited.insert(dep.clone()) {
+            queue.push_back(dep.clone());
+        }
+    }
+    false
+}
+
 /// Check if `start` appears in its own transitive dependency closure via BFS.
 fn has_cycle_from(start: &str, adj: &HashMap<String, Vec<String>>) -> Option<String> {
     let mut visited = HashSet::new();
     let mut queue = VecDeque::new();
-    // Seed with direct dependencies of start.
-    if let Some(deps) = adj.get(start) {
-        for dep in deps {
-            if dep == start {
-                return Some(format!("{start}->>{start}"));
-            }
-            if visited.insert(dep.clone()) {
-                queue.push_back(dep.clone());
-            }
-        }
+
+    // Seed with direct dependencies of start; a hit here is a self-loop.
+    if enqueue_dependencies(start, start, adj, &mut visited, &mut queue) {
+        return Some(format!("{start}->>{start}"));
     }
+
     while let Some(current) = queue.pop_front() {
-        if let Some(deps) = adj.get(&current) {
-            for dep in deps {
-                if dep == start {
-                    return Some(format!(
-                        "bidirectional path: {start}>>...>>{current}>>...>>{start}"
-                    ));
-                }
-                if visited.insert(dep.clone()) {
-                    queue.push_back(dep.clone());
-                }
-            }
+        if enqueue_dependencies(&current, start, adj, &mut visited, &mut queue) {
+            return Some(format!(
+                "bidirectional path: {start}>>...>>{current}>>...>>{start}"
+            ));
         }
     }
     None

--- a/src/core/dogfood/exercises.rs
+++ b/src/core/dogfood/exercises.rs
@@ -305,9 +305,105 @@ fn cron(t: &ResourceType) -> Outcome {
 /// SAFETY property rather than the happy path: a destination that does not
 /// match the source must leave the source alive. The happy path is proved too,
 /// because a guard that refuses everything would also pass the safety check.
-fn nas_archive(t: &ResourceType) -> Outcome {
-    use crate::core::types::{Resource, ResourceType as RT};
+/// A `nas-archive` resource declaring that `src`'s `payload` dir is archived to
+/// `dst`, with no minimum age so the exercise does not have to wait a day.
+fn declare_nas_archive(src: &Path, dst: &Path) -> crate::core::types::Resource {
+    let mut r = crate::core::types::Resource {
+        resource_type: ResourceType::NasArchive,
+        path: Some(src.to_string_lossy().to_string()),
+        ..Default::default()
+    };
+    r.archive.destination = Some(dst.to_string_lossy().to_string());
+    r.archive.dirs = vec!["payload".to_string()];
+    r.archive.min_age_days = Some(0);
+    r
+}
 
+/// Runs a generated archive script with deletion actually armed, returning its
+/// exit code and its combined stdout and stderr.
+fn run_archive_script(script: &str, dir: &Path) -> (i32, String) {
+    let f = dir.join("archive.sh");
+    let _ = fs::write(&f, script);
+    match Command::new("bash")
+        .arg(&f)
+        .env("ARCHIVE_EXECUTE", "1")
+        .output()
+    {
+        Ok(o) => {
+            let mut text = String::from_utf8_lossy(&o.stdout).to_string();
+            text.push_str(&String::from_utf8_lossy(&o.stderr));
+            (o.status.code().unwrap_or(-1), text)
+        }
+        Err(e) => (-1, e.to_string()),
+    }
+}
+
+/// The script `src` -> `dst` generates, or the outcome to report if the
+/// declaration is refused outright.
+fn nas_archive_script(t: &ResourceType, src: &Path, dst: &Path) -> Result<String, Outcome> {
+    let r = declare_nas_archive(src, dst);
+    match crate::resources::nas_archive::archive_of(&r) {
+        Ok(a) => Ok(crate::resources::nas_archive::archive_script(&a)),
+        Err(e) => Err(bad(t, format!("declaration refused: {e}"))),
+    }
+}
+
+/// Scenario A — a destination already holding a foreign tree must fail the
+/// pass, and above all must leave the source alive. `None` when the guard held.
+fn nas_archive_refuses_mismatch(t: &ResourceType, root: &Path) -> Option<Outcome> {
+    let (src, dst) = (root.join("a/src"), root.join("a/dst"));
+    let _ = fs::create_dir_all(src.join("payload"));
+    let _ = fs::create_dir_all(dst.join("payload"));
+    let _ = fs::write(src.join("payload/real.bin"), "x".repeat(100_000));
+    let _ = fs::write(dst.join("payload/intruder.bin"), "z".repeat(100_000));
+
+    let script = match nas_archive_script(t, &src, &dst) {
+        Ok(s) => s,
+        Err(outcome) => return Some(outcome),
+    };
+    let (code, out) = run_archive_script(&script, root);
+    if code == 0 {
+        return Some(bad(
+            t,
+            "a mismatched destination did NOT fail the archive pass",
+        ));
+    }
+    if !src.join("payload/real.bin").exists() {
+        return Some(bad(
+            t,
+            format!("THE SOURCE WAS DELETED after a failed verify:\n{out}"),
+        ));
+    }
+    None
+}
+
+/// Scenario B — a matching pass must still archive: the data lands at the
+/// destination and a symlink is left behind. Without this, scenario A would
+/// pass just as well for a guard that refuses everything.
+fn nas_archive_completes_matching_pass(t: &ResourceType, root: &Path) -> Option<Outcome> {
+    let (src, dst) = (root.join("b/src"), root.join("b/dst"));
+    let _ = fs::create_dir_all(src.join("payload"));
+    let _ = fs::create_dir_all(&dst);
+    let _ = fs::write(src.join("payload/real.bin"), "x".repeat(100_000));
+
+    let script = match nas_archive_script(t, &src, &dst) {
+        Ok(s) => s,
+        Err(outcome) => return Some(outcome),
+    };
+    let (code, out) = run_archive_script(&script, root);
+    if code != 0 {
+        return Some(bad(t, format!("a valid archive pass failed:\n{out}")));
+    }
+    if !dst.join("payload/real.bin").exists() {
+        return Some(bad(t, "the archived data is not at the destination"));
+    }
+    match fs::symlink_metadata(src.join("payload")) {
+        Ok(m) if m.file_type().is_symlink() => None,
+        _ => Some(bad(t, "no symlink was left at the old location")),
+    }
+}
+
+fn nas_archive(t: &ResourceType) -> Outcome {
     if Command::new("rsync").arg("--version").output().is_err() {
         return bad(
             t,
@@ -319,78 +415,11 @@ fn nas_archive(t: &ResourceType) -> Outcome {
         return bad(t, "could not create scratch dir");
     };
 
-    let declare = |src: &PathBuf, dst: &PathBuf| {
-        let mut r = Resource {
-            resource_type: RT::NasArchive,
-            path: Some(src.to_string_lossy().to_string()),
-            ..Default::default()
-        };
-        r.archive.destination = Some(dst.to_string_lossy().to_string());
-        r.archive.dirs = vec!["payload".to_string()];
-        r.archive.min_age_days = Some(0);
-        r
-    };
-    let run = |script: &str, dir: &PathBuf| -> (i32, String) {
-        let f = dir.join("archive.sh");
-        let _ = fs::write(&f, script);
-        match Command::new("bash")
-            .arg(&f)
-            .env("ARCHIVE_EXECUTE", "1")
-            .output()
-        {
-            Ok(o) => {
-                let mut text = String::from_utf8_lossy(&o.stdout).to_string();
-                text.push_str(&String::from_utf8_lossy(&o.stderr));
-                (o.status.code().unwrap_or(-1), text)
-            }
-            Err(e) => (-1, e.to_string()),
-        }
-    };
-
-    // ── A. a foreign tree at the destination must NOT lead to a delete ──────
-    let (src_a, dst_a) = (root.join("a/src"), root.join("a/dst"));
-    let _ = fs::create_dir_all(src_a.join("payload"));
-    let _ = fs::create_dir_all(dst_a.join("payload"));
-    let _ = fs::write(src_a.join("payload/real.bin"), "x".repeat(100_000));
-    let _ = fs::write(dst_a.join("payload/intruder.bin"), "z".repeat(100_000));
-
-    let r_a = declare(&src_a, &dst_a);
-    let script_a = match crate::resources::nas_archive::archive_of(&r_a) {
-        Ok(a) => crate::resources::nas_archive::archive_script(&a),
-        Err(e) => return bad(t, format!("declaration refused: {e}")),
-    };
-    let (code_a, out_a) = run(&script_a, &root);
-    if code_a == 0 {
-        return bad(t, "a mismatched destination did NOT fail the archive pass");
+    if let Some(failure) = nas_archive_refuses_mismatch(t, &root) {
+        return failure;
     }
-    if !src_a.join("payload/real.bin").exists() {
-        return bad(
-            t,
-            format!("THE SOURCE WAS DELETED after a failed verify:\n{out_a}"),
-        );
-    }
-
-    // ── B. and a matching pass must still archive, or A proves nothing ──────
-    let (src_b, dst_b) = (root.join("b/src"), root.join("b/dst"));
-    let _ = fs::create_dir_all(src_b.join("payload"));
-    let _ = fs::create_dir_all(&dst_b);
-    let _ = fs::write(src_b.join("payload/real.bin"), "x".repeat(100_000));
-
-    let r_b = declare(&src_b, &dst_b);
-    let script_b = match crate::resources::nas_archive::archive_of(&r_b) {
-        Ok(a) => crate::resources::nas_archive::archive_script(&a),
-        Err(e) => return bad(t, format!("declaration refused: {e}")),
-    };
-    let (code_b, out_b) = run(&script_b, &root);
-    if code_b != 0 {
-        return bad(t, format!("a valid archive pass failed:\n{out_b}"));
-    }
-    if !dst_b.join("payload/real.bin").exists() {
-        return bad(t, "the archived data is not at the destination");
-    }
-    match fs::symlink_metadata(src_b.join("payload")) {
-        Ok(m) if m.file_type().is_symlink() => {}
-        _ => return bad(t, "no symlink was left at the old location"),
+    if let Some(failure) = nas_archive_completes_matching_pass(t, &root) {
+        return failure;
     }
 
     let _ = fs::remove_dir_all(&root);

--- a/src/core/parser/format_validation.rs
+++ b/src/core/parser/format_validation.rs
@@ -179,38 +179,55 @@ fn validate_cron_schedule(id: &str, resource: &Resource, errors: &mut Vec<Valida
     }
 }
 
-/// Validate a single cron field against min..=max range.
-pub(crate) fn validate_cron_field(field: &str, min: u32, max: u32) -> Result<(), String> {
-    for part in field.split(',') {
-        if part == "*" {
-            continue;
-        }
-        if let Some(step) = part.strip_prefix("*/") {
-            let n: u32 = step.parse().map_err(|_| format!("invalid step '{step}'"))?;
-            if n == 0 || n > max {
-                return Err(format!("step {n} out of range (1-{max})"));
-            }
-            continue;
-        }
-        if part.contains('-') {
-            let (lo, hi) = part
-                .split_once('-')
-                .ok_or_else(|| format!("invalid range '{part}'"))?;
-            let lo: u32 = lo.parse().map_err(|_| format!("invalid number '{lo}'"))?;
-            let hi: u32 = hi.parse().map_err(|_| format!("invalid number '{hi}'"))?;
-            if lo < min || hi > max || lo > hi {
-                return Err(format!("range {lo}-{hi} out of bounds ({min}-{max})"));
-            }
-            continue;
-        }
-        let n: u32 = part
-            .parse()
-            .map_err(|_| format!("invalid value '{part}'"))?;
-        if n < min || n > max {
-            return Err(format!("value {n} out of range ({min}-{max})"));
-        }
+/// `*/N` — the step must parse and land in `1..=max`.
+fn validate_cron_step(step: &str, max: u32) -> Result<(), String> {
+    let n: u32 = step.parse().map_err(|_| format!("invalid step '{step}'"))?;
+    if n == 0 || n > max {
+        return Err(format!("step {n} out of range (1-{max})"));
     }
     Ok(())
+}
+
+/// `lo-hi` — both ends must parse, sit inside `min..=max`, and be in order.
+fn validate_cron_range(part: &str, min: u32, max: u32) -> Result<(), String> {
+    let (lo, hi) = part
+        .split_once('-')
+        .ok_or_else(|| format!("invalid range '{part}'"))?;
+    let lo: u32 = lo.parse().map_err(|_| format!("invalid number '{lo}'"))?;
+    let hi: u32 = hi.parse().map_err(|_| format!("invalid number '{hi}'"))?;
+    if lo < min || hi > max || lo > hi {
+        return Err(format!("range {lo}-{hi} out of bounds ({min}-{max})"));
+    }
+    Ok(())
+}
+
+/// One comma-separated part of a cron field: `*`, a `*/N` step, an `lo-hi`
+/// range, or a plain value.
+fn validate_cron_part(part: &str, min: u32, max: u32) -> Result<(), String> {
+    if part == "*" {
+        return Ok(());
+    }
+    if let Some(step) = part.strip_prefix("*/") {
+        return validate_cron_step(step, max);
+    }
+    if part.contains('-') {
+        return validate_cron_range(part, min, max);
+    }
+    let n: u32 = part
+        .parse()
+        .map_err(|_| format!("invalid value '{part}'"))?;
+    if n < min || n > max {
+        return Err(format!("value {n} out of range ({min}-{max})"));
+    }
+    Ok(())
+}
+
+/// Validate a single cron field against min..=max range. Reports the first
+/// offending part, left to right.
+pub(crate) fn validate_cron_field(field: &str, min: u32, max: u32) -> Result<(), String> {
+    field
+        .split(',')
+        .try_for_each(|part| validate_cron_part(part, min, max))
 }
 
 /// FJ-2300: Check resource path against `policy.deny_paths` glob patterns.

--- a/src/core/types/refinement.rs
+++ b/src/core/types/refinement.rs
@@ -157,6 +157,21 @@ impl std::fmt::Display for SemVer {
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Hostname(String);
 
+/// Validate one dot-separated hostname label against RFC 1123: 1-63 characters,
+/// ASCII alphanumerics and dashes only, and never a leading or trailing dash.
+fn validate_hostname_label(label: &str) -> Result<(), String> {
+    if label.is_empty() || label.len() > 63 {
+        return Err(format!("label length must be 1-63: '{label}'"));
+    }
+    if !label.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
+        return Err(format!("invalid chars in label: '{label}'"));
+    }
+    if label.starts_with('-') || label.ends_with('-') {
+        return Err(format!("label cannot start/end with dash: '{label}'"));
+    }
+    Ok(())
+}
+
 impl Hostname {
     /// Create a validated hostname from a string.
     pub fn new(s: &str) -> Result<Self, String> {
@@ -164,15 +179,7 @@ impl Hostname {
             return Err(format!("hostname length must be 1-253, got {}", s.len()));
         }
         for label in s.split('.') {
-            if label.is_empty() || label.len() > 63 {
-                return Err(format!("label length must be 1-63: '{label}'"));
-            }
-            if !label.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
-                return Err(format!("invalid chars in label: '{label}'"));
-            }
-            if label.starts_with('-') || label.ends_with('-') {
-                return Err(format!("label cannot start/end with dash: '{label}'"));
-            }
+            validate_hostname_label(label)?;
         }
         Ok(Hostname(s.to_string()))
     }

--- a/src/core/webhook_source.rs
+++ b/src/core/webhook_source.rs
@@ -267,6 +267,55 @@ pub fn validate_request_at(
     }
 }
 
+/// Check forjar's own signature header: it is timestamped and bound to the
+/// method, path and body.
+fn verify_forjar_signature(
+    config: &WebhookConfig,
+    request: &WebhookRequest,
+    key: &[u8],
+    raw: &str,
+    now: i64,
+) -> ValidationResult {
+    let header = webhook_sig::parse_forjar_signature(raw);
+    // A header with a `t` but no `v1` is malformed, not unsigned — treating it
+    // as unsigned would let a sender opt out of authentication by sending
+    // junk.
+    if !header.has_v1() {
+        return ValidationResult::SignatureInvalid;
+    }
+    let Some(t) = header.timestamp else {
+        return ValidationResult::SignatureInvalid;
+    };
+    if !timestamp_is_fresh(t, now, config.signature_tolerance_secs) {
+        return ValidationResult::SignatureStale {
+            skew_secs: now.saturating_sub(t).unsigned_abs(),
+        };
+    }
+    let signed = canonical_payload(t, &request.method, &request.path, &request.body);
+    // Accept if ANY v1 verifies, so a secret rotation can overlap.
+    if header
+        .v1
+        .iter()
+        .any(|sig| webhook_sig::verify_hex(key, &signed, sig))
+    {
+        return ValidationResult::Valid;
+    }
+    ValidationResult::SignatureInvalid
+}
+
+/// Check GitHub's signature header.
+///
+/// GitHub cannot be told to sign a custom canonical form, so its header is
+/// verified over the bare body. That means no timestamp binding and no path
+/// binding for GitHub senders — acceptable because GitHub delivers to one
+/// configured URL, and the replay guard still makes a delivery single-use.
+fn verify_github_signature(request: &WebhookRequest, key: &[u8], raw: &str) -> ValidationResult {
+    match webhook_sig::parse_github_signature(raw) {
+        Some(hex) if webhook_sig::verify_hex(key, &request.body, &hex) => ValidationResult::Valid,
+        _ => ValidationResult::SignatureInvalid,
+    }
+}
+
 /// Check forjar's own signature, falling back to GitHub's header.
 fn verify_signature(
     config: &WebhookConfig,
@@ -277,44 +326,11 @@ fn verify_signature(
     let key = secret.as_bytes();
 
     if let Some(raw) = request.headers.get(SIG_HEADER) {
-        let header = webhook_sig::parse_forjar_signature(raw);
-        // A header with a `t` but no `v1` is malformed, not unsigned — treating it
-        // as unsigned would let a sender opt out of authentication by sending
-        // junk.
-        if !header.has_v1() {
-            return ValidationResult::SignatureInvalid;
-        }
-        let Some(t) = header.timestamp else {
-            return ValidationResult::SignatureInvalid;
-        };
-        if !timestamp_is_fresh(t, now, config.signature_tolerance_secs) {
-            return ValidationResult::SignatureStale {
-                skew_secs: now.saturating_sub(t).unsigned_abs(),
-            };
-        }
-        let signed = canonical_payload(t, &request.method, &request.path, &request.body);
-        // Accept if ANY v1 verifies, so a secret rotation can overlap.
-        if header
-            .v1
-            .iter()
-            .any(|sig| webhook_sig::verify_hex(key, &signed, sig))
-        {
-            return ValidationResult::Valid;
-        }
-        return ValidationResult::SignatureInvalid;
+        return verify_forjar_signature(config, request, key, raw, now);
     }
 
-    // GitHub cannot be told to sign a custom canonical form, so its header is
-    // verified over the bare body. That means no timestamp binding and no path
-    // binding for GitHub senders — acceptable because GitHub delivers to one
-    // configured URL, and the replay guard still makes a delivery single-use.
     if let Some(raw) = request.headers.get(GITHUB_SIG_HEADER) {
-        return match webhook_sig::parse_github_signature(raw) {
-            Some(hex) if webhook_sig::verify_hex(key, &request.body, &hex) => {
-                ValidationResult::Valid
-            }
-            _ => ValidationResult::SignatureInvalid,
-        };
+        return verify_github_signature(request, key, raw);
     }
 
     ValidationResult::SignatureMissing

--- a/src/mcp/handlers_state.rs
+++ b/src/mcp/handlers_state.rs
@@ -66,6 +66,60 @@ impl Handler for StatusHandler {
     }
 }
 
+/// Machine directories under `state_dir`, honouring an optional machine filter.
+/// A missing state directory yields nothing; an unreadable one is an error,
+/// exactly as it was when each handler walked the directory itself.
+fn machine_dir_names(
+    state_dir: &std::path::Path,
+    machine: Option<&str>,
+) -> pforge_runtime::Result<Vec<String>> {
+    if !state_dir.exists() {
+        return Ok(Vec::new());
+    }
+    let entries =
+        std::fs::read_dir(state_dir).map_err(|e| pforge_runtime::Error::Handler(e.to_string()))?;
+
+    let mut names = Vec::new();
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if machine.is_some_and(|filter| name != filter) {
+            continue;
+        }
+        if !entry.path().is_dir() {
+            continue;
+        }
+        names.push(name);
+    }
+    Ok(names)
+}
+
+/// Flatten one recorded span into its MCP output shape.
+fn to_span_output(machine: String, span: tracer::TraceSpan) -> TraceSpanOutput {
+    TraceSpanOutput {
+        machine,
+        trace_id: span.trace_id,
+        span_id: span.span_id,
+        parent_span_id: span.parent_span_id,
+        name: span.name,
+        start_time: span.start_time,
+        duration_us: span.duration_us,
+        exit_code: span.exit_code,
+        resource_type: span.resource_type,
+        action: span.action,
+        content_hash: span.content_hash,
+        logical_clock: span.logical_clock,
+    }
+}
+
+/// How many distinct traces the collected spans belong to.
+fn distinct_trace_count(spans: &[(String, tracer::TraceSpan)]) -> usize {
+    spans
+        .iter()
+        .map(|(_, s)| s.trace_id.as_str())
+        .collect::<std::collections::HashSet<&str>>()
+        .len()
+}
+
 #[async_trait::async_trait]
 impl Handler for TraceHandler {
     type Input = TraceInput;
@@ -77,54 +131,18 @@ impl Handler for TraceHandler {
             super::paths::resolve_state_dir_opt(input.path.as_deref(), input.state_dir.as_deref());
 
         let mut all_spans = Vec::new();
-
-        if state_dir.exists() {
-            let entries = std::fs::read_dir(&state_dir)
-                .map_err(|e| pforge_runtime::Error::Handler(e.to_string()))?;
-
-            for entry in entries.flatten() {
-                let name = entry.file_name().to_string_lossy().to_string();
-                if let Some(ref filter) = input.machine {
-                    if &name != filter {
-                        continue;
-                    }
-                }
-                if !entry.path().is_dir() {
-                    continue;
-                }
-
-                if let Ok(spans) = tracer::read_trace(&state_dir, &name) {
-                    for span in spans {
-                        all_spans.push((name.clone(), span));
-                    }
-                }
+        for name in machine_dir_names(&state_dir, input.machine.as_deref())? {
+            if let Ok(spans) = tracer::read_trace(&state_dir, &name) {
+                all_spans.extend(spans.into_iter().map(|span| (name.clone(), span)));
             }
         }
 
         all_spans.sort_by_key(|(_, span)| span.logical_clock);
 
-        let trace_count = {
-            let ids: std::collections::HashSet<&str> =
-                all_spans.iter().map(|(_, s)| s.trace_id.as_str()).collect();
-            ids.len()
-        };
-
+        let trace_count = distinct_trace_count(&all_spans);
         let spans = all_spans
             .into_iter()
-            .map(|(machine, span)| TraceSpanOutput {
-                machine,
-                trace_id: span.trace_id,
-                span_id: span.span_id,
-                parent_span_id: span.parent_span_id,
-                name: span.name,
-                start_time: span.start_time,
-                duration_us: span.duration_us,
-                exit_code: span.exit_code,
-                resource_type: span.resource_type,
-                action: span.action,
-                content_hash: span.content_hash,
-                logical_clock: span.logical_clock,
-            })
+            .map(|(machine, span)| to_span_output(machine, span))
             .collect();
 
         Ok(TraceOutput { trace_count, spans })
@@ -188,29 +206,12 @@ impl Handler for AnomalyHandler {
         let min_events = input.min_events.unwrap_or(3);
 
         let mut metrics: AnomalyMetrics = std::collections::HashMap::new();
-
-        if state_dir.exists() {
-            let entries = std::fs::read_dir(&state_dir)
-                .map_err(|e| pforge_runtime::Error::Handler(e.to_string()))?;
-
-            for entry in entries.flatten() {
-                let name = entry.file_name().to_string_lossy().to_string();
-                if let Some(ref filter) = input.machine {
-                    if &name != filter {
-                        continue;
-                    }
-                }
-                if !entry.path().is_dir() {
-                    continue;
-                }
-
-                let log_path = entry.path().join("events.jsonl");
-                if !log_path.exists() {
-                    continue;
-                }
-
-                tally_machine_events(&log_path, &name, &mut metrics)?;
+        for name in machine_dir_names(&state_dir, input.machine.as_deref())? {
+            let log_path = state_dir.join(&name).join("events.jsonl");
+            if !log_path.exists() {
+                continue;
             }
+            tally_machine_events(&log_path, &name, &mut metrics)?;
         }
 
         let metrics_vec: Vec<(String, u32, u32, u32)> = metrics


### PR DESCRIPTION
119 violations over 47 Rust files -> 0. Two workers on disjoint file sets, each
told that a cosmetic split is worse than an honest "this one is irreducible".
Neither needed the escape hatch: no `#[allow(clippy::cognitive_complexity)]`,
no threshold changed, no `_part1`/`_part2`.

THE DOMINANT PATTERN WAS CONTROL FLOW STANDING IN FOR DATA. Most flagged files
were long `if flag { return Some(cmd(sd, machine, json)) }` chains — pmat
charges ~3 cognitive per arm, so any dispatcher with nine or more flags was
over by construction. The fix was already in the tree: `dispatch_graph_b.rs`
had `first_enabled_analysis` + a `(bool, fn)` table, and the one dispatcher
using it sat at cognitive 0 while its neighbours sat at 36. So this is adoption
of an existing idiom, not invention:

    try_status_phase75            36 -> 0     try_graph_scoring_phase81  36 -> 0
    try_validate_phases_97_100    36 -> 0     dispatch_validate          35 -> 3
    validate_cron_field (parser)  46 -> 0     cmd_audit                  40 -> 3
    lint_scripts                  39 -> 8     cmd_refresh_only           39 -> 4

FOUR PLACES THE TABLE WAS THE WRONG ANSWER, and saying so is the point:

  * Three dispatchers mix bool flags with value-carrying options (`--trend N`,
    `--compliance PATH`), which an `fn`-pointer table cannot express. They
    became lazy `.then(..)/.or_else(..)` chains instead — first-match-wins and
    short-circuiting preserved exactly, because **flag priority is observable
    when two flags are passed together** and a table would have reordered it.
  * Three fleet-wide reports take no machine filter. They got named adapters
    (`fleet_overview_report`, …) rather than a table entry silently ignoring an
    argument.
  * `dispatch_graph.rs` was grouped by *meaning* and kept contiguous —
    `try_impact_of_change`, `try_visualization_summary`, `try_visualization_shape`
    — so evaluation order is bit-identical.
  * `StatusHandler::handle` sits at exactly 25 and was LEFT ALONE. Folding it
    into the shared `machine_dir_names` would change how it derives a machine
    name ("unknown" fallback vs lossy UTF-8) — a real behaviour change, however
    pathological, to fix a function that was never in violation.

`tarjan_scc` deserves its own line: the nested `strongconnect` threaded ten
`&mut` parameters. It became a `TarjanState` with `discover` /
`relax_dependencies` / `close_component_at`, so the recursion now reads the way
the algorithm is written down. 27 -> 3.

Two extractions removed real duplication rather than just moving it: the
"walk machine directories honouring --machine" block appeared in six functions,
and `status_transport`'s two reports were copy-paste of each other.

ALSO DELETED: `src/cli/commands/status_args_ext.rs` (#323). The issue asked to
fix or exclude an "un-parseable" file. It is neither — it is compiled by
nothing. `grep -rn status_args_ext src/` returns zero hits, there is no `mod`
declaration, and its 12,449 bytes are a VERBATIM copy of lines 377-680 of
`status_args.rs`. `pmat_split.py` splits Rust by function boundary, and
`status_args.rs` is a 219-field struct with zero functions, so the splitter
carved an arbitrary byte range out of the struct body and emitted no wrapper.
Every flag in it is already live — `forjar status --help` still lists
`--machine-drift-age` after the deletion. Wrapping it in a struct would have
manufactured a second `clap::Args` duplicating 101 live fields; excluding it
from pmat would have hidden a real pmat bug. Neither was the right answer.

VERIFIED
  cargo build --all-targets   clean
  cargo clippy --all-targets  clean (the one "warning" is a build-script line)
  cargo fmt --check           0 diffs
  cargo test --lib            13,125 passed, 0 failed, 8 ignored
  20+ integration binaries    pass (validate, cron, state, lock, refresh, mcp,
                              webhook, query, tracer, doc-cli-parity)
  pmat analyze complexity     .rs violations 119 -> 0

STILL OPEN, deliberately: 16 violations remain in `split_files.py` (9) and
`pmat_split.py` (7). #321 is scoped to CLI modules and these are Python — but
`pmat_split.py` is the script that produced the orphan deleted above, so its
own complexity is not an academic matter. Worth its own issue.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)