### PR TITLE
fix(cargo): a cache populated before #320 can never register

### DIFF
--- a/src/resources/package.rs
+++ b/src/resources/package.rs
@@ -351,7 +351,8 @@ fn cargo_cached_install(pkg: &str, version: Option<&str>) -> String {
          _CACHE_DIR=\"${{FORJAR_CACHE_DIR:-$HOME/.forjar/cache/cargo}}/$_CACHE_KEY\"\n\
          if [ -z \"${{FORJAR_NO_CARGO_CACHE:-}}\" ] && \
             [ -d \"$_CACHE_DIR/bin\" ] && \
-            ls \"$_CACHE_DIR/bin/\"* >/dev/null 2>&1; then\n\
+            ls \"$_CACHE_DIR/bin/\"* >/dev/null 2>&1 && \\\n\
+            [ -f \"$_CACHE_DIR/.crates.toml\" ]; then\n\
            install -m 755 \"$_CACHE_DIR/bin/\"* \"$_CARGO_BIN/\"\n\
            _fj_register \"$_CACHE_DIR/.crates.toml\"\n\
            echo \"forjar: cache-hit {crate_name} [$_CACHE_KEY]\"\n\


### PR DESCRIPTION
Refs #320, which was **incomplete** — and applying it to a real machine is what showed that.

gx10 after #320, applying `cargo-tools`:

```
missing:bat
missing:hyperfine
0 converged, 0 unchanged, 1 FAILED   (0.4s)
```

Still failing, and **fast** — so nothing was reinstalled.

## Cause

The cache-hit path copies binaries out of `$_CACHE_DIR/bin` and calls `_fj_register "$_CACHE_DIR/.crates.toml"`. But a cache populated by **any earlier forjar has no `.crates.toml`** — that file only started being saved in #320. `_fj_register` correctly returns early on a missing source, so the crates got installed and never registered, on every apply, forever.

**A warm cache was a permanent trap: the faster path was the one that could not repair the thing #320 exists to repair.**

## Fix

A cache entry without `.crates.toml` is no longer a cache hit. It falls through to the install path, which registers *and* repopulates the cache with the registry entry. Old caches self-heal on first use, once, and are fast again afterwards.

## Verified on gx10 — the machine that had been failing this on every apply

```
before:  0 converged, 0 unchanged, 1 FAILED   (0.4s)
after:   1 converged, 0 unchanged, 0 failed   (95.4s)
```

And the registry now agrees with the disk:

```
cargo install --list   ->  bat 0.26.1, fd-find 10.4.2, hyperfine 1.20.0, ripgrep 15.2.0
rg / fd / bat / hyperfine  ->  all run, versions match
```

The 95 seconds is the one-time reinstall; subsequent applies take the cache-hit path again.

## Why #320's tests did not catch it

They exercised `_fj_register` against a fixture registry and the generated script against `sh -n` — both correct, and both blind to a cache whose **shape predates the feature**. The condition needed a real machine carrying real historical state.

That is the argument for the fleet dogfood existing at all, and it is the second time today the same lesson has landed: a sandbox cannot hold the state that makes a defect reachable.

142 package tests pass; clippy `-D warnings` clean.