### PR TITLE
fix(task): a task could never drift — its observable was the declaration

### DIFF
--- a/src/resources/task.rs
+++ b/src/resources/task.rs
@@ -388,10 +388,38 @@ pub fn state_query_script(resource: &Resource) -> String {
         return hash_cmds.join("\n");
     }
 
+    // A COMPLETION CHECK IS AN OBSERVABLE. AN ECHO OF THE DECLARATION IS NOT.
+    //
+    // Below this used to be, unconditionally, `echo 'command=<the YAML text>'`
+    // — a PURE FUNCTION OF THE DECLARATION. It cannot ever differ from the
+    // config it was generated from, so hashing it answers "is the config the
+    // config". A task could never drift, by construction.
+    //
+    // Measured on the paiml fleet: 151 task resources, ZERO with
+    // `output_artifacts`, so every one of them had this observable — while 186
+    // `completion_check`s sat there being called by the apply path and by
+    // nothing else. Those resources carry the fleet's network configuration.
+    //
+    // `check_script` already turns a completion_check into
+    // `verdict::single(check, "task=completed", "task=pending")`, which asks
+    // the HOST. The generator was never the problem; nothing on the drift path
+    // called it. (forjar#279.)
+    //
+    // Ordering note: `output_artifacts` still wins above, because artifact
+    // digests distinguish WHICH output changed, where a completion_check only
+    // says completed-or-not.
+    if let Some(ref check) = resource.completion_check {
+        return verdict::single(check, "task=completed", "task=pending");
+    }
+
+    // No artifacts and no completion_check: there is genuinely nothing to
+    // observe. Say so rather than echoing the declaration back — a caller can
+    // tell "unobservable" from "unchanged", which an echo cannot.
     let command = resource.command.as_deref().unwrap_or("true");
-    // `command` is intentionally arbitrary; quote the whole label so a stray
-    // quote can't break the echo.
-    format!("echo {}", sh_squote(&format!("command={command}")))
+    format!(
+        "echo {}",
+        sh_squote(&format!("unobservable:no-completion-check:{command}"))
+    )
 }
 
 /// FJ-2704: Generate shell script to scatter local artifacts to remote paths.

--- a/src/resources/tests_task.rs
+++ b/src/resources/tests_task.rs
@@ -108,9 +108,19 @@ fn test_state_query_with_artifacts() {
 
 #[test]
 fn test_state_query_no_artifacts() {
+    // This asserted `script.contains("command=echo hello")` — i.e. it required
+    // the observable to be an ECHO OF THE DECLARATION, which is precisely
+    // forjar#279. No correct fix could have passed it.
+    //
+    // A task with no artifacts and no completion_check genuinely has nothing to
+    // observe; the observable now says that instead of restating the config.
     let r = make_task_resource("echo hello");
     let script = state_query_script(&r);
-    assert!(script.contains("command=echo hello"));
+    assert!(script.contains("unobservable:no-completion-check"));
+    assert!(
+        !script.contains("command=echo hello"),
+        "the observable must not be a function of the declaration:\n{script}"
+    );
 }
 
 #[test]
@@ -521,4 +531,76 @@ for p in /sys/devices/system/cpu/cpufreq/policy*/scaling_governor; do \
     if let Err(e) = crate::core::purifier::validate_script(&script) {
         panic!("task apply_script fails forjar's own I8 gate:\n{script}\n\n{e}");
     }
+}
+
+// ── forjar#279: a task could never drift ─────────────────────────────────────
+
+/// The drift observable for a task was `echo 'command=<the YAML text>'` — a
+/// PURE FUNCTION OF THE DECLARATION. It cannot ever differ from the config it
+/// was generated from, so hashing it answers "is the config the config", and a
+/// task could never drift by construction.
+///
+/// Measured on the paiml fleet when this was found: 151 task resources, ZERO
+/// with `output_artifacts` (so every one had this observable), and 186
+/// `completion_check`s that the apply path called and the drift path did not.
+/// Those resources carry the fleet's network configuration.
+#[test]
+fn a_task_observable_asks_the_host_not_the_declaration() {
+    let mut r = Resource {
+        resource_type: ResourceType::Task,
+        machine: MachineTarget::Single("m1".to_string()),
+        command: Some("systemctl start thing".to_string()),
+        ..Default::default()
+    };
+    r.completion_check = Some("systemctl is-active thing".to_string());
+
+    let q = state_query_script(&r);
+
+    // THE ASSERTION THAT MATTERS: the observable must run the check.
+    assert!(
+        q.contains("systemctl is-active thing"),
+        "the task observable does not consult its completion_check, so it \
+         cannot see the host:\n{q}"
+    );
+
+    // And must NOT be an echo of the declaration. Without this, appending the
+    // check to the old echo would satisfy the assertion above while leaving the
+    // digest still dominated by config text.
+    assert!(
+        !q.contains("command=systemctl start thing"),
+        "the observable still echoes the declaration, so it remains a pure \
+         function of the config:\n{q}"
+    );
+
+    // CHANGING THE COMMAND MUST NOT CHANGE THE OBSERVABLE. That is the whole
+    // defect stated as a property: an observable derived from the declaration
+    // moves when the declaration moves, which is what made every task look
+    // permanently converged.
+    let mut r2 = r.clone();
+    r2.command = Some("systemctl restart thing --with --different --args".to_string());
+    assert_eq!(
+        state_query_script(&r2),
+        q,
+        "editing the command changed the observable — it is still derived from \
+         the declaration rather than from the host"
+    );
+}
+
+/// A task with neither artifacts nor a completion_check has genuinely nothing
+/// to observe. It must SAY so rather than echo the declaration, so a caller can
+/// tell "unobservable" from "unchanged" — an echo cannot express that
+/// difference, which is how the original defect stayed invisible.
+#[test]
+fn a_task_with_nothing_to_observe_says_so() {
+    let r = Resource {
+        resource_type: ResourceType::Task,
+        machine: MachineTarget::Single("m1".to_string()),
+        command: Some("echo hello".to_string()),
+        ..Default::default()
+    };
+    let q = state_query_script(&r);
+    assert!(
+        q.contains("unobservable:no-completion-check"),
+        "an unobservable task must be labelled as such:\n{q}"
+    );
 }

--- a/tests/falsification_refresh_reruns_checks.rs
+++ b/tests/falsification_refresh_reruns_checks.rs
@@ -142,11 +142,37 @@ fn refresh_does_not_reapply_a_resource_that_is_genuinely_converged() {
 }
 
 #[test]
-fn a_plain_apply_still_trusts_the_lock() {
-    // The contrast that gives --refresh its reason to exist, pinned so the fix
-    // cannot quietly turn every apply into a host round-trip. A plain apply
-    // over the same out-of-band damage keeps its existing (fast, lock-based)
-    // behaviour; only --refresh pays for the check.
+fn a_plain_apply_converges_a_task_the_way_it_converges_a_file() {
+    // CHANGED DELIBERATELY, which is what the previous version of this test
+    // asked for by name. It was `a_plain_apply_still_trusts_the_lock`, and it
+    // asserted the marker STAYED deleted:
+    //
+    //     "a plain apply is documented as lock-based; if it now repairs
+    //      out-of-band damage, --refresh has no distinct meaning and every
+    //      apply just got slower. Change this test deliberately, not by
+    //      accident."
+    //
+    // That premise stopped being true in 1.18.0, for files. `apply` converges a
+    // file changed on the target — that release's headline, taken after a 3/3
+    // NO-GO gate. Verified on main: `apply_restores_a_tampered_source_file`
+    // passes.
+    //
+    // So the fleet was left asserting BOTH: a plain apply repairs a drifted
+    // file and does not repair a drifted task. That inconsistency is harder to
+    // reason about than either rule alone — an operator cannot answer "does
+    // apply fix this?" without first knowing the resource type — and it is
+    // exactly forjar#279: a task's drift observable was `echo` of its own
+    // declaration, so a task could never drift and the question never arose.
+    //
+    // The cost objection stands and is answered rather than dismissed: the
+    // observable is the resource's OWN `completion_check`, which apply already
+    // runs. No new round-trip is introduced for a task that declares one, and a
+    // task that declares none stays unobservable and costs nothing.
+    //
+    // --refresh keeps its distinct meaning: it re-checks resources the lock
+    // reports Converged regardless of what drift detection can see, which is
+    // what `refresh_reapplies_a_resource_whose_live_check_now_fails` above
+    // pins.
     let dir = tempfile::tempdir().unwrap();
     let state = dir.path().join("state");
     let marker = dir.path().join("marker");
@@ -161,9 +187,10 @@ fn a_plain_apply_still_trusts_the_lock() {
     let (_out, ok) = apply(&cfg, &state, &[]);
     assert!(ok);
     assert!(
-        !marker.exists(),
-        "a plain apply is documented as lock-based; if it now repairs \
-         out-of-band damage, --refresh has no distinct meaning and every apply \
-         just got slower. Change this test deliberately, not by accident."
+        marker.exists(),
+        "a plain apply repaired a drifted FILE but not a drifted TASK. Whether \
+         apply fixes out-of-band damage must not depend on the resource type — \
+         an operator cannot answer 'does apply fix this?' without first \
+         knowing what kind of thing it is."
     );
 }


### PR DESCRIPTION
Closes #279 — the triage's only BLOCKER. Replaces #327, which wedged mid-rebase on the `.pmat` churn that #332 has now fixed.

The drift observable for a task with no `output_artifacts` was:

```sh
echo 'command=<the YAML text>'
```

**A pure function of the declaration** — generated from the config, then compared against the config. It answers *"is the config the config"*. A task could not drift, by construction.

**151 fleet task resources, zero with `output_artifacts`** — so every one had this — while **186 `completion_check`s** were called by the apply path and nothing else. Those resources carry the fleet's network configuration.

```
published 1.18.0   completion_check broken  ->  0 drift findings
this build         completion_check broken  ->  1 drift finding
```

A task with neither artifacts nor a check now emits `unobservable:no-completion-check:<command>`, so a caller can tell *"I cannot see this"* from *"this has not changed"* — a distinction an echo cannot express, which is how the defect stayed invisible.

## ⚠️ One deliberate semantic decision — flagged for veto

Two tests encoded behaviour, and I treated them differently on purpose.

`test_state_query_no_artifacts` asserted `contains("command=echo hello")` — it **required** the observable to be an echo of the declaration. No correct fix could pass it. Inverted; that is the third instance of this shape found today.

`a_plain_apply_still_trusts_the_lock` is a different thing: a deliberate test carrying *"Change this test deliberately, not by accident."* I checked its premise before touching it, and it **stopped being true in 1.18.0 — for files**. Verified on main: `apply_restores_a_tampered_source_file` passes.

So the codebase asserted **both**:

| resource | plain apply repairs drift? |
|---|---|
| file | **yes** (1.18.0 headline) |
| task | no (that test) |

That split is not a design — it is this defect's shadow. A task could never drift, so the question never arose. I changed it toward consistency: an operator should not need to know a resource's type to answer *"does apply fix this?"*.

**The cost objection is answered, not dismissed.** The observable is the resource's own `completion_check`, which apply already runs — no new round-trip for a task that declares one, and a task that declares none stays unobservable and costs nothing. `--refresh` keeps its distinct meaning and its own test.

**If you would rather tasks stay lock-based, drop the third commit** — the observable fix is separable from the test change.

## The new tests assert the property, not the string

The load-bearing one: **editing the command must not change the observable.** A text assertion would go green again the moment someone appended the check to the old echo.

58 `tests_task` pass; 3 refresh tests pass.