### PR TITLE
fix(proofs): the containment proof measured the raw bytes, not the paths

### DIFF
--- a/src/core/kani_proofs_nas_archive.rs
+++ b/src/core/kani_proofs_nas_archive.rs
@@ -33,11 +33,34 @@
 /// Proved over every short path built from an alphabet containing the separator,
 /// so the boundary between "next byte is `/`" and "next byte is anything else"
 /// is exercised exhaustively rather than sampled.
+///
+/// STATED OVER NORMALISED PATHS, and that is the whole content of this
+/// harness's history. It first said, of the RAW arguments,
+///
+///     assert!(inner.len() > outer.len());
+///     assert_eq!(inner.as_bytes()[outer.len()], b'/');
+///
+/// and `cargo kani` refused it: `1 of 557 failed — assertion failed:
+/// inner.len() > outer.len()`. The refusal was correct and the function was
+/// not at fault. `contains_path` decides on `norm_path(..)` of each argument,
+/// so arithmetic on the raw lengths describes a different pair of strings than
+/// the one the decision was made about. `outer = "///"` normalises to the root
+/// and is 3 bytes long while meaning 1; every one of the eight `inner` values
+/// that is not `outer` itself falsifies the raw form.
+///
+/// The root is also why the boundary index is not simply `o.len()`: `/` is the
+/// one path that already ENDS in its own separator, so what follows it starts
+/// at index 0, not at index 1. `boundary` below is that distinction and
+/// nothing else. Enumerated over a wider space than Kani's (alphabet `/abc`,
+/// paths to length 4, 85 paths, 7225 ordered pairs): 0 counterexamples to the
+/// form below, and 207 to the same form if `contains_path` is mutated into the
+/// raw string-prefix test this proof exists to exclude — so restating it did
+/// not cost the property its teeth.
 #[cfg(kani)]
 #[kani::proof]
 #[kani::unwind(8)]
 fn proof_archive_containment_is_component_wise() {
-    use super::types::contains_path;
+    use super::types::{contains_path, norm_path};
 
     // Deliberately includes the separator and two bytes that make a shared
     // prefix without a component boundary (`a` then `b` gives /a vs /ab).
@@ -57,11 +80,18 @@ fn proof_archive_containment_is_component_wise() {
     // `dest == path` a rejection rather than a no-op move.
     assert!(contains_path(outer, outer));
 
-    if contains_path(outer, inner) && outer != inner {
+    // Compare the paths `contains_path` actually decided about, not the bytes
+    // they were written with: `/a/` and `/a` are one path, and "strictly
+    // inside" has to mean strictly inside AFTER normalisation.
+    let (o, i) = (norm_path(outer), norm_path(inner));
+    if contains_path(outer, inner) && o != i {
         // Strict containment implies a component boundary: `inner` continues
-        // `outer` with a separator, never mid-component.
-        assert!(inner.len() > outer.len());
-        assert_eq!(inner.as_bytes()[outer.len()], b'/');
+        // `outer` with a separator, never mid-component. The root already ends
+        // in its separator, so its boundary is at index 0.
+        let boundary = if o == "/" { 0 } else { o.len() };
+        assert!(i.starts_with(o));
+        assert!(i.len() > boundary + 1);
+        assert_eq!(i.as_bytes()[boundary], b'/');
     }
 }
 

--- a/src/core/types/nas_archive_types.rs
+++ b/src/core/types/nas_archive_types.rs
@@ -181,7 +181,12 @@ pub struct NasArchive {
 }
 
 /// Normalise a path for containment tests: strip trailing slashes, keeping `/`.
-fn norm(p: &str) -> &str {
+///
+/// `pub(crate)` so the Kani harness can state its property over the SAME
+/// normalisation `contains_path` applies. Stating it over the raw arguments is
+/// what made `proof_archive_containment_is_component_wise` fail: see
+/// `core::kani_proofs_nas_archive`.
+pub(crate) fn norm_path(p: &str) -> &str {
     let t = p.trim_end_matches('/');
     if t.is_empty() {
         "/"
@@ -196,7 +201,7 @@ fn norm(p: &str) -> &str {
 /// a prefix test on raw strings would say otherwise and refuse a valid
 /// declaration.
 pub(crate) fn contains_path(outer: &str, inner: &str) -> bool {
-    let (o, i) = (norm(outer), norm(inner));
+    let (o, i) = (norm_path(outer), norm_path(inner));
     if o == i {
         return true;
     }
@@ -275,8 +280,8 @@ impl NasArchive {
             return Err(explain(reason, path, destination, &dirs));
         }
         Ok(Self {
-            path: norm(path).to_string(),
-            destination: norm(destination.unwrap_or_default()).to_string(),
+            path: norm_path(path).to_string(),
+            destination: norm_path(destination.unwrap_or_default()).to_string(),
             dirs,
             max_small_bytes,
             min_age_days,


### PR DESCRIPTION
## The defect

`forjar/Proofs` is one of the seven lanes the infra nightly audit's
`lane-liveness` dead-man's switch reported dead on 2026-08-27
(infra run 33071842506):

    forjar/Proofs   DEAD no-healthy 999d (>3d) — not allowlisted

999d is the switch's sentinel for "no healthy scheduled or dispatched run has
ever been observed", and here it is literal. The `kani` job has failed on
**every push to main since the harness landed in #284 (2026-08-21)** and on the
lane's only scheduled run (33099376626). `lean`, `contracts` and
`ledger-replay` are green; the `proofs` aggregator refuses on `kani`. On a
`pull_request` the kani job is skipped unless the PR carries the `proofs`
label, which is why the PR runs looked green throughout.

    Manual Harness Summary:
    Verification failed for -
      core::kani_proofs_nas_archive::proof_archive_containment_is_component_wise
    Complete - 28 successfully verified harnesses, 1 failures, 29 total.

Reproduced locally with kani 0.67.0 before changing anything:

    ** 1 of 557 failed (34 unreachable)
    Failed Checks: assertion failed: inner.len() > outer.len()
      src/core/kani_proofs_nas_archive.rs, line 63

## The proof was wrong; `contains_path` was not

`contains_path` decides on `norm_path(..)` of each argument. The harness then
asserted the component-boundary property using the **raw** arguments:

    assert!(inner.len() > outer.len());
    assert_eq!(inner.as_bytes()[outer.len()], b'/');

so the arithmetic described a different pair of strings than the decision was
made about. `outer = "///"` normalises to the root: it *means* one byte and
*measures* three. Over the harness's own 9-path space, eight ordered pairs
falsify the raw form — every `inner` other than `outer` itself — and in each of
them the function's answer (a path IS inside the root) is correct.

The root is also why the boundary index is not simply `o.len()`: `/` is the one
path that already ENDS in its own separator, so what follows it begins at index
0. Restating over `norm_path` alone is not enough — the first restatement I
checked still had six counterexamples, all of them `outer = "///"`. `boundary`
in the new code is that distinction and nothing else.

## The restatement keeps its teeth

A proof that merely re-spells the implementation is worth nothing, so the new
form was checked for falsifying power before it was committed. Enumerated over
a space wider than Kani's (alphabet `/abc`, paths to length 4 — 85 paths, 7225
ordered pairs):

| `contains_path` under test | counterexamples to the new assertion |
|---|---|
| the real one | **0** |
| mutated to a raw string-prefix test (the bug this proof exists to exclude) | **207** |

and on the harness's own 3-byte space that same mutation still produces 8. A
proof that could not go red for `/mnt/unas-old` being "inside" `/mnt/unas`
would be pointless; this one still does.

`norm` is renamed `norm_path` and made `pub(crate)` so the harness can state
its property over the same normalisation the function applies. The bare name
would otherwise have entered the crate namespace through
`pub use nas_archive_types::*`.

## Verification

    $ cargo kani --harness proof_archive_containment_is_component_wise
      VERIFICATION:- SUCCESSFUL
      Complete - 1 successfully verified harnesses, 0 failures, 1 total.

    $ cargo kani --output-format terse          # the whole suite, as the lane runs it
      Complete - 29 successfully verified harnesses, 0 failures, 29 total.

    $ cargo test --lib nas_archive
      test result: ok. 33 passed; 0 failed

29/29 is the number the lane needs; it was 28/29 before.

## Not fixed here — worth its own ticket

`norm_path` strips trailing separators but does not collapse repeated interior
ones, so `contains_path("/mnt/unas", "/mnt//unas")` is **false** for two
spellings of one directory: a declaration that IS a move onto itself would be
accepted. That is a change to the admission algebra with its own proof
obligations, not a by-product of repairing this harness, so it is left alone
and called out rather than folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)