### PR TITLE
chore(release): 1.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.21.0] — 2026-08-28
+
 ### Added
 
 - **A task could not declare an input that is not a path, so an ambient change

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1123,7 +1123,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "forjar"
-version = "1.20.1"
+version = "1.21.0"
 dependencies = [
  "age",
  "aprender-contracts",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forjar"
-version = "1.20.1"
+version = "1.21.0"
 edition.workspace = true
 rust-version = "1.89.0"
 authors = ["Pragmatic AI Labs"]


### PR DESCRIPTION
Version bump and CHANGELOG date for 1.21.0. `Cargo.toml` and `Cargo.lock` move together — `lockfile-preflight` enforces that, and every 1.4.x release before #131 got it wrong.

Preflight run locally: `cargo package --locked --no-verify` → `Packaged 1735 files, 16.3MiB (2.8MiB compressed)`.

## What 1.21.0 contains

**Every issue that was open in the tracker is closed**: #228, #236, #237, #244, #290, #292, #298, #318, #321, #325, #334, #335, #336, #342, #345, #348, #349, #350, #354, plus #357 found while fixing them.

Highlights, one line each:

- forjar's own I8 gate rejected the shell forjar generates (#350) — bashrs SC2075 flags the correct POSIX `'\''` idiom that forjar's own escaper emits, and `sh_squote` stripped newlines so the sentinel named a command that was never run.
- A recipe's resources were validated by nothing (#357). `expand_recipes` ran *after* `validate_config`; `includes` were moved above it by FJ-254 and recipes never were. **Breaking**: configs that loaded yesterday can hard-fail today.
- `sudo: true` governed the apply and neither of the two read paths (#349).
- `FORJAR_BUDGET_DRY_RUN=1` did not prevent deletion (#334).
- Narrowing `lifecycle.ignore_drift` widened it to everything (#335) — and the cookbook was teaching the broken shape.
- The registry client was eight curl subprocesses (#228), one of which used a **download** range flag to upload, so every chunk sent the whole blob.
- Nothing ever read a published release object back (#325). All 28 asset-bearing tags are now self-describing, with a producer guard and a daily audit.

## How it was verified

Seven conflict-disjoint groups implemented in parallel, then each handed to an independent agent instructed to **refute** — revert the production hunk, rebuild, confirm the test actually goes red. Every fix has a falsification test that was *run* red, not asserted.

That caught two regressions that would otherwise have shipped green:

- **#345 bricked the cargo provider.** The new `_fj_crates_ok` probe emits `rm -rf "$_vh"`; bashrs rates SEC011 at Error severity and `validate_before_exec` refuses any script carrying one, so every `provider: cargo` apply was rejected before execution. The full suite, clippy and #345's own falsification test were all green, because nothing in this repo pushed a generated script through the gate that runs before executing it. `src/transport/tests_generated_scripts_lint.rs` now does.
- **The release-audit lane would have been born red**, and its obvious remedy — deleting the "strays" it reported — would have destroyed 17 legitimate historical artifacts under the pre-v1.4.2 `forjar-v<ver>-*` naming.

## Left open, deliberately

Five defects found by doing this work: #358, #359, #360, #362, #363 (plus #364, a yanked transitive dep). Two have fixes in flight on the epic branches. #362 and #363 were found by fact-checking this release's own changelog against the code it describes.

Three issues closed with their remainder stated rather than implied — #335 (field list needs a lock schema change, split to #360), #298 (`pv audit` belongs to aprender-contracts), #292 (near-clone item).

Epic #356 is **not** in this release. Its verification kept finding that the spec was wrong — the plan seal is integrity not authentication, `forjar check` mutates despite being specified read-only, `doctor` writes — and two of its four groups still have open blockers. It lands in 1.22.0 rather than holding a complete, verified release.

No `--no-verify` was used anywhere in this work.